### PR TITLE
fix(security): SAST sweep — close AP-2/AP-4/AP-6 chains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,9 @@ tests/
 ├── test_init.py                     # setup/unload smoke tests
 ├── test_config_flow.py              # PKCE step navigation (user → exchange → select_contract)
 ├── test_agl_client.py               # AglAuth token rotation + AglClient HTTP methods
-├── test_parser.py                   # parse_interval_readings, parse_overview, parse_plan (22 tests)
-└── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, aggregation (26 tests)
+├── test_const.py                    # base64 sanity-check on AGL_AUTH0_CLIENT
+├── test_parser.py                   # parse_interval_readings, parse_overview, parse_plan, _safe_float
+└── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, numeric guards
 
 scripts/
 ├── wt                   # bash worktree helper (new / list / rm)
@@ -276,6 +277,19 @@ The HA Energy dashboard requires:
   40-char commit SHA with a `# vX.Y` comment. `@main`, `@master`, and floating
   major tags (`@v6`) are all branch-poisonable supply-chain vectors. Dependabot
   (`github-actions` ecosystem) keeps the SHAs current.
+- **Don't surface raw AGL/Auth0 response bodies in exceptions** that propagate
+  to `ConfigEntryAuthFailed` / `UpdateFailed`. They reach HA Persistent
+  Notifications and `home-assistant.log` at ERROR level. Auth0 5xx/429 bodies
+  can include diagnostic fields (`mfa_token`, internal trace IDs); AGL BFF URLs
+  carry the contract number (PII). Pattern:
+  `_LOGGER.debug("…body: %s", text[:200]); raise AGLError(f"HTTP {status} …")`.
+- **Don't use unbounded `float()` coercion on AGL response values**. Use the
+  `_safe_float` helpers in `agl/parser.py` / `coordinator.py` so `inf`/`nan`/
+  negative values can't reach `async_add_external_statistics` and corrupt the
+  cumulative-sum series.
+- **Don't forward raw AGL response dicts** via `dict(rate)` or similar
+  open-schema passthrough. Allowlist exactly the fields the coordinator
+  consumes, so a MITM-crafted response can't smuggle keys into runtime state.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Switch `release.yml` to `body_path:`** instead of interpolating
   `${{ steps.changelog.outputs.body }}` directly into the release body, removing
   the shell-context injection vector.
+- **Hash refresh-token before using it as a fallback `unique_id`** in the config
+  flow. The HA entity registry is plaintext JSON on disk; previously the first
+  16 chars of the live OAuth2 refresh token landed there when contracts were
+  unavailable at setup time. Now uses `sha256(refresh_token)[:16]`. (SAST-001)
+- **Use the return value of `AglAuth.async_force_refresh`** on the 401-retry
+  path in `AglClient._get` instead of reading `_auth._token_set.access_token`
+  via private-attribute access. The retry path no longer silently masks auth
+  failures. (SAST-002)
+- **Redact AGL/Auth0 response bodies from exceptions** that propagate to
+  `ConfigEntryAuthFailed` / `UpdateFailed`. Bodies and PII-bearing URLs now go
+  to `_LOGGER.debug` only — they no longer surface in HA Persistent
+  Notifications or the default `home-assistant.log`. Affects token refresh,
+  the `_get` error path, and the config-flow `_fetch_contracts` overview call.
+  (SAST-003, SAST-004)
+- **Consolidate the `auth0-client` SDK identity blob** to a single
+  `AGL_AUTH0_CLIENT` constant in `const.py`. Previously the same JSON shape was
+  base64-encoded twice with different field ordering — once in `const.py`,
+  once in `agl/client.py` — risking inconsistent headers per call site.
+  (SAST-006)
+- **Allowlist plan-rate fields** in `parse_plan` instead of forwarding the
+  raw API rate dict via `dict(rate)`. Only `kind`, `type`, `title`, `price`
+  propagate into `PlanRates.unit_rates` — closes the open-schema vector that
+  a MITM AGL response could exploit to inject keys into coordinator state.
+  (SAST-007)
+- **Bound numeric API values** with a shared `_safe_float()` helper in
+  `agl/parser.py` and `coordinator.py`. Non-finite (`inf`, `nan`) and negative
+  values clamp to `0.0` with a warning so adversarial AGL responses can no
+  longer poison the recorder via `async_add_external_statistics`. (SAST-008)
+- **Trigger reauth on persist failure**: if `async_update_entry` raises while
+  saving a rotated refresh token, `__init__.py::_persist_refresh_token` now
+  calls `entry.async_start_reauth(hass)` immediately instead of silently
+  continuing in split-brain state. (SAST-009)
 
 ---
 

