### PR TITLE
chore(deps): tighten Python and dep constraints for HA 2026.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "AGL Australia smart meter -> Home Assistant Energy dashboard"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Naanya Biz", email = "davosparent@gmail.com" }]
-requires-python = ">=3.13"
+requires-python = ">=3.13.2"
 keywords = ["home-assistant", "hacs", "agl", "energy", "smart-meter", "australia"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -23,9 +23,9 @@ classifiers = [
 dependencies = [
     # Runtime deps mirror what's in custom_components/haggle/manifest.json
     # so editor tooling resolves imports. HA installs from manifest at runtime.
-    "homeassistant>=2025.1",
+    "homeassistant>=2026.2.3",
     "aiohttp>=3.10",
-    "beautifulsoup4>=4.12",
+    "beautifulsoup4>=4.14.3",
 ]
 
 [project.optional-dependencies]
@@ -33,7 +33,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=5.0",
-    "pytest-homeassistant-custom-component>=0.13.316",
+    "pytest-homeassistant-custom-component>=0.13.316,<0.13.317",
     "ruff>=0.7",
     "mypy>=1.13",
     "types-beautifulsoup4",


### PR DESCRIPTION
## Summary

- `requires-python`: `>=3.13` → `>=3.13.2` — fixes uv cross-environment resolution failures for hypothetical Python 3.13.0/3.13.1 environments (HA 2026.2.3 already requires 3.13.2, so this just makes the floor honest)
- `homeassistant`: `>=2025.1` → `>=2026.2.3` — matches what PHC 0.13.316 pins
- `beautifulsoup4`: `>=4.12` → `>=4.14.3`
- `pytest-homeassistant-custom-component`: `>=0.13` → `>=0.13.316,<0.13.317` — caps below 0.13.317 which requires Python >=3.14

Supersedes Dependabot PRs #6, #7, #10 (being closed).

## Documentation updated
- [ ] CHANGELOG.md — N/A (tooling-only)
- [ ] AGENTS.md — N/A
- [ ] Memory files — N/A

## Test plan
- [ ] `uv sync` resolves cleanly (verified locally)
- [ ] 63 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)