### PR TITLE
ci(security): pin actions, scope permissions, harden release body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
@@ -15,15 +17,15 @@ jobs:
         python-version: ["3.13"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -43,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         if: matrix.python-version == '3.13'
         with:
           files: coverage.xml

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -6,16 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   validate:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      # hacsjson and integration_manifest checks will fail until the repo is
-      # registered in the HACS store (requires public repo + hacs/default PR).
-      # brands, topics, archived, issues, description, information pass now.
-      - uses: hacs/action@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main@2026-01-26
         with:
           category: integration
-        continue-on-error: true

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -6,10 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: home-assistant/actions/hassfest@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b # master@2026-04-07

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -22,19 +22,15 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Extract changelog section
-        id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Extract the section between ## [VERSION] and the next ## [
           awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md > release_notes.txt
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          cat release_notes.txt >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: "v${{ steps.version.outputs.version }}"
-          body: ${{ steps.changelog.outputs.body }}
+          body_path: release_notes.txt
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,10 @@ The HA Energy dashboard requires:
   consumption picker filters by `unit_class="energy"`. `None` silently hides the statistic.
 - **No committing directly to `main`** — the `guard-main-branch` hook blocks it.
   Use a feature branch + PR.
+- **No mutable GitHub Action refs** — pin every `uses: owner/action@…` to a
+  40-char commit SHA with a `# vX.Y` comment. `@main`, `@master`, and floating
+  major tags (`@v6`) are all branch-poisonable supply-chain vectors. Dependabot
+  (`github-actions` ecosystem) keeps the SHAs current.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Security
+- **Pin all GitHub Actions to commit SHAs** across `ci.yml`, `hacs.yml`,
+  `hassfest.yml`, `release.yml`. Closes the supply-chain branch-poisoning vector
+  on `hacs/action@main` and `home-assistant/actions/hassfest@master`.
+- **Add `permissions: read-all` to `ci.yml`, `hacs.yml`, `hassfest.yml`**.
+  `release.yml` retains its job-level `contents: write`.
+- **Remove `continue-on-error: true` from the HACS validation step**. The
+  underlying validation passes (`All (8) checks passed` confirmed against
+  `main`); the suppression flag was hiding real failures from CI.
+- **Switch `release.yml` to `body_path:`** instead of interpolating
+  `${{ steps.changelog.outputs.body }}` directly into the release body, removing
+  the shell-context injection vector.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the **AP-3 supply-chain attack path** from the 2026-05-02 security review (`security/2026-05-02T04-43Z/`). Three independent fixes that together prevent a compromised upstream Action from poisoning a future HACS release.

- **SHA-pin all 10 Action references** across `ci.yml`, `hacs.yml`, `hassfest.yml`, `release.yml` with `# vX.Y` comments. Removes the branch-poisoning vector on `hacs/action@main` and `home-assistant/actions/hassfest@master`, plus the floating-major-tag risk on the others. Dependabot's `github-actions` ecosystem (already configured) will keep the SHAs current.
- **Add workflow-level `permissions: read-all`** to `ci.yml`, `hacs.yml`, `hassfest.yml`. `release.yml` keeps its job-level `contents: write`.
- **Drop `continue-on-error: true`** from the HACS validation step. A re-run against current `main` reports `All (8) checks passed` (verified via `gh run view`), so the flag was suppressing green CI and would have hidden a compromised `hacs/action` too.
- **Switch `release.yml` to `body_path:`** instead of interpolating `${{ steps.changelog.outputs.body }}` directly into the action input — removes the shell-context injection vector flagged by repo-hygiene B6.

Per `CLAUDE.md` docs checklist:
- `CHANGELOG.md` → new `## [Unreleased]` `### Security` section.
- `AGENTS.md` → "What NOT to Do" gains a no-mutable-Action-refs rule.

`codecov-action` keeps its `continue-on-error: true` (codecov outages should not block merges; not a security concern).

## Test plan

- [ ] CI workflow green on this PR (proves SHA-pinning didn't break anything).
- [ ] Hassfest workflow green (validates that pinning `hassfest@<sha>` still passes).
- [ ] HACS workflow green **without** `continue-on-error` masking the result.
- [ ] No new diff in `pyproject.toml`, `manifest.json`, or any Python file (this PR is CI-only).
- [ ] `gh workflow view hacs.yml` no longer renders the `continue-on-error` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
