### PR TITLE
fix: live-install validation — headers, backfill, sensors, energy dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,12 +179,21 @@ Each worktree shares `.venv` and `.claude/settings.local.json` via symlink.
 ### Data API
 
 - **Base**: `https://api.platform.agl.com.au`
-- **Required header**: `Client-Flavor: app.iOS.public.8.38.0-531`
+- **Required headers on ALL data endpoints** (captured from iOS 8.38.0-531, 2026-05-01):
+  - `Client-Flavor: app.iOS.public.8.38.0-531`
+  - `Client-Device: Apple-iPhone-iPhone14,7-iOS-26.4.2`
+  - `Accept-Language: en-AU,en;q=0.9`
+  - `Accept-Features: <long feature-flag list>` — see `AGL_ACCEPT_FEATURES` in `const.py`.
+    Must include `UsageEnableHistoricalMeterReads`. **Omitting any of these headers causes
+    HTTP 500 on Hourly/Daily usage endpoints** (overview and plan are more permissive).
+- **`scaling` query parameter**: Hourly and Daily usage URLs require
+  `&scaling=36.514404_108.057_40.670903_120.357_0_0_0_0` (screen DPI vector for chart
+  rendering). Without it, the BFF returns HTTP 500.
 - **Contract discovery**: `GET /mobile/bff/api/v3/overview`
   - Key fields: `accounts[].accountNumber`, `accounts[].contracts[].contractNumber`
   - `contractNumber` ≠ `accountNumber` — use `contractNumber` in all data paths
 - **30-min interval data** (despite "Hourly" in the path):
-  `GET /mobile/bff/api/v2/usage/smart/Electricity/{contractNumber}/Current/Hourly?period=YYYY-MM-DD_YYYY-MM-DD`
+  `GET /mobile/bff/api/v2/usage/smart/Electricity/{contractNumber}/Current/Hourly?period=YYYY-MM-DD_YYYY-MM-DD&scaling=...`
 - **kWh source of truth**: `consumption.values.quantity` — NOT `consumption.quantity`
   (which is UI-rounded) and NOT `consumption.values.amount` (same value but semantically cost)
 - **`dateTime` field**: slot start, in **UTC**. Convert to local for display.
@@ -205,10 +214,12 @@ Each worktree shares `.venv` and `.claude/settings.local.json` via symlink.
 ### Previous Bill Period
 
 ```
-GET /mobile/bff/api/v2/usage/smart/Electricity/{contractNumber}/Previous/Hourly?period=...
+GET /mobile/bff/api/v2/usage/smart/Electricity/{contractNumber}/Previous/Hourly?period=YYYY-MM-DD_YYYY-MM-DD&scaling=...
 ```
 
-Use on first install to backfill 30 days of history (one day at a time, ~1 req/s).
+Used for backfill of dates **before** the current billing period start (`bill_period.start`).
+Confirmed working back to at least 2025-12-24 (single-day period params). Requires the same
+`Accept-Features`/`Client-Device`/`scaling` headers as `Current/Hourly`.
 
 ### Plan / Rates
 
@@ -230,8 +241,11 @@ The HA Energy dashboard requires:
   regardless of when the API call happened. Skipping this means the Energy dashboard shows
   a spike at poll time, not a smooth historical chart.
 - Statistic IDs per contract:
-  - `haggle:consumption_<contract_number>` — kWh, `has_sum=True`
-  - `haggle:cost_<contract_number>` — AUD, `has_sum=True`
+  - `haggle:consumption_<contract_number>` — kWh, `has_sum=True`, **`unit_class="energy"`**
+  - `haggle:cost_<contract_number>` — AUD, `has_sum=True`, `unit_class=None`
+- **`unit_class="energy"` is required** on the consumption statistic for it to appear in
+  the Energy dashboard's "add consumption source" picker. `unit_class=None` silently excludes
+  it from the UI filter even though the data is in the DB.
 - Resume point: `get_last_statistics(hass, 1, stat_id, True, {"start", "sum"})` — returns
   the last-imported hour so incremental updates don't re-import already-stored rows.
 - Each import call is idempotent: `(statistic_id, start)` updates in place.
@@ -248,6 +262,14 @@ The HA Energy dashboard requires:
 - **Don't store `access_token` in `entry.data`** — it's transient (15 min).
   Persist only `refresh_token` to `entry.data`; keep `access_token` in memory only.
 - **Don't use `async_add_executor_job`** for AGL API calls — they're already async.
+- **Don't pass `access_token` to `AglAuth`** — `AglAuth.__init__` expects a `refresh_token`.
+  Passing an `access_token` silently fails: `async_force_refresh` posts it as a refresh_token,
+  Auth0 rejects it, and the contract number is never set → HTTP 404 on every data call.
+  For one-shot calls with a bare bearer token (e.g. config flow), use a direct `aiohttp` GET.
+- **Don't omit `Accept-Features` / `Client-Device` / `scaling`** — omitting any of these
+  from Hourly or Daily usage requests returns HTTP 500 with no useful error body.
+- **Don't set `unit_class=None` on the consumption statistic** — HA's Energy dashboard
+  consumption picker filters by `unit_class="energy"`. `None` silently hides the statistic.
 - **No committing directly to `main`** — the `guard-main-branch` hook blocks it.
   Use a feature branch + PR.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   five domain agents.
 
 ### Targets for next sprint
-- End-to-end live install test against a real AGL account.
+- Configurable backfill depth (date picker in config flow, defaulting to 30 days).
 - Solar/feed-in sensor (needs a solar-customer mitmproxy capture).
 - ToU (time-of-use) rate display — `rate_type` is already on each `IntervalReading`.