--- a/custom_components/haggle/__init__.py
+++ b/custom_components/haggle/__init__.py
@@ -50,16 +50,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bo
     _LOGGER.info("Setting up haggle entry: contract=%s", contract_number or "unknown")
 
     async def _persist_refresh_token(new_token: str) -> None:
-        """Persist rotated refresh token back to config entry data."""
+        """Persist rotated refresh token back to config entry data.
+
+        Auth0 has already consumed the previous refresh token by the time this
+        callback runs; failing to persist the new one means the next HA restart
+        will load a stale (revoked) token. Surface that immediately via the
+        reauth flow rather than letting the user discover it on next restart.
+        """
         try:
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, CONF_REFRESH_TOKEN: new_token}
             )
             _LOGGER.debug("Refresh token persisted (len=%d)", len(new_token))
         except Exception:
-            _LOGGER.error(
-                "Failed to persist rotated refresh token — next restart will require reauth"
+            _LOGGER.exception(
+                "Failed to persist rotated refresh token — triggering reauth"
             )
+            entry.async_start_reauth(hass)
 
     session = aiohttp.ClientSession()
     auth = AglAuth(refresh_token, _persist_refresh_token)

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..const import (
     AGL_ACCEPT_FEATURES,
+    AGL_AUTH0_CLIENT,
     AGL_AUTH_HOST,
     AGL_CLIENT_DEVICE,
     AGL_CLIENT_FLAVOR,
@@ -52,9 +53,6 @@ if TYPE_CHECKING:
     import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
-
-# auth0-client header value — base64-encoded SDK identity blob (Auth0.swift 2.12.0).
-_AUTH0_CLIENT = "eyJlbnYiOnsic3dpZnQiOiI2LngiLCJpT1MiOiIyNi40In0sIm5hbWUiOiJBdXRoMC5zd2lmdCIsInZlcnNpb24iOiIyLjEyLjAifQ"  # gitleaks:allow
 
 # Refresh when this many seconds remain before expiry.
 _REFRESH_MARGIN_SECONDS = 120
@@ -140,8 +138,7 @@ class AglAuth:
             if exp is not None and (exp - now) >= _REFRESH_MARGIN_SECONDS:
                 return self._token_set.access_token
 
-        await self.async_force_refresh(session)
-        return self._token_set.access_token  # type: ignore[union-attr]
+        return await self.async_force_refresh(session)
 
     async def async_force_refresh(self, session: aiohttp.ClientSession) -> str:
         """Force a token refresh. Persists the rotated refresh token.
@@ -156,7 +153,7 @@ class AglAuth:
             "Accept-Encoding": "gzip, deflate, br",
             "Client-Flavor": AGL_CLIENT_FLAVOR,
             "User-Agent": AGL_USER_AGENT,
-            "auth0-client": _AUTH0_CLIENT,
+            "auth0-client": AGL_AUTH0_CLIENT,
         }
         body = {
             "grant_type": "refresh_token",
@@ -168,17 +165,18 @@ class AglAuth:
             if resp.status == 401:
                 raise AGLAuthError("Token refresh rejected (401) — reauth required")
             if resp.status != 200:
+                # Auth0 error bodies can include diagnostic fields (mfa_token,
+                # error_description, internal trace IDs); keep them out of the
+                # exception that propagates to ConfigEntryAuthFailed → HA
+                # Persistent Notifications. Body lives in DEBUG only.
                 text = await resp.text()
-                raise AGLAuthError(
-                    f"Token refresh failed HTTP {resp.status}: {text[:200]}"
-                )
+                _LOGGER.debug("Token refresh non-200 body: %s", text[:200])
+                raise AGLAuthError(f"Token refresh failed HTTP {resp.status}")
             data: dict[str, Any] = await resp.json(content_type=None)
 
         error = data.get("error")
         if error:
-            raise AGLAuthError(
-                f"Token refresh error: {error} — {data.get('error_description', '')}"
-            )
+            raise AGLAuthError(f"Token refresh error: {error}")
 
         access_token: str = data["access_token"]
         new_refresh_token: str = data["refresh_token"]
@@ -241,28 +239,36 @@ class AglClient:
 
         async with self._session.get(url, headers=headers) as resp:
             if resp.status == 429:
-                raise AGLRateLimitError(f"Rate limited on {url}")
+                raise AGLRateLimitError(f"Rate limited (HTTP {resp.status})")
             if resp.status == 401:
                 _LOGGER.debug("Got 401 on %s; forcing token refresh", url)
             elif resp.status >= 400:
+                # URL contains contract_number (PII) and body may carry
+                # AGL-side diagnostics; keep both in DEBUG only.
                 text = await resp.text()
-                raise AGLError(f"HTTP {resp.status} on {url}: {text[:200]}")
+                _LOGGER.debug("HTTP %s on %s body: %s", resp.status, url, text[:200])
+                raise AGLError(f"HTTP {resp.status} fetching AGL data")
             else:
                 return await resp.json(content_type=None)
 
         # Only reached on 401 — force refresh and retry once.
-        await self._auth.async_force_refresh(self._session)
-        token = self._auth._token_set.access_token  # type: ignore[union-attr]
+        token = await self._auth.async_force_refresh(self._session)
         headers = {**self._default_headers, "Authorization": f"Bearer {token}"}
 
         async with self._session.get(url, headers=headers) as resp2:
             if resp2.status == 401:
-                raise AGLAuthError(f"Still 401 after token refresh on {url}")
+                raise AGLAuthError("Still 401 after token refresh")
             if resp2.status == 429:
-                raise AGLRateLimitError(f"Rate limited on {url}")
+                raise AGLRateLimitError(f"Rate limited (HTTP {resp2.status})")
             if resp2.status >= 400:
                 text = await resp2.text()
-                raise AGLError(f"HTTP {resp2.status} on {url}: {text[:200]}")
+                _LOGGER.debug(
+                    "HTTP %s on %s body (post-refresh): %s",
+                    resp2.status,
+                    url,
+                    text[:200],
+                )
+                raise AGLError(f"HTTP {resp2.status} fetching AGL data")
             return await resp2.json(content_type=None)
 
     # --- Discovery ---

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -11,10 +11,30 @@ Critical fields:
 
 from __future__ import annotations
 
+import logging
+import math
 from datetime import UTC, date, datetime
 from typing import Any
 
 from .models import BillPeriod, Contract, DailyReading, IntervalReading, PlanRates
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _safe_float(raw: Any) -> float:
+    """Coerce raw API value to a non-negative finite float.
+
+    Treats inf/nan/negative as 0.0 with a warning, so adversarial or corrupt
+    AGL responses cannot poison the recorder via async_add_external_statistics.
+    """
+    try:
+        value = float(raw or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(value) or value < 0:
+        _LOGGER.warning("Rejecting non-finite/negative AGL value: %r", raw)
+        return 0.0
+    return value
 
 
 def parse_overview(data: dict[str, Any]) -> list[Contract]:
@@ -59,8 +79,8 @@ def parse_interval_readings(data: dict[str, Any]) -> list[IntervalReading]:
             except (ValueError, AttributeError):
                 continue
             values = consumption.get("values") or {}
-            kwh: float = float(values.get("quantity") or 0.0)
-            cost_aud: float = float(consumption.get("amount") or 0.0)
+            kwh = _safe_float(values.get("quantity"))
+            cost_aud = _safe_float(consumption.get("amount"))
             readings.append(
                 IntervalReading(
                     dt=dt,
@@ -92,8 +112,8 @@ def parse_daily_readings(data: dict[str, Any]) -> list[DailyReading]:
             except (ValueError, AttributeError):
                 continue
             values = consumption.get("values") or {}
-            kwh: float = float(values.get("quantity") or 0.0)
-            cost_aud: float = float(consumption.get("amount") or 0.0)
+            kwh = _safe_float(values.get("quantity"))
+            cost_aud = _safe_float(consumption.get("amount"))
             readings.append(DailyReading(day=day, kwh=kwh, cost_aud=cost_aud))
     return readings
 
@@ -124,10 +144,7 @@ def parse_bill_period(data: dict[str, Any]) -> BillPeriod:
     projection_label: str = data.get("additionalLabelValue", "")
 
     quantity_str: str = (usage.get("quantity") or "0").replace(",", "").split()[0]
-    try:
-        consumption_kwh: float = float(quantity_str)
-    except (ValueError, IndexError):
-        consumption_kwh = 0.0
+    consumption_kwh = _safe_float(quantity_str)
 
     return BillPeriod(
         start=start,
@@ -148,10 +165,19 @@ def parse_plan(data: dict[str, Any]) -> PlanRates:
         if rate.get("kind") != "detail":
             continue
         rate_type: str = rate.get("type", "")
-        price: float = float(rate.get("price") or 0.0)
+        price = _safe_float(rate.get("price"))
         if rate_type == "c/day" and "supply" in (rate.get("title") or "").lower():
             supply_charge = price
-        unit_rates.append(dict(rate))
+        # Allowlist the four fields the coordinator actually consumes — drops
+        # any extra keys an attacker-controlled (MITM) response could inject.
+        unit_rates.append(
+            {
+                "kind": rate.get("kind"),
+                "type": rate_type,
+                "title": rate.get("title"),
+                "price": price,
+            }
+        )
 
     return PlanRates(
         product_name=product_name,

--- a/custom_components/haggle/config_flow.py
+++ b/custom_components/haggle/config_flow.py
@@ -161,8 +161,11 @@ async def _fetch_contracts(access_token: str) -> list[Contract]:
         session.get(url, headers=headers) as resp,
     ):
         if resp.status >= 400:
+            # Body kept out of the exception so it doesn't surface in
+            # ConfigEntryAuthFailed → HA Persistent Notifications.
             text = await resp.text()
-            raise AGLError(f"HTTP {resp.status} on {url}: {text[:200]}")
+            _LOGGER.debug("HTTP %s on %s body: %s", resp.status, url, text[:200])
+            raise AGLError(f"HTTP {resp.status} fetching AGL overview")
         data = await resp.json(content_type=None)
     return parse_overview(data)
 
@@ -323,13 +326,15 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
         account_number: str,
         title: str | None = None,
     ) -> ConfigFlowResult:
-        unique_id = (
-            f"{account_number}_{contract_number}"
-            if account_number and contract_number
-            else self._refresh_token[:16]
-            if self._refresh_token
-            else "unknown"
-        )
+        # Fall back to a SHA-256 hash of the refresh token (one-way) so the
+        # entity registry — written as plaintext JSON — never sees raw token
+        # material. The token itself stays in entry.data which HAOS encrypts.
+        if account_number and contract_number:
+            unique_id = f"{account_number}_{contract_number}"
+        elif self._refresh_token:
+            unique_id = hashlib.sha256(self._refresh_token.encode()).hexdigest()[:16]
+        else:
+            unique_id = "unknown"
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
         _LOGGER.info(

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -17,11 +17,11 @@ billing period use Current/Hourly; older days use Previous/Hourly.
 
 from __future__ import annotations
 
-import contextlib
 import logging
+import math
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import (
@@ -46,6 +46,18 @@ if TYPE_CHECKING:
     from .agl.client import AglClient, IntervalReading
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _safe_float(raw: Any) -> float:
+    """Coerce raw API value to a non-negative finite float, defaulting to 0.0."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(value) or value < 0:
+        _LOGGER.warning("Rejecting non-finite/negative coordinator value: %r", raw)
+        return 0.0
+    return value
 
 
 @dataclass
@@ -146,7 +158,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         if plan is not None:
             for rate in plan.unit_rates:
                 if rate.get("type") == "c/kWh":
-                    cents = float(rate.get("price") or 0.0)
+                    cents = _safe_float(rate.get("price"))
                     unit_rate_aud = cents / 100.0
                     break
 
@@ -160,14 +172,13 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         projection: float | None = None
 
         if summary is not None:
-            with contextlib.suppress(TypeError, ValueError):
-                period_kwh = float(summary.consumption_kwh)
-            with contextlib.suppress(ValueError, AttributeError):
-                period_cost = float(summary.cost_label.lstrip("$").replace(",", ""))
-            with contextlib.suppress(ValueError, AttributeError):
-                projection = float(
-                    summary.projection_label.lstrip("$").replace(",", "")
-                )
+            period_kwh = _safe_float(summary.consumption_kwh)
+            period_cost = _safe_float(
+                (summary.cost_label or "").lstrip("$").replace(",", "")
+            )
+            proj_label = (summary.projection_label or "").lstrip("$").replace(",", "")
+            if proj_label:
+                projection = _safe_float(proj_label)
 
         return HaggleData(
             consumption_period_kwh=period_kwh,

--- a/tests/test_agl_client.py
+++ b/tests/test_agl_client.py
@@ -200,6 +200,40 @@ class TestAglAuth:
         with pytest.raises(AGLAuthError):
             await auth.async_force_refresh(session)
 
+    async def test_force_refresh_redacts_body_from_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """SAST-003: Auth0 error body must stay in DEBUG logs, not in the raised exception.
+
+        ConfigEntryAuthFailed(str(err)) reaches HA Persistent Notifications;
+        Auth0 error bodies may include diagnostic fields that should not surface
+        there.
+        """
+        # Synthetic body: must not look enough like a real JWT to trip secret
+        # scanners, but still contain a marker we can grep for in assertions.
+        sensitive_body = {
+            "error": "rate_limited",
+            "error_description": "MARKER-SHOULD-NOT-LEAK",
+        }
+        session = _make_session(sensitive_body, status=429)
+
+        async def persist(token: str) -> None:
+            pass
+
+        auth = AglAuth("v1.initial", persist)
+        with (
+            caplog.at_level("DEBUG", logger="custom_components.haggle.agl.client"),
+            pytest.raises(AGLAuthError) as exc_info,
+        ):
+            await auth.async_force_refresh(session)
+
+        # The exception message must mention the status code but NOT the body.
+        assert "429" in str(exc_info.value)
+        assert "MARKER-SHOULD-NOT-LEAK" not in str(exc_info.value)
+        assert "rate_limited" not in str(exc_info.value)
+        # Body was logged at DEBUG.
+        assert any("MARKER-SHOULD-NOT-LEAK" in r.message for r in caplog.records)
+
     async def test_force_refresh_raises_on_error_field(self) -> None:
         session = _make_session(
             {"error": "invalid_grant", "error_description": "Refresh token expired"},
@@ -318,3 +352,30 @@ class TestAglClient:
             pytest.raises(AGLError),
         ):
             await client.async_get_overview()
+
+    async def test_http_error_keeps_url_and_body_out_of_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """SAST-004: contract_number-bearing URL + response body stay in DEBUG."""
+        sensitive_body = {"detail": "internal MARKER2-SHOULD-NOT-LEAK"}
+        client, _ = self._make_client(sensitive_body, status=500)
+
+        with (
+            caplog.at_level("DEBUG", logger="custom_components.haggle.agl.client"),
+            patch.object(
+                client._auth,
+                "async_ensure_valid_token",
+                new_callable=AsyncMock,
+                return_value="tok",
+            ),
+            pytest.raises(AGLError) as exc_info,
+        ):
+            # contract_number is part of the URL path
+            await client.async_get_usage_summary("9999999999_PII")
+
+        msg = str(exc_info.value)
+        assert "500" in msg
+        assert "9999999999_PII" not in msg  # URL not in exception
+        assert "MARKER2-SHOULD-NOT-LEAK" not in msg  # body not in exception
+        # But both are present in DEBUG.
+        assert any("9999999999_PII" in r.message for r in caplog.records)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -150,6 +150,49 @@ async def test_fetch_contracts_failure_shows_cannot_connect(
     assert result["errors"]["base"] == "cannot_connect"
 
 
+async def test_unique_id_fallback_hashes_refresh_token(hass: HomeAssistant) -> None:
+    """When _fetch_contracts returns nothing, unique_id must be a hash, not a token prefix.
+
+    SAST-001 / SEC-001: HA's entity registry is plaintext JSON on disk; a leaked
+    refresh-token prefix from there could be correlated against captured token
+    material. Hashing makes the on-disk identifier one-way.
+    """
+    import hashlib
+
+    refresh_token = "v1.MdLHBM9JNbgB4ABUpW5K_FAKE_token_for_test_only"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    authorize_url: str = result["description_placeholders"]["authorize_url"]
+    callback_url = _make_callback_url(authorize_url)
+
+    with (
+        patch(
+            "custom_components.haggle.config_flow._exchange_code",
+            new_callable=AsyncMock,
+            return_value=("access_tok", refresh_token),
+        ),
+        patch(
+            "custom_components.haggle.config_flow._fetch_contracts",
+            new_callable=AsyncMock,
+            return_value=[],  # no contracts → fallback path
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CALLBACK_URL_FIELD: callback_url},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    entry = result["result"]
+    expected_hash = hashlib.sha256(refresh_token.encode()).hexdigest()[:16]
+
+    assert entry.unique_id == expected_hash
+    assert entry.unique_id != refresh_token[:16]
+    assert refresh_token[:8] not in (entry.unique_id or "")
+
+
 async def test_user_flow_multiple_contracts_shows_selector(hass: HomeAssistant) -> None:
     """Two discovered contracts show the select_contract form."""
     second = Contract(

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,27 @@
+"""Tests for constants — currently focused on the auth0-client identity blob."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from custom_components.haggle.const import AGL_AUTH0_CLIENT
+
+
+def test_auth0_client_decodes_to_expected_sdk_identity() -> None:
+    """Decoding AGL_AUTH0_CLIENT yields the AGL iOS SDK identity Auth0 expects.
+
+    Auth0 doesn't byte-validate this header, but the JSON shape is required:
+    `name`, `version`, and `env` keys must be present so a future refactor
+    can't quietly mangle the encoding (e.g. SAST-006 had two divergent base64
+    encodings of the same JSON in const.py and client.py — now consolidated
+    here).
+    """
+    # Pad to a multiple of 4 (AGL ships unpadded base64).
+    padded = AGL_AUTH0_CLIENT + "=" * (-len(AGL_AUTH0_CLIENT) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(padded))
+
+    assert payload["name"] == "Auth0.swift"
+    assert payload["version"].startswith("2.")
+    assert "env" in payload
+    assert "iOS" in payload["env"]

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -591,3 +591,79 @@ class TestFetchAndImport:
 
         assert result.unit_rate_aud_per_kwh == pytest.approx(33.792 / 100.0)
         assert result.supply_charge_aud_per_day == pytest.approx(131.714 / 100.0)
+
+
+# ---------------------------------------------------------------------------
+# SAST-008: numeric bounds before recorder import
+# ---------------------------------------------------------------------------
+
+
+class TestNumericGuards:
+    """Adversarial summaries (inf/nan/negative) must clamp to 0.0, not poison stats."""
+
+    async def test_summary_with_inf_clamps_to_zero(self, hass: HomeAssistant) -> None:
+        from custom_components.haggle.agl.models import BillPeriod
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = BillPeriod(
+            start=date.today() - timedelta(days=15),
+            end=date.today() + timedelta(days=15),
+            consumption_kwh=float("inf"),
+            cost_label="$inf",
+            projection_label="$nan",
+        )
+        mock_client.async_get_plan.side_effect = NotImplementedError
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(100.0, yesterday),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+        ):
+            result = await coord._fetch_and_import()
+
+        # Adversarial values must not propagate to recorder-bound HaggleData.
+        assert result.consumption_period_kwh == 0.0
+        assert result.consumption_period_cost_aud == 0.0
+        # "$nan" parses to nan → clamped to 0.0 (not None — proj_label was non-empty).
+        assert result.bill_projection_aud == 0.0
+
+    async def test_summary_with_negative_clamps_to_zero(
+        self, hass: HomeAssistant
+    ) -> None:
+        from custom_components.haggle.agl.models import BillPeriod
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = BillPeriod(
+            start=date.today() - timedelta(days=15),
+            end=date.today() + timedelta(days=15),
+            consumption_kwh=-5.0,
+            cost_label="$-99.99",
+            projection_label="",
+        )
+        mock_client.async_get_plan.side_effect = NotImplementedError
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(100.0, yesterday),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+        ):
+            result = await coord._fetch_and_import()
+
+        assert result.consumption_period_kwh == 0.0
+        assert result.consumption_period_cost_aud == 0.0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -79,3 +79,59 @@ async def test_setup_and_unload(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
         mock_session.close.assert_called_once()
+
+
+async def test_persist_failure_triggers_reauth(hass: HomeAssistant) -> None:
+    """SAST-009: a failed config-entry update must start the reauth flow.
+
+    When Auth0 has rotated the refresh token but our persist call to
+    `async_update_entry` fails, in-memory state diverges from disk: the next HA
+    restart loads a stale (revoked) token. Surface that immediately rather than
+    letting the user discover it on next boot.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=_ENTRY_DATA,
+        unique_id="1234567890_9999999999",
+    )
+    entry.add_to_hass(hass)
+
+    mock_session = MagicMock()
+    mock_session.close = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.haggle.aiohttp.ClientSession",
+            return_value=mock_session,
+        ),
+        patch(
+            "custom_components.haggle.agl.client.AglAuth.async_ensure_valid_token",
+            new_callable=AsyncMock,
+            return_value="access_token",
+        ),
+        patch(
+            "custom_components.haggle.coordinator.HaggleCoordinator._async_setup",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.haggle.coordinator.HaggleCoordinator._async_update_data",
+            new_callable=AsyncMock,
+            return_value=_COORDINATOR_DATA,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        persist = entry.runtime_data.auth._persist
+
+        with (
+            patch.object(
+                hass.config_entries,
+                "async_update_entry",
+                side_effect=RuntimeError("storage layer unavailable"),
+            ),
+            patch.object(entry, "async_start_reauth") as mock_start_reauth,
+        ):
+            await persist("v1.rotated_new_token")
+
+        mock_start_reauth.assert_called_once_with(hass)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,6 +31,84 @@ def load_fixture(name: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Numeric guard (SAST-008)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeFloat:
+    """Adversarial / corrupt API values must clamp to 0.0 instead of poisoning stats."""
+
+    def test_finite_positive_passes_through(self) -> None:
+        from custom_components.haggle.agl.parser import _safe_float
+
+        assert _safe_float(0.5) == 0.5
+        assert _safe_float("12.34") == pytest.approx(12.34)
+
+    def test_inf_nan_negative_clamp_to_zero(self) -> None:
+        from custom_components.haggle.agl.parser import _safe_float
+
+        assert _safe_float(float("inf")) == 0.0
+        assert _safe_float(float("nan")) == 0.0
+        assert _safe_float(-1.0) == 0.0
+        assert _safe_float("1e308") == pytest.approx(1e308)  # finite, allowed
+        assert _safe_float(1e400) == 0.0  # overflow → inf → clamped
+
+    def test_unparseable_clamps_to_zero(self) -> None:
+        from custom_components.haggle.agl.parser import _safe_float
+
+        assert _safe_float(None) == 0.0
+        assert _safe_float("not a number") == 0.0
+        assert _safe_float({}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# parse_plan allowlist (SAST-007)
+# ---------------------------------------------------------------------------
+
+
+class TestParsePlanAllowlist:
+    """Open-schema dict(rate) is gone — only four documented keys propagate."""
+
+    def test_only_known_keys_land_in_unit_rates(self) -> None:
+        data = {
+            "productName": "Smart Saver",
+            "gstInclusiveRates": [
+                {
+                    "kind": "detail",
+                    "type": "c/kWh",
+                    "title": "Peak",
+                    "price": 33.792,
+                    "validTo": "9999-12-31",
+                    # Attacker-injected keys must NOT propagate.
+                    "evil_callback": "https://attacker.example/x",
+                    "__proto__": "polluted",
+                }
+            ],
+        }
+        plan = parse_plan(data)
+        assert len(plan.unit_rates) == 1
+        rate = plan.unit_rates[0]
+        assert set(rate.keys()) == {"kind", "type", "title", "price"}
+        assert "evil_callback" not in rate
+        assert "validTo" not in rate
+
+    def test_extreme_price_clamped_to_zero(self) -> None:
+        data = {
+            "productName": "Smart Saver",
+            "gstInclusiveRates": [
+                {
+                    "kind": "detail",
+                    "type": "c/kWh",
+                    "title": "Peak",
+                    "price": float("inf"),
+                }
+            ],
+        }
+        plan = parse_plan(data)
+        assert plan.unit_rates[0]["price"] == 0.0
+
+
+# ---------------------------------------------------------------------------
 # parse_interval_readings
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the **AP-2 / AP-4 / AP-6** attack paths from the 2026-05-02 security review (`security/2026-05-02T04-43Z/`) by addressing 7 of the 14 SAST findings in a single bundled sweep, per the agreed pre-public-flip plan.

| Finding | File | Change |
|---|---|---|
| **SAST-001** | `config_flow.py` | Hash refresh-token via `sha256(...)[:16]` for the fallback `unique_id` so the entity registry never sees raw token material. Closes AP-4. |
| **SAST-002** | `agl/client.py` | Use the `str` return value of `async_force_refresh()` on the 401-retry path; drop the `_auth._token_set.access_token` private-attr access + `# type: ignore`. |
| **SAST-003 / 004** | `agl/client.py`, `config_flow.py` | Move `text[:200]` and contract-bearing URLs out of `AGLAuthError` / `AGLError` messages — they go to `_LOGGER.debug` only and no longer leak through `ConfigEntryAuthFailed` to HA Persistent Notifications. Closes AP-6. |
| **SAST-006** | `const.py`, `agl/client.py` | Consolidate the divergent base64 encodings of the `auth0-client` SDK identity to a single `AGL_AUTH0_CLIENT` constant; new `tests/test_const.py` decodes and shape-checks it. |
| **SAST-007** | `agl/parser.py` | Allowlist `{kind, type, title, price}` in `parse_plan` instead of `dict(rate)` passthrough — closes the schema-injection amplifier in AP-2. |
| **SAST-008** | `agl/parser.py`, `coordinator.py` | New `_safe_float()` helpers clamp `inf` / `nan` / negative AGL values to `0.0` with a warning, so adversarial responses cannot poison the recorder via `async_add_external_statistics`. Closes the integrity leg of AP-2. |
| **SAST-009** | `__init__.py` | Trigger `entry.async_start_reauth(hass)` on persist-callback failure instead of swallowing the exception — Auth0 has already consumed the previous token by then. Surfaces the issue immediately. |

Per `CLAUDE.md` docs checklist:
- `CHANGELOG.md` → new `## [Unreleased]` `### Security` section listing every change above.
- `AGENTS.md` "What NOT to Do" → three new rules: don't surface API bodies in exceptions, use `_safe_float`, don't forward raw response dicts.
- `AGENTS.md` Repo Map → notes the new `tests/test_const.py`.

## Test plan

- [x] 12 new tests added; 77 passing total (was 65). `uv run pytest`.
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy custom_components/haggle` all clean.
- [x] `uv run pre-commit run --all-files` clean (gitleaks, commitlint, etc.).
- [ ] CI workflow green on PR.
- [ ] Hassfest workflow green.
- [ ] Live install soak (deferred to PR 4 + final integration check).

### What's not in this PR

- TLS pinning (PR 4 — TOFU SPKI design, separate worktree).
- aiohttp ≥3.13.4 + `beautifulsoup4` removal (PR 3 — dependency hygiene).
- Repo posture files (PR 5 — `SECURITY.md`, `CODEOWNERS`, etc.).
- SAST-005 (hardcoded client_id), SAST-010 (callback URL domain validation), SAST-011 (contract_number regex) — deferred per the agreed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
