### PR TITLE
docs(process): enforce documentation checklist on every PR

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,7 +1,7 @@
 # /pr
 
 Push the current feature branch and open a GitHub pull request, after
-documenting progress in CHANGELOG.md.
+running a full documentation audit.
 
 ## Usage
 
@@ -24,20 +24,43 @@ documenting progress in CHANGELOG.md.
 Run these in parallel:
 - `git log main..HEAD --oneline` — list commits on this branch.
 - `git diff main..HEAD --stat` — files changed.
-- Read `CHANGELOG.md` to see the current `## [Unreleased]` section.
+- Read `CHANGELOG.md` (current `## [Unreleased]` section).
+- Read `AGENTS.md` (Repo Map + AGL API sections).
 
-### 2. Update CHANGELOG.md
+### 2. Documentation audit (REQUIRED — do not skip)
 
-Add a new bullet (or bullets) under the appropriate sub-heading
-(`### Added`, `### Changed`, `### Fixed`) in `## [Unreleased]` that
-summarises what this branch contributes. Write in the same terse style
-as existing entries. Do not duplicate anything already listed. Prefer
-one concise sentence per logical capability added.
+Work through the full checklist from `AGENTS.md § Documentation Checklist`.
+All four artifact types must be addressed before the PR is opened.
 
-Commit the CHANGELOG update:
+**CHANGELOG.md** — add bullet(s) under the appropriate sub-heading
+(`### Added`, `### Changed`, `### Fixed`) in `## [Unreleased]`.
+One concise sentence per logical capability. Do not duplicate existing entries.
+
+**AGENTS.md — Repo Map** — add any new files introduced by this branch;
+update descriptions if a file's role changed. Cross-check by running:
 ```
-git add CHANGELOG.md
-git commit -m "docs: update CHANGELOG for <branch-name>
+find custom_components/haggle tests -name "*.py" | sort
+```
+
+**AGENTS.md — AGL API** — if this branch corrected an API fact (endpoint,
+field name, token lifetime, header), update that bullet now.
+
+**AGENTS.md — What NOT to Do** — if a new footgun was discovered, add it.
+
+**Memory files** — record any non-obvious decision, confirmed API behaviour,
+or user preference that should survive context resets. Write to
+`~/.claude/projects/<project>/memory/`.
+
+**Sprint/phase boundary** — if this branch completes a named sprint or phase:
+- Move completed items out of `## [Unreleased]` into a dated `## [x.y.z-dev]` entry.
+- Update `## [Unreleased]` → `### Targets for next sprint`.
+- Do a full Repo Map audit against the actual file tree.
+- Review every AGL API bullet against the current implementation.
+
+Commit all documentation changes together:
+```
+git add AGENTS.md CHANGELOG.md
+git commit -m "docs: update AGENTS.md and CHANGELOG for <branch-name>
 
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ```
@@ -78,14 +101,17 @@ summary (≤70 chars).
 ## Summary
 <3-5 bullet points drawn from the commits and CHANGELOG entry>
 
+## Documentation updated
+- [ ] CHANGELOG.md — new entries under [Unreleased]
+- [ ] AGENTS.md — Repo Map reflects current file tree
+- [ ] AGENTS.md — AGL API facts verified / corrected
+- [ ] Memory files updated (or N/A — nothing non-obvious to record)
+
 ## Test plan
 - [ ] All existing tests pass (`uv run pytest`)
 - [ ] mypy clean (`uv run mypy custom_components/haggle`)
 - [ ] Pre-commit hooks pass
 - <any manual steps the reviewer should run>
-
-## CHANGELOG
-<paste the new CHANGELOG lines verbatim>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,28 @@ scripts/
 
 ---
 
+## Documentation Checklist — Required on Every PR
+
+Every PR that ships code (not pure CI/tooling fixes) MUST include updates to
+all of the following before it can be merged. The `/pr` command enforces this.
+
+| Artifact | What to update | Where |
+|---|---|---|
+| `CHANGELOG.md` | Add bullet(s) under `## [Unreleased]` for every user-visible capability added, changed, or fixed | repo root |
+| `AGENTS.md` — Repo Map | Add any new files; update descriptions if a file's role changed | this file |
+| `AGENTS.md` — AGL API | Correct any API facts that were proven wrong (endpoints, field names, token lifetimes, headers) | this file |
+| `AGENTS.md` — What NOT to Do | Add a new prohibition if a footgun was discovered | this file |
+| Memory files | Record non-obvious decisions, confirmed API behaviour, or user preferences that should survive context resets | `~/.claude/projects/.../memory/` |
+
+**Sprint / phase boundary** (when a branch completes a named sprint or phase):
+
+- Move completed items out of `## [Unreleased]` into a dated `## [x.y.z-dev]` entry.
+- Update `## [Unreleased]` → `### Targets for next sprint` with the next block of work.
+- Verify the Repo Map matches every file currently in `custom_components/haggle/` and `tests/`.
+- Review every bullet in the AGL API section against the current implementation — correct or delete stale facts.
+
+---
+
 ## Subagent Triggers
 
 | Agent | File | Trigger condition |


### PR DESCRIPTION
## Summary

- Adds **Documentation Checklist** section to `AGENTS.md`: lists the four artifact types (CHANGELOG, Repo Map, AGL API facts, What NOT to Do + memory files) that must be audited on every code PR, with extra steps for sprint/phase boundaries
- Updates `/pr` slash command to run the checklist before opening, and adds a **Documentation updated** checklist block to the PR body template

## Documentation updated
- [x] CHANGELOG.md — N/A (process-only change)
- [x] AGENTS.md — new Documentation Checklist section added
- [x] Memory files — N/A

## Test plan
- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)