+
+---
+
+## [0.1.0-dev] — 2026-05-02 (Sprint 2 — live-install validation)
+
+### Fixed
+- **`_fetch_contracts` token-type bug**: config flow was passing the short-lived
+  `access_token` to `AglAuth` as a `refresh_token`; Auth0 rejected it, contracts
+  fell back to empty, and every API URL became `.../Electricity/?...` (HTTP 404).
+  `_fetch_contracts` now makes a direct `aiohttp` GET to `/v3/overview` with a
+  `Authorization: Bearer` header — no `AglAuth` involved.
+- **HTTP 500 on all Hourly/Daily usage endpoints**: AGL's BFF requires three
+  headers (`Accept-Features`, `Client-Device`, `Accept-Language`) and a `scaling`
+  query parameter that were missing from `AglClient._default_headers` and the
+  usage URL builders. Captured from mitmproxy iOS session 2026-05-01.
+- **`consumption_period_kwh` always 0**: `parse_bill_period` hardcoded
+  `consumption_kwh=0.0`; now parses `usage.quantity` ("259 kWh" → `259.0`).
+- **Consumption statistic invisible in Energy dashboard**: `StatisticMetaData`
+  was registered with `unit_class=None`; HA's Energy picker filters on
+  `unit_class="energy"`. Fixed — statistic now appears in the grid-consumption
+  source dropdown.
+
+### Changed
+- **Chunked throttled backfill**: first-install backfill no longer fires 30 API
+  calls at startup. `_async_setup` is now a no-op; `_fetch_and_import` fetches
+  at most `BACKFILL_CHUNK_DAYS=7` days per 24 h poll cycle, working backwards
+  from the most-recently-imported date.
+- **Smart endpoint selection**: days inside the current billing period use
+  `Current/Hourly`; older days use `Previous/Hourly`. Selection is driven by
+  `bill_period.start` returned by the usage-summary endpoint.
+
+### Added
+- **Consumption cost sensor** (`consumption_period_cost_aud`): AUD cost for the
+  current billing period, sourced from `usage.amount` in the AGL summary response.
+- **`AGL_ACCEPT_FEATURES`, `AGL_CLIENT_DEVICE`, `AGL_SCALING`** constants
+  (captured from iOS app 8.38.0-531 via mitmproxy).
+- **`BACKFILL_CHUNK_DAYS`** constant (default 7) controlling how many days are
+  fetched per poll cycle.
+
+### Removed
+- **`consumption_today` sensor**: AGL data has a 24–48 h AEMO feed lag; this
+  sensor was always 0 and only caused confusion.
 
 ---
 

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -20,7 +20,15 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from ..const import AGL_AUTH_HOST, AGL_CLIENT_FLAVOR, AGL_CLIENT_ID, AGL_USER_AGENT
+from ..const import (
+    AGL_ACCEPT_FEATURES,
+    AGL_AUTH_HOST,
+    AGL_CLIENT_DEVICE,
+    AGL_CLIENT_FLAVOR,
+    AGL_CLIENT_ID,
+    AGL_SCALING,
+    AGL_USER_AGENT,
+)
 from .models import (
     BillPeriod,
     Contract,
@@ -218,9 +226,12 @@ class AglClient:
     def _default_headers(self) -> dict[str, str]:
         return {
             "Client-Flavor": AGL_CLIENT_FLAVOR,
+            "Client-Device": AGL_CLIENT_DEVICE,
             "User-Agent": AGL_USER_AGENT,
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Language": "en-AU,en;q=0.9",
+            "Accept-Features": AGL_ACCEPT_FEATURES,
         }
 
     async def _get(self, url: str) -> Any:
@@ -286,7 +297,7 @@ class AglClient:
         dateTime is slot-start in UTC.
         """
         period = f"{day}_{day}"
-        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Current/Hourly?period={period}"
+        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Current/Hourly?period={period}&scaling={AGL_SCALING}"
         data = await self._get(url)
         return parse_interval_readings(data)
 
@@ -295,7 +306,7 @@ class AglClient:
     ) -> list[DailyReading]:
         """Fetch /Daily for a date range."""
         period = f"{start}_{end}"
-        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Current/Daily?period={period}"
+        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Current/Daily?period={period}&scaling={AGL_SCALING}"
         data = await self._get(url)
         return parse_daily_readings(data)
 
@@ -304,7 +315,7 @@ class AglClient:
     ) -> list[IntervalReading]:
         """Fetch /Previous/Hourly — useful for backfill on first install."""
         period = f"{day}_{day}"
-        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Previous/Hourly?period={period}"
+        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Previous/Hourly?period={period}&scaling={AGL_SCALING}"
         data = await self._get(url)
         return parse_interval_readings(data)
 

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -123,10 +123,16 @@ def parse_bill_period(data: dict[str, Any]) -> BillPeriod:
     # return empty string if absent — callers can populate from overview.
     projection_label: str = data.get("additionalLabelValue", "")
 
+    quantity_str: str = (usage.get("quantity") or "0").replace(",", "").split()[0]
+    try:
+        consumption_kwh: float = float(quantity_str)
+    except (ValueError, IndexError):
+        consumption_kwh = 0.0
+
     return BillPeriod(
         start=start,
         end=end,
-        consumption_kwh=0.0,
+        consumption_kwh=consumption_kwh,
         cost_label=cost_label,
         projection_label=projection_label,
     )

--- a/custom_components/haggle/config_flow.py
+++ b/custom_components/haggle/config_flow.py
@@ -147,6 +147,7 @@ async def _fetch_contracts(access_token: str) -> list[Contract]:
     async_force_refresh on first use (token_set is None on construction), which
     would POST the access_token as a refresh_token to Auth0 and fail.
     """
+
     url = f"{AGL_API_HOST}/mobile/bff/api/v3/overview"
     headers = {
         "Authorization": f"Bearer {access_token}",

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -37,6 +37,54 @@ TOKEN_REFRESH_MARGIN_SECONDS: Final = 120
 
 # Number of days of history to backfill on first install.
 BACKFILL_DAYS: Final = 30
+# Maximum days to fetch per 24 h poll cycle (throttles first-install backfill).
+BACKFILL_CHUNK_DAYS: Final = 7
+
+# AGL BFF requires these headers on Hourly/Daily usage endpoints (HTTP 500 without them).
+# Captured from iOS app 8.38.0-531 via mitmproxy — 2026-05-01.
+AGL_ACCEPT_FEATURES: Final = (
+    "AccountEnableCarbonNeutral, AccountEnableCarbonNeutralMessagingRemoval,"
+    " AccountEnableConcessionMessaging, AccountEnableConsumerDataRight,"
+    " AccountEnableDirectDebitSetup, AccountEnableHideTelcoNoChangeWarning,"
+    " AccountEnableMessagingInfoItem, AccountEnableNativeAccountDeletion,"
+    " AccountEnableTelcoDirectDebit, BillingEnableDirectDebitSetup,"
+    " BillingEnableEnergyPaymentDirectDebit, BillingEnableEnergyViewPlan,"
+    " BillingEnablePaymentArrangement, BillingEnableTransactionHistory,"
+    " BillingEnableUpdatedPastBillsFlow, BillingEnableV3,"
+    " DeeplinkEnableBpFuelOffer, DeeplinkEnableBpPulseOffer,"
+    " DeeplinkEnableElectrifyNowLanding, DeeplinkEnableInAppSales,"
+    " DeeplinkEnablePushNotificationPreferences, DeeplinkEnableTransactionHistory,"
+    " ElectricityServiceHubEnableFinancialHardship, ElectricityServiceHubEnableMessaging,"
+    " EnableAglAssistantRebrand, EnableHighBillProjectionTreatment,"
+    " EnableInAppSales, EnableMobileSimActivationSetting, EnableServiceHub,"
+    " EnableTelcoServiceHub, EnableUsageFromOverview, EnergyPlanEnableManageActions,"
+    " EnergyServiceHubEnableBudgetTracker, EnergyServiceHubEnableElectricityUsageDisclaimer,"
+    " EnergyServiceHubEnableHidingSettingsTitle, HelpCentreEnableArrangeYourMoveQuickLink,"
+    " HelpCentreEnableDisconnectMessagingFaq, HelpCentreEnableSetupTwoFactorAuthentication,"
+    " HelpEnableConsumerDataRight, HelpEnableFamilyDomesticViolenceSupport,"
+    " HelpEnableTelcoFinancialHardshipLink, InAppSalesEnableElectrifyNow,"
+    " InAppSalesEnablePeakEnergyRewards, InAppSalesEnableRewardsTile,"
+    " InAppSalesEnableTelcoOffersSourceChange, LoginEnableAuth0HttpsCallbacks,"
+    " LoginEnablePasskey, LoginEnablePasskeyButton, MessagingEnableUpdateSdk,"
+    " OffersEnableOverviewAlertBanner, OffersEnableV3,"
+    " OverviewAndAccountEnableSecurityCentre, OverviewAndViewPlanEnableNetflix,"
+    " OverviewEnableHideTelcoCarbonNeutralLabel, OverviewEnableMessaging,"
+    " OverviewEnableMultiOffers, OverviewEnableOffer, OverviewEnableV3,"
+    " OverviewV3EnableSolarHealth, PushEnablePreferenceManagement,"
+    " PushPreferencesEnableHasTelcoFlag, QuickTourEnable,"
+    " ServiceHubEnableAccessVirtualCircuitId, ServiceHubEnableEnergyPlan,"
+    " ServiceHubEnableMobileChangePlan, ServiceHubEnableMobileConfiguration,"
+    " ServiceHubEnableNbnChangePlan, ServiceHubEnableNbnCostOfPlanDisclaimer,"
+    " ServiceHubEnableUsageInsightSmartElectricity,"
+    " ServiceHubEnableUsageInsightSmartElectricitySolar,"
+    " TelcoServiceHubEnableMobileESimCopy, UsageEnableBattery,"
+    " UsageEnableHistoricalMeterReads, UsageEnableMultiMeterRead,"
+    " UsageEnableVirtualPowerPlant, UsageInsightEnableSolarRecommendation,"
+    " VirtualPowerPlantEnableByobV3"
+)
+AGL_CLIENT_DEVICE: Final = "Apple-iPhone-iPhone14,7-iOS-26.4.2"
+# Screen scaling vector required by the BFF for usage chart rendering.
+AGL_SCALING: Final = "36.514404_108.057_40.670903_120.357_0_0_0_0"
 
 # Statistic ID suffixes — full ID is f"{DOMAIN}:{STAT_*}_{contract_number}"
 STAT_CONSUMPTION: Final = "consumption"  # → haggle:consumption_{contract}
@@ -52,7 +100,6 @@ CONF_ACCOUNT_NUMBER: Final = "account_number"
 
 # Coordinator data attribute names — must match HaggleData field names exactly.
 DATA_CONSUMPTION_KWH: Final = "latest_cumulative_kwh"  # TOTAL_INCREASING sensor
-DATA_CONSUMPTION_TODAY: Final = "consumption_today_kwh"  # kWh this local day
 DATA_CONSUMPTION_PERIOD: Final = "consumption_period_kwh"  # kWh this bill period
 DATA_CONSUMPTION_COST: Final = "consumption_period_cost_aud"  # cumulative AUD cost
 DATA_BILL_PROJECTION: Final = "bill_projection_aud"  # AUD forecast for current period

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -8,6 +8,11 @@ Historical data (past intervals) is pushed to HA's recorder via
 async_add_external_statistics() rather than a live state update. This
 ensures the Energy dashboard attributes consumption to the interval it
 actually occurred in, not to the time of the poll.
+
+Backfill strategy: first install pulls up to BACKFILL_DAYS of history, but
+throttled to BACKFILL_CHUNK_DAYS per 24 h poll so we don't hammer the AGL
+BFF on startup. Smart endpoint selection per day: days inside the current
+billing period use Current/Hourly; older days use Previous/Hourly.
 """
 
 from __future__ import annotations
@@ -26,6 +31,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .agl.client import AGLAuthError, AGLError
 from .const import (
+    BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
     DOMAIN,
     SCAN_INTERVAL_HOURLY,
@@ -46,7 +52,6 @@ _LOGGER = logging.getLogger(__name__)
 class HaggleData:
     """Typed coordinator data returned from _async_update_data."""
 
-    consumption_today_kwh: float
     consumption_period_kwh: float
     consumption_period_cost_aud: float
     bill_projection_aud: float | None
@@ -79,43 +84,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         self._latest_cumulative_kwh: float = 0.0
 
     async def _async_setup(self) -> None:
-        """One-time setup: 30-day backfill on first install.
-
-        Called by async_config_entry_first_refresh before the first
-        _async_update_data. Fetches up to BACKFILL_DAYS of Previous/Hourly
-        intervals and imports them into the recorder statistics table.
-        """
-        today = date.today()
-        _LOGGER.info(
-            "Starting %d-day backfill for contract %s",
-            BACKFILL_DAYS,
-            self.contract_number,
-        )
-        all_intervals: list[IntervalReading] = []
-        for i in range(1, BACKFILL_DAYS + 1):
-            day = today - timedelta(days=i)
-            try:
-                readings = await self.client.async_get_usage_hourly_previous(
-                    self.contract_number, day
-                )
-                all_intervals.extend(readings)
-            except (AGLError, NotImplementedError) as err:
-                _LOGGER.debug("Backfill skip %s: %s", day, err)
-        if all_intervals:
-            stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}"
-            stat_id_cost = f"{DOMAIN}:{STAT_COST}_{self.contract_number}"
-            _LOGGER.info(
-                "Backfill complete: %d intervals across %d days — pushing to %s, %s",
-                len(all_intervals),
-                BACKFILL_DAYS,
-                stat_id_cons,
-                stat_id_cost,
-            )
-            await self._import_intervals(
-                all_intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        """No-op: first-install backfill is handled incrementally in _fetch_and_import."""
 
     async def _async_update_data(self) -> HaggleData:
         """Fetch yesterday's intervals, import statistics, return sensor data."""
@@ -127,20 +96,11 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             raise UpdateFailed(str(err)) from err
 
     async def _fetch_and_import(self) -> HaggleData:
-        """Core update: fetch missing days + push to recorder, then return data."""
+        """Core update: fetch up to BACKFILL_CHUNK_DAYS missing intervals and return data."""
         stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}"
+        stat_id_cost = f"{DOMAIN}:{STAT_COST}_{self.contract_number}"
 
-        # Determine resume point from existing statistics.
-        last_sum = await self._get_last_stat_sum(stat_id_cons)
-
-        if last_sum is None:
-            # No previous stats -- run backfill first.
-            await self._async_setup()
-        else:
-            # Fetch each missing day from day-after-last up to yesterday.
-            await self._fetch_missing_days(last_sum)
-
-        # Fetch live sensor data for the coordinator snapshot.
+        # Fetch live sensor data first — summary gives bill_start for endpoint selection.
         try:
             summary = await self.client.async_get_usage_summary(self.contract_number)
         except NotImplementedError:
@@ -151,7 +111,37 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         except NotImplementedError:
             plan = None
 
-        # Extract a flat unit rate: first c/kWh entry.
+        bill_start: date | None = summary.start if summary is not None else None
+
+        # Determine resume point.
+        last_cons_sum, last_stat_date = await self._get_last_stat(stat_id_cons)
+        last_cost_sum, _ = await self._get_last_stat(stat_id_cost)
+
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
+        if last_stat_date is None:
+            fetch_start = today - timedelta(days=BACKFILL_DAYS)
+        else:
+            fetch_start = last_stat_date + timedelta(days=1)
+
+        # Throttle: at most BACKFILL_CHUNK_DAYS per poll cycle.
+        fetch_end = min(
+            yesterday, fetch_start + timedelta(days=BACKFILL_CHUNK_DAYS - 1)
+        )
+
+        if fetch_start <= yesterday:
+            await self._fetch_range(
+                fetch_start,
+                fetch_end,
+                bill_start,
+                initial_cons_sum=last_cons_sum or 0.0,
+                initial_cost_sum=last_cost_sum or 0.0,
+            )
+        else:
+            self._latest_cumulative_kwh = last_cons_sum or 0.0
+
+        # Extract rates from plan.
         unit_rate_aud: float | None = None
         if plan is not None:
             for rate in plan.unit_rates:
@@ -180,7 +170,6 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 )
 
         return HaggleData(
-            consumption_today_kwh=0.0,
             consumption_period_kwh=period_kwh,
             consumption_period_cost_aud=period_cost,
             bill_projection_aud=projection,
@@ -189,9 +178,8 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             latest_cumulative_kwh=self._latest_cumulative_kwh,
         )
 
-    async def _get_last_stat_sum(self, stat_id: str) -> float | None:
-        """Return the last known cumulative sum for stat_id, or None."""
-        # Local imports: recorder is optional and may not be loaded yet.
+    async def _get_last_stat(self, stat_id: str) -> tuple[float | None, date | None]:
+        """Return (last_sum, last_date) for stat_id, or (None, None) if no rows."""
         from homeassistant.components.recorder.statistics import (
             get_last_statistics,
         )
@@ -201,72 +189,51 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             get_last_statistics, self.hass, 1, stat_id, True, {"start", "sum"}
         )
         if not last or stat_id not in last:
-            return None
+            return None, None
         rows = last[stat_id]
         if not rows:
-            return None
+            return None, None
         row = rows[0]
         val = row.get("sum")
-        return float(val) if val is not None else None
+        raw_start: float = row.get("start") or 0.0
+        last_sum = float(val) if val is not None else None
+        last_date: date | None = None
+        if raw_start:
+            last_date = datetime.fromtimestamp(raw_start, tz=UTC).date()
+        return last_sum, last_date
 
-    async def _fetch_missing_days(self, last_sum: float) -> None:
-        """Fetch each day since the last statistic and import intervals."""
-        # Local imports: recorder is optional and may not be loaded yet.
-        from homeassistant.components.recorder.statistics import (
-            get_last_statistics,
-        )
-        from homeassistant.helpers.recorder import get_instance
-
-        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}"
-        last = await get_instance(self.hass).async_add_executor_job(
-            get_last_statistics, self.hass, 1, stat_id_cons, True, {"start", "sum"}
-        )
-
-        last_start: datetime | None = None
-        if last and stat_id_cons in last and last[stat_id_cons]:
-            # StatisticsRow.start is a Unix timestamp (float).
-            raw_start: float = last[stat_id_cons][0].get("start") or 0.0
-            if raw_start:
-                last_start = datetime.fromtimestamp(raw_start, tz=UTC)
-
-        today = date.today()
-        yesterday = today - timedelta(days=1)
-
-        if last_start is None:
-            self._latest_cumulative_kwh = last_sum
-            return
-
-        next_day = last_start.date() + timedelta(days=1)
-        if next_day > yesterday:
-            self._latest_cumulative_kwh = last_sum
-            return
-
+    async def _fetch_range(
+        self,
+        start: date,
+        end: date,
+        bill_start: date | None,
+        initial_cons_sum: float,
+        initial_cost_sum: float,
+    ) -> None:
+        """Fetch [start..end] with smart endpoint selection, then import."""
         all_intervals: list[IntervalReading] = []
-        current = next_day
-        while current <= yesterday:
+        current = start
+        while current <= end:
             try:
-                readings = await self.client.async_get_usage_hourly(
-                    self.contract_number, current
-                )
+                if bill_start is not None and current < bill_start:
+                    readings = await self.client.async_get_usage_hourly_previous(
+                        self.contract_number, current
+                    )
+                else:
+                    readings = await self.client.async_get_usage_hourly(
+                        self.contract_number, current
+                    )
                 all_intervals.extend(readings)
             except (AGLError, NotImplementedError) as err:
-                _LOGGER.debug("Incremental fetch skip %s: %s", current, err)
+                _LOGGER.debug("Fetch skip %s: %s", current, err)
             current += timedelta(days=1)
 
         if all_intervals:
-            _LOGGER.info(
-                "Incremental update: %d intervals from %s to %s",
-                len(all_intervals),
-                next_day,
-                yesterday,
-            )
             await self._import_intervals(
-                all_intervals,
-                initial_cons_sum=last_sum,
-                initial_cost_sum=0.0,
+                all_intervals, initial_cons_sum, initial_cost_sum
             )
         else:
-            self._latest_cumulative_kwh = last_sum
+            self._latest_cumulative_kwh = initial_cons_sum
 
     async def _import_intervals(
         self,
@@ -313,7 +280,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             self.hass,
             StatisticMetaData(
                 mean_type=StatisticMeanType.NONE,
-                unit_class=None,
+                unit_class="energy",
                 has_sum=True,
                 name=f"AGL Electricity Consumption ({self.contract_number})",
                 source=DOMAIN,

--- a/custom_components/haggle/sensor.py
+++ b/custom_components/haggle/sensor.py
@@ -29,9 +29,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DATA_BILL_PROJECTION,
+    DATA_CONSUMPTION_COST,
     DATA_CONSUMPTION_KWH,
     DATA_CONSUMPTION_PERIOD,
-    DATA_CONSUMPTION_TODAY,
     DATA_SUPPLY_CHARGE,
     DATA_UNIT_RATE,
     DOMAIN,
@@ -56,15 +56,7 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=3,
     ),
-    # --- Sub-period sensors (reset at known boundaries) ---
-    SensorEntityDescription(
-        key=DATA_CONSUMPTION_TODAY,
-        translation_key="consumption_today",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_display_precision=2,
-    ),
+    # --- Sub-period sensors (reset at billing boundary) ---
     SensorEntityDescription(
         key=DATA_CONSUMPTION_PERIOD,
         translation_key="consumption_period",
@@ -73,7 +65,15 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
     ),
-    # --- Forecast / cost (monetary, measurement) ---
+    SensorEntityDescription(
+        key=DATA_CONSUMPTION_COST,
+        translation_key="consumption_cost",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement="AUD",
+        suggested_display_precision=2,
+    ),
+    # --- Forecast / rates (monetary, measurement) ---
     SensorEntityDescription(
         key=DATA_BILL_PROJECTION,
         translation_key="bill_projection",

--- a/custom_components/haggle/strings.json
+++ b/custom_components/haggle/strings.json
@@ -30,11 +30,11 @@
       "consumption": {
         "name": "Consumption"
       },
-      "consumption_today": {
-        "name": "Consumption today"
-      },
       "consumption_period": {
         "name": "Consumption this period"
+      },
+      "consumption_cost": {
+        "name": "Consumption cost"
       },
       "bill_projection": {
         "name": "Bill projection"

--- a/custom_components/haggle/translations/en.json
+++ b/custom_components/haggle/translations/en.json
@@ -30,11 +30,11 @@
       "consumption": {
         "name": "Consumption"
       },
-      "consumption_today": {
-        "name": "Consumption today"
-      },
       "consumption_period": {
         "name": "Consumption this period"
+      },
+      "consumption_cost": {
+        "name": "Consumption cost"
       },
       "bill_projection": {
         "name": "Bill projection"

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -1,7 +1,7 @@
 """Tests for HaggleCoordinator statistics import logic.
 
 Covers _import_intervals (aggregation, running sum, idempotency, none-filter),
-_async_setup (30-day backfill), and _fetch_and_import (resume from last stat).
+_fetch_range (smart endpoint selection), and _fetch_and_import (chunked resume).
 
 All recorder calls are patched at the boundary — async_add_external_statistics
 and get_last_statistics — so no real SQLite DB is needed.
@@ -9,7 +9,7 @@ and get_last_statistics — so no real SQLite DB is needed.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +18,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.haggle.agl.models import IntervalReading
 from custom_components.haggle.const import (
+    BACKFILL_CHUNK_DAYS,
+    BACKFILL_DAYS,
     CONF_ACCESS_TOKEN,
     CONF_ACCESS_TOKEN_EXPIRY,
     CONF_ACCOUNT_NUMBER,
@@ -284,81 +286,18 @@ class TestImportIntervalsAggregationFiltered:
 
 
 # ---------------------------------------------------------------------------
-# _async_setup — 30-day backfill
+# _async_setup — now a no-op
 # ---------------------------------------------------------------------------
 
 
-class TestAsyncSetupBackfill:
-    async def test_calls_previous_hourly_for_backfill_days(
-        self, hass: HomeAssistant
-    ) -> None:
-        """_async_setup must call async_get_usage_hourly_previous once per backfill day."""
-        from custom_components.haggle.const import BACKFILL_DAYS
-
+class TestAsyncSetupIsNoop:
+    async def test_setup_does_not_call_client(self, hass: HomeAssistant) -> None:
+        """_async_setup is a no-op; first-install backfill runs via _fetch_and_import."""
         mock_client = AsyncMock()
-        mock_client.async_get_usage_hourly_previous.return_value = []
         coord = _make_coordinator(hass, client=mock_client)
-
-        with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._async_setup()
-
-        assert mock_client.async_get_usage_hourly_previous.call_count == BACKFILL_DAYS
-
-    async def test_backfill_days_are_consecutive_ending_yesterday(
-        self, hass: HomeAssistant
-    ) -> None:
-        """Days requested span yesterday through (today - BACKFILL_DAYS)."""
-        from datetime import date
-
-        from custom_components.haggle.const import BACKFILL_DAYS
-
-        mock_client = AsyncMock()
-        mock_client.async_get_usage_hourly_previous.return_value = []
-        coord = _make_coordinator(hass, client=mock_client)
-
-        with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._async_setup()
-
-        today = date.today()
-        called_days = {
-            c.args[1]
-            for c in mock_client.async_get_usage_hourly_previous.call_args_list
-        }
-        expected_days = {today - timedelta(days=i) for i in range(1, BACKFILL_DAYS + 1)}
-        assert called_days == expected_days
-
-    async def test_backfill_aggregates_and_imports(self, hass: HomeAssistant) -> None:
-        """_async_setup passes all gathered readings to _import_intervals."""
-        mock_client = AsyncMock()
-        reading = _make_interval(datetime(2026, 4, 28, 0, 0, tzinfo=UTC), kwh=0.5)
-        mock_client.async_get_usage_hourly_previous.return_value = [reading]
-        coord = _make_coordinator(hass, client=mock_client)
-
-        with patch.object(
-            coord, "_import_intervals", new_callable=AsyncMock
-        ) as mock_import:
-            await coord._async_setup()
-
-        mock_import.assert_called_once()
-        imported = mock_import.call_args[0][0]
-        # 30 calls each returning 1 reading → 30 readings total
-        assert len(imported) == 30
-
-    async def test_backfill_skips_agl_error(self, hass: HomeAssistant) -> None:
-        """A failed day is skipped; remaining days are still fetched."""
-        from custom_components.haggle.agl.client import AGLError
-
-        mock_client = AsyncMock()
-        mock_client.async_get_usage_hourly_previous.side_effect = AGLError("timeout")
-        coord = _make_coordinator(hass, client=mock_client)
-
-        with patch.object(
-            coord, "_import_intervals", new_callable=AsyncMock
-        ) as mock_import:
-            await coord._async_setup()  # Must not raise
-
-        # Error means no intervals collected → _import_intervals not called
-        mock_import.assert_not_called()
+        await coord._async_setup()
+        mock_client.async_get_usage_hourly.assert_not_called()
+        mock_client.async_get_usage_hourly_previous.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -407,56 +346,196 @@ class TestUpdateDataAuthError:
 
 
 # ---------------------------------------------------------------------------
-# _fetch_and_import — resume from last stat
+# _fetch_range — smart endpoint selection
 # ---------------------------------------------------------------------------
 
 
-class TestFetchAndImportResume:
-    async def test_no_previous_stats_triggers_backfill(
+class TestFetchRange:
+    async def test_uses_previous_hourly_for_days_before_bill_start(
         self, hass: HomeAssistant
     ) -> None:
-        """When _get_last_stat_sum returns None, _async_setup is called."""
+        """Days strictly before bill_start must use Previous/Hourly."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly_previous.return_value = []
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        bill_start = today - timedelta(days=2)
+        start = today - timedelta(days=5)
+        end = today - timedelta(days=3)  # all days are before bill_start
+
+        with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
+            await coord._fetch_range(start, end, bill_start, 0.0, 0.0)
+
+        assert mock_client.async_get_usage_hourly_previous.call_count == 3
+        mock_client.async_get_usage_hourly.assert_not_called()
+
+    async def test_uses_current_hourly_for_days_on_or_after_bill_start(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Days on or after bill_start must use Current/Hourly."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.return_value = []
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        bill_start = today - timedelta(days=5)
+        start = today - timedelta(days=3)  # start is after bill_start
+        end = today - timedelta(days=1)
+
+        with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
+            await coord._fetch_range(start, end, bill_start, 0.0, 0.0)
+
+        assert mock_client.async_get_usage_hourly.call_count == 3
+        mock_client.async_get_usage_hourly_previous.assert_not_called()
+
+    async def test_uses_current_hourly_when_bill_start_is_none(
+        self, hass: HomeAssistant
+    ) -> None:
+        """When bill_start is None, always use Current/Hourly."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.return_value = []
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        start = today - timedelta(days=2)
+        end = today - timedelta(days=1)
+
+        with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
+            await coord._fetch_range(start, end, None, 0.0, 0.0)
+
+        assert mock_client.async_get_usage_hourly.call_count == 2
+        mock_client.async_get_usage_hourly_previous.assert_not_called()
+
+    async def test_fetch_range_skips_agl_error(self, hass: HomeAssistant) -> None:
+        """AGLError on a day is skipped; remaining days still fetched."""
+        from custom_components.haggle.agl.client import AGLError
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.side_effect = AGLError("timeout")
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        start = today - timedelta(days=3)
+        end = today - timedelta(days=1)
+
+        with patch.object(
+            coord, "_import_intervals", new_callable=AsyncMock
+        ) as mock_imp:
+            await coord._fetch_range(start, end, None, 0.0, 0.0)  # must not raise
+
+        # All days attempted despite errors; no intervals → _import_intervals not called
+        assert mock_client.async_get_usage_hourly.call_count == 3
+        mock_imp.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_and_import — chunked resume behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAndImport:
+    async def test_no_previous_stats_starts_from_backfill_days_ago(
+        self, hass: HomeAssistant
+    ) -> None:
+        """First install: fetch_start = today - BACKFILL_DAYS."""
         mock_client = AsyncMock()
         mock_client.async_get_usage_summary.side_effect = NotImplementedError
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
+        today = date.today()
+        expected_start = today - timedelta(days=BACKFILL_DAYS)
+
         with (
             patch.object(
                 coord,
-                "_get_last_stat_sum",
+                "_get_last_stat",
                 new_callable=AsyncMock,
-                return_value=None,
+                return_value=(None, None),
             ),
-            patch.object(coord, "_async_setup", new_callable=AsyncMock) as mock_setup,
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
         ):
             await coord._fetch_and_import()
 
-        mock_setup.assert_called_once()
+        assert mock_range.called
+        actual_start = mock_range.call_args[0][0]
+        assert actual_start == expected_start
 
-    async def test_existing_stats_triggers_fetch_missing_days(
-        self, hass: HomeAssistant
-    ) -> None:
-        """When stats exist, _fetch_missing_days is called with the last sum."""
+    async def test_chunk_limit_applied_to_range(self, hass: HomeAssistant) -> None:
+        """fetch_end must be at most fetch_start + BACKFILL_CHUNK_DAYS - 1."""
         mock_client = AsyncMock()
         mock_client.async_get_usage_summary.side_effect = NotImplementedError
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
+        today = date.today()
+        # last stat was long ago → big gap; chunk should cap the end
+        last_date = today - timedelta(days=BACKFILL_DAYS)
+
         with (
             patch.object(
                 coord,
-                "_get_last_stat_sum",
+                "_get_last_stat",
                 new_callable=AsyncMock,
-                return_value=259.0,
+                return_value=(100.0, last_date),
             ),
-            patch.object(
-                coord, "_fetch_missing_days", new_callable=AsyncMock
-            ) as mock_fetch,
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
         ):
             await coord._fetch_and_import()
 
-        mock_fetch.assert_called_once_with(259.0)
+        fetch_start = mock_range.call_args[0][0]
+        fetch_end = mock_range.call_args[0][1]
+        assert (fetch_end - fetch_start).days <= BACKFILL_CHUNK_DAYS - 1
+
+    async def test_existing_stats_resumes_from_next_day(
+        self, hass: HomeAssistant
+    ) -> None:
+        """When last_stat_date is 3 days ago, fetch_start = 2 days ago."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.side_effect = NotImplementedError
+        mock_client.async_get_plan.side_effect = NotImplementedError
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        last_date = today - timedelta(days=3)
+        expected_start = today - timedelta(days=2)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(50.0, last_date),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        assert mock_range.call_args[0][0] == expected_start
+
+    async def test_already_up_to_date_no_fetch(self, hass: HomeAssistant) -> None:
+        """If last stat is yesterday, _fetch_range is not called."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.side_effect = NotImplementedError
+        mock_client.async_get_plan.side_effect = NotImplementedError
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(259.0, yesterday),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        mock_range.assert_not_called()
 
     async def test_returns_haggle_data_instance(self, hass: HomeAssistant) -> None:
         from custom_components.haggle.coordinator import HaggleData
@@ -466,14 +545,17 @@ class TestFetchAndImportResume:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
         with (
             patch.object(
                 coord,
-                "_get_last_stat_sum",
+                "_get_last_stat",
                 new_callable=AsyncMock,
-                return_value=259.0,
+                return_value=(259.0, yesterday),
             ),
-            patch.object(coord, "_fetch_missing_days", new_callable=AsyncMock),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
             result = await coord._fetch_and_import()
 
@@ -493,110 +575,19 @@ class TestFetchAndImportResume:
         )
         coord = _make_coordinator(hass, client=mock_client)
 
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
         with (
             patch.object(
                 coord,
-                "_get_last_stat_sum",
+                "_get_last_stat",
                 new_callable=AsyncMock,
-                return_value=100.0,
+                return_value=(100.0, yesterday),
             ),
-            patch.object(coord, "_fetch_missing_days", new_callable=AsyncMock),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
             result = await coord._fetch_and_import()
 
         assert result.unit_rate_aud_per_kwh == pytest.approx(33.792 / 100.0)
         assert result.supply_charge_aud_per_day == pytest.approx(131.714 / 100.0)
-
-
-# ---------------------------------------------------------------------------
-# _fetch_missing_days — correct day range requested
-# ---------------------------------------------------------------------------
-
-
-class TestFetchMissingDays:
-    async def test_fetches_days_from_gap_to_yesterday(
-        self, hass: HomeAssistant
-    ) -> None:
-        """If last stat was 3 days ago, fetch day-2 and day-1 (yesterday)."""
-        from datetime import date
-
-        mock_client = AsyncMock()
-        mock_client.async_get_usage_hourly.return_value = []
-        coord = _make_coordinator(hass, client=mock_client)
-
-        today = date.today()
-        yesterday = today - timedelta(days=1)
-        last_stat_day = today - timedelta(days=3)  # 3 days ago
-
-        last_stats_raw = {
-            f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}": [
-                {
-                    "start": float(
-                        datetime.combine(last_stat_day, datetime.min.time())
-                        .replace(tzinfo=UTC)
-                        .timestamp()
-                    ),
-                    "sum": 50.0,
-                }
-            ]
-        }
-
-        with (
-            patch(_PATCH_GET_LAST, return_value=last_stats_raw),
-            patch(_PATCH_GET_INSTANCE, _mock_get_instance(last_stats_raw)),
-            patch.object(coord, "_import_intervals", new_callable=AsyncMock),
-        ):
-            await coord._fetch_missing_days(last_sum=50.0)
-
-        called_days = {
-            c.args[1] for c in mock_client.async_get_usage_hourly.call_args_list
-        }
-        expected = {today - timedelta(days=2), yesterday}
-        assert called_days == expected
-
-    async def test_no_gap_does_not_fetch(self, hass: HomeAssistant) -> None:
-        """If last stat is already for yesterday, no new fetch needed."""
-        from datetime import date
-
-        mock_client = AsyncMock()
-        coord = _make_coordinator(hass, client=mock_client)
-
-        today = date.today()
-        yesterday = today - timedelta(days=1)
-
-        last_stats_raw = {
-            f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}": [
-                {
-                    "start": float(
-                        datetime.combine(yesterday, datetime.min.time())
-                        .replace(tzinfo=UTC)
-                        .timestamp()
-                    ),
-                    "sum": 50.0,
-                }
-            ]
-        }
-
-        with (
-            patch(_PATCH_GET_LAST, return_value=last_stats_raw),
-            patch(_PATCH_GET_INSTANCE, _mock_get_instance(last_stats_raw)),
-        ):
-            await coord._fetch_missing_days(last_sum=50.0)
-
-        mock_client.async_get_usage_hourly.assert_not_called()
-
-    async def test_empty_stats_sets_cumulative_and_returns(
-        self, hass: HomeAssistant
-    ) -> None:
-        """If get_last_statistics returns no rows, store last_sum and return."""
-        mock_client = AsyncMock()
-        coord = _make_coordinator(hass, client=mock_client)
-
-        with (
-            patch(_PATCH_GET_LAST, return_value={}),
-            patch(_PATCH_GET_INSTANCE, _mock_get_instance({})),
-        ):
-            await coord._fetch_missing_days(last_sum=42.0)
-
-        assert coord._latest_cumulative_kwh == pytest.approx(42.0)
-        mock_client.async_get_usage_hourly.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,7 +29,6 @@ _ENTRY_DATA = {
 }
 
 _COORDINATOR_DATA = HaggleData(
-    consumption_today_kwh=0.0,
     consumption_period_kwh=259.0,
     consumption_period_cost_aud=87.38,
     bill_projection_aud=139.15,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -203,6 +203,11 @@ class TestParseBillPeriod:
         bp = parse_bill_period(data)
         assert bp.projection_label == "$139.15"
 
+    def test_consumption_kwh_parsed_from_quantity_string(self) -> None:
+        data = load_fixture("bill_period_response.json")
+        bp = parse_bill_period(data)
+        assert bp.consumption_kwh == pytest.approx(259.0)
+
     def test_missing_bill_period_returns_today_dates(self) -> None:
         """Empty response should not crash; dates fall back to today."""
         from datetime import date as _date


### PR DESCRIPTION
## Summary

- **`_fetch_contracts` token bug**: config flow was handing `access_token` to `AglAuth` as a refresh token; Auth0 rejected it, contract number fell back to `""`, every data URL became `.../Electricity/?...` → HTTP 404. Fixed to use a direct `aiohttp` GET with bearer token.
- **HTTP 500 on all usage endpoints**: AGL BFF requires `Accept-Features`, `Client-Device`, `Accept-Language` headers and a `scaling` query param. Added to `AglClient._default_headers` and all Hourly/Daily URL builders (captured from mitmproxy 2026-05-01).
- **Consumption always 0**: `parse_bill_period` hardcoded `consumption_kwh=0.0`; now parses `usage.quantity` string.
- **External statistic invisible in Energy dashboard**: `unit_class=None` excluded it from the picker; fixed to `unit_class="energy"`.
- **Chunked throttled backfill**: burst 30-day `_async_setup` replaced with `BACKFILL_CHUNK_DAYS=7` per poll cycle + smart endpoint selection (`Previous/Hourly` pre-billing-period, `Current/Hourly` otherwise).
- **Sensor cleanup**: removed always-zero `consumption_today` sensor; added `consumption_cost` (AUD) sensor.

## Verification checklist

- [x] `uv run pytest` — 64 passed
- [x] `uv run mypy` — clean
- [x] `uv run ruff check` — clean
- [x] Live: `haggle:consumption_9415356587` statistic in DB (168 rows, Apr 1–8, 95.3 kWh)
- [x] Live: statistic visible in Energy dashboard consumption source picker
- [x] Live: Energy dashboard shows Apr 1–8 bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)