### PR TITLE
feat(security): TOFU TLS pinning for AGL endpoints — close AP-1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ custom_components/haggle/
 │   ├── __init__.py
 │   ├── client.py        # AglAuth (JWT expiry + token rotation) + AglClient (HTTP methods)
 │   ├── models.py        # TokenSet, Contract, IntervalReading, DailyReading, BillPeriod, PlanRates
-│   └── parser.py        # JSON → typed dataclasses (filters type=none intervals)
+│   ├── parser.py        # JSON → typed dataclasses (filters type=none intervals)
+│   └── pinning.py       # SPKI extraction helper for Trust-On-First-Use TLS pinning
 ├── strings.json         # translatable config-flow strings
 └── translations/en.json # English strings (must mirror strings.json)
 
@@ -68,9 +69,10 @@ tests/
 │   └── bill_period_response.json    # usage summary
 ├── test_init.py                     # setup/unload smoke tests
 ├── test_config_flow.py              # PKCE step navigation (user → exchange → select_contract)
-├── test_agl_client.py               # AglAuth token rotation + AglClient HTTP methods
+├── test_agl_client.py               # AglAuth token rotation + AglClient HTTP methods + pin-check wiring
 ├── test_const.py                    # base64 sanity-check on AGL_AUTH0_CLIENT
 ├── test_parser.py                   # parse_interval_readings, parse_overview, parse_plan, _safe_float
+├── test_pinning.py                  # SPKI extraction + host-name guards
 └── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, numeric guards
 
 scripts/
@@ -230,6 +232,26 @@ GET /mobile/bff/api/v2/plan/energy/{contractNumber}
 
 Returns `gstInclusiveRates` list with `c/kWh` and `c/day` entries. Supply charge
 is a `c/day` entry with `title` containing "Supply charge".
+
+### TLS pinning (Trust-On-First-Use)
+
+Both `secure.agl.com.au` and `api.platform.agl.com.au` are pinned by SPKI hash.
+The hashes are captured during the initial PKCE config flow (in
+`config_flow._exchange_code` and `config_flow._fetch_contracts`) by extracting
+the leaf cert from the live aiohttp response via
+`agl/pinning.py::get_peer_spki_hash` and persisted to `entry.data` under
+`CONF_PINNED_SPKI_AUTH` / `CONF_PINNED_SPKI_BFF`.
+
+Every subsequent request observes the live SPKI and compares against the
+stored value. **Mismatch is warn-only** — log a WARNING + raise an HA
+persistent notification (`haggle_pin_mismatch_<host>`) — but the request still
+succeeds. This keeps a legitimate AGL cert rotation from bricking HACS users;
+the documented remediation is to re-run Reconfigure on the integration card,
+which re-captures both hashes.
+
+Empty stored values (`""`) mean "no pin yet" — the validator is a no-op.
+Older entries created before this feature land in this state and silently
+upgrade on next Reconfigure.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Trust-On-First-Use TLS certificate pinning** for `secure.agl.com.au` and
+  `api.platform.agl.com.au`. The SHA-256 SPKI hash of each AGL host's leaf
+  certificate is captured during the initial PKCE config flow and persisted
+  to the config entry; every subsequent token refresh and BFF request is
+  observed and compared. Mismatches surface as a HA persistent notification
+  (`haggle_pin_mismatch_<host>`) plus a WARNING log — they do **not** block
+  the request, so a legitimate AGL cert rotation cannot brick HACS users.
+  Re-pin via the standard Reconfigure flow on the integration card. New
+  module `custom_components/haggle/agl/pinning.py`. Closes AP-1 from
+  `security/2026-05-02T04-43Z/`.
+
 ### Removed
 - **`beautifulsoup4` runtime dependency**. Zero call sites in
   `custom_components/`; was a dead dep that every HACS installer downloaded for

--- a/custom_components/haggle/__init__.py
+++ b/custom_components/haggle/__init__.py
@@ -12,10 +12,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import aiohttp
+from homeassistant.components import persistent_notification
 from homeassistant.const import Platform
 
 from .agl.client import AglAuth, AglClient
-from .const import CONF_CONTRACT_NUMBER, CONF_REFRESH_TOKEN
+from .agl.pinning import AGL_AUTH_HOST_NAME
+from .const import (
+    CONF_CONTRACT_NUMBER,
+    CONF_PINNED_SPKI_AUTH,
+    CONF_PINNED_SPKI_BFF,
+    CONF_REFRESH_TOKEN,
+)
 from .coordinator import HaggleCoordinator
 
 if TYPE_CHECKING:
@@ -46,8 +53,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bo
     """Set up haggle from a config entry."""
     refresh_token = entry.data[CONF_REFRESH_TOKEN]
     contract_number: str = entry.data.get(CONF_CONTRACT_NUMBER, "")
+    pinned_auth: str = entry.data.get(CONF_PINNED_SPKI_AUTH, "")
+    pinned_bff: str = entry.data.get(CONF_PINNED_SPKI_BFF, "")
 
-    _LOGGER.info("Setting up haggle entry: contract=%s", contract_number or "unknown")
+    _LOGGER.info(
+        "Setting up haggle entry: contract=%s pin_auth=%s pin_bff=%s",
+        contract_number or "unknown",
+        "set" if pinned_auth else "unset",
+        "set" if pinned_bff else "unset",
+    )
 
     async def _persist_refresh_token(new_token: str) -> None:
         """Persist rotated refresh token back to config entry data.
@@ -68,9 +82,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bo
             )
             entry.async_start_reauth(hass)
 
+    # Pin-check is fire-and-forget per request: compare observed SPKI against
+    # the TOFU value captured at config-flow time. Mismatch surfaces as a HA
+    # persistent notification + WARNING log, but does NOT block the request —
+    # legitimate AGL cert rotations should not brick HACS users. Re-pin via
+    # the standard Reconfigure flow.
+    def _check_pin(host: str, observed: str) -> None:
+        expected = pinned_auth if host == AGL_AUTH_HOST_NAME else pinned_bff
+        if not expected or observed == expected:
+            return
+        _LOGGER.warning(
+            "Pinned SPKI mismatch for %s (stored=%s observed=%s) — investigate or reauth",
+            host,
+            expected[:12],
+            observed[:12],
+        )
+        persistent_notification.async_create(
+            hass,
+            title="haggle: AGL certificate changed",
+            message=(
+                f"The TLS certificate for {host} no longer matches the value "
+                "captured during initial setup. If you are on a trusted network, "
+                "click Reconfigure on the haggle integration to re-pin. If this "
+                "is unexpected, suspect a man-in-the-middle on your local network."
+            ),
+            notification_id=f"haggle_pin_mismatch_{host}",
+        )
+
     session = aiohttp.ClientSession()
-    auth = AglAuth(refresh_token, _persist_refresh_token)
-    client = AglClient(auth, session)
+    auth = AglAuth(refresh_token, _persist_refresh_token, pin_check=_check_pin)
+    client = AglClient(auth, session, pin_check=_check_pin)
     coordinator = HaggleCoordinator(hass, entry, client, contract_number)  # type: ignore[arg-type]
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -8,6 +8,11 @@ Architecture (§7 of AGL-API-FINDINGS.md):
               Client-Flavor, User-Agent) and retries once on 401 by forcing
               an auth refresh.
 
+Both classes accept an optional `pin_check` callback that receives
+(host, observed_spki_hex) after every successful TLS response. The callback
+is wired up in __init__.py to compare against the persisted Trust-On-First-Use
+pin and surface an HA persistent notification on mismatch. See agl/pinning.py.
+
 Token endpoint: POST https://secure.agl.com.au/oauth/token (grant=refresh_token).
 Access tokens expire in 900 s (15 min); refresh when exp - now < 120 s (2 min).
 """
@@ -45,6 +50,7 @@ from .parser import (
     parse_overview,
     parse_plan,
 )
+from .pinning import AGL_AUTH_HOST_NAME, AGL_BFF_HOST_NAME, get_peer_spki_hash
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -106,6 +112,32 @@ def _decode_jwt_exp(token: str) -> int | None:
         return None
 
 
+def _safe_pin_check(
+    callback: Callable[[str, str], None] | None,
+    host: str,
+    resp: aiohttp.ClientResponse,
+) -> None:
+    """Capture SPKI from `resp` and invoke `callback`, swallowing any error.
+
+    Pin checks must never raise — a transient introspection failure should not
+    take down the coordinator. Mismatches are signalled by the callback itself
+    (warning + persistent notification), not by exceptions from this helper.
+    """
+    if callback is None:
+        return
+    try:
+        observed = get_peer_spki_hash(resp)
+    except Exception:
+        _LOGGER.debug("SPKI extraction failed for %s", host, exc_info=True)
+        return
+    if observed is None:
+        return
+    try:
+        callback(host, observed)
+    except Exception:
+        _LOGGER.debug("Pin-check callback raised for %s", host, exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # AglAuth — Auth0 token lifecycle
 # ---------------------------------------------------------------------------
@@ -119,15 +151,19 @@ class AglAuth:
     - Rotates the refresh token on every exchange and calls
       `persist_callback(new_refresh_token)` so the caller can persist it.
       Failure to persist = lockout within one cycle.
+    - Optionally invokes `pin_check(host, observed_spki)` after each successful
+      token exchange so callers can validate against a TOFU pin.
     """
 
     def __init__(
         self,
         refresh_token: str,
         persist_callback: Callable[[str], Awaitable[None]],
+        pin_check: Callable[[str, str], None] | None = None,
     ) -> None:
         self._refresh_token = refresh_token
         self._persist = persist_callback
+        self._pin_check = pin_check
         self._token_set: TokenSet | None = None
 
     async def async_ensure_valid_token(self, session: aiohttp.ClientSession) -> str:
@@ -172,6 +208,7 @@ class AglAuth:
                 text = await resp.text()
                 _LOGGER.debug("Token refresh non-200 body: %s", text[:200])
                 raise AGLAuthError(f"Token refresh failed HTTP {resp.status}")
+            _safe_pin_check(self._pin_check, AGL_AUTH_HOST_NAME, resp)
             data: dict[str, Any] = await resp.json(content_type=None)
 
         error = data.get("error")
@@ -216,9 +253,11 @@ class AglClient:
         self,
         auth: AglAuth,
         session: aiohttp.ClientSession,
+        pin_check: Callable[[str, str], None] | None = None,
     ) -> None:
         self._auth = auth
         self._session = session
+        self._pin_check = pin_check
 
     @property
     def _default_headers(self) -> dict[str, str]:
@@ -249,6 +288,7 @@ class AglClient:
                 _LOGGER.debug("HTTP %s on %s body: %s", resp.status, url, text[:200])
                 raise AGLError(f"HTTP {resp.status} fetching AGL data")
             else:
+                _safe_pin_check(self._pin_check, AGL_BFF_HOST_NAME, resp)
                 return await resp.json(content_type=None)
 
         # Only reached on 401 — force refresh and retry once.
@@ -269,6 +309,7 @@ class AglClient:
                     text[:200],
                 )
                 raise AGLError(f"HTTP {resp2.status} fetching AGL data")
+            _safe_pin_check(self._pin_check, AGL_BFF_HOST_NAME, resp2)
             return await resp2.json(content_type=None)
 
     # --- Discovery ---

--- a/custom_components/haggle/agl/pinning.py
+++ b/custom_components/haggle/agl/pinning.py
@@ -1,0 +1,66 @@
+"""Trust-On-First-Use TLS certificate pinning for AGL endpoints.
+
+The integration captures the SHA-256 SPKI (SubjectPublicKeyInfo) hash of each
+AGL host's leaf certificate during the initial PKCE config flow and persists
+both hashes to the config entry. Every subsequent token-refresh and BFF
+request is observed and the live SPKI is compared against the stored pin.
+
+Mismatch handling is a soft warn-on-mismatch: log + HA persistent notification.
+The integration does not block the request, so a legitimate AGL cert rotation
+does not brick HACS users — they re-pin via the standard Reconfigure flow.
+A strict-reject mode is left for v0.2.x once we have a feel for AGL's rotation
+cadence.
+
+First-install caveat: PKCE happens in the user's browser (system trust store +
+visible lock indicator), so a LAN MITM at HA does not necessarily compromise
+the auth bootstrap. The integration cannot defend against MITM on first auth
+without pre-shipping a cert hash, which would tightly couple every release to
+AGL's cert rotation. See SECURITY.md for the full threat model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+if TYPE_CHECKING:
+    import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+# Hosts the integration knows how to pin. Anything else (e.g. a MITM-injected
+# redirect to attacker.example) is invisible to the validator and simply not
+# pinned — but the OAuth state nonce + PKCE verifier already block that path.
+AGL_AUTH_HOST_NAME = "secure.agl.com.au"
+AGL_BFF_HOST_NAME = "api.platform.agl.com.au"
+
+
+def get_peer_spki_hash(resp: aiohttp.ClientResponse) -> str | None:
+    """Return SHA-256 hex digest of the response's leaf-cert SPKI, or None.
+
+    Used both during config-flow capture and at every subsequent request site.
+    Returns None if the response was not over TLS or if the platform doesn't
+    expose the underlying SSL object — in which case validation degrades to a
+    no-op (better than failing closed for a transient introspection issue).
+    """
+    conn = resp.connection
+    if conn is None:
+        return None
+    transport = conn.transport
+    if transport is None:
+        return None
+    ssl_object = transport.get_extra_info("ssl_object")
+    if ssl_object is None:
+        return None
+    der_cert = ssl_object.getpeercert(binary_form=True)
+    if not der_cert:
+        return None
+    cert = x509.load_der_x509_certificate(der_cert)
+    spki_der = cert.public_key().public_bytes(
+        Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+    )
+    return hashlib.sha256(spki_der).hexdigest()

--- a/custom_components/haggle/config_flow.py
+++ b/custom_components/haggle/config_flow.py
@@ -7,11 +7,16 @@ Onboarding strategy:
             URL from the address bar and paste it back into HA.
   Step 2 (exchange) -- extract the authorization code from the pasted URL,
             POST /oauth/token (authorization_code grant + PKCE), store tokens.
+            Captures the SHA-256 SPKI hash of secure.agl.com.au's leaf cert
+            for Trust-On-First-Use pinning (see agl/pinning.py).
   Step 3 (select_contract) -- fetch /api/v3/overview, let user pick a contract
-            if multiple electricity contracts are found.
-  Step 4 -- create entry.
+            if multiple electricity contracts are found. Captures the SPKI
+            hash of api.platform.agl.com.au at the same time.
+  Step 4 -- create entry. Both pinned SPKI hashes are persisted to entry.data
+            and validated on every subsequent request from coordinator polling.
 
-Reauth re-enters at Step 1 with fresh PKCE params.
+Reauth re-enters at Step 1 with fresh PKCE params, which naturally re-pins
+both endpoints — the recommended remediation for legitimate AGL cert rotation.
 """
 
 from __future__ import annotations
@@ -29,6 +34,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
 from .agl.client import AGLAuthError, AGLError, Contract
 from .agl.parser import parse_overview
+from .agl.pinning import get_peer_spki_hash
 from .const import (
     AGL_API_HOST,
     AGL_AUTH0_CLIENT,
@@ -43,6 +49,8 @@ from .const import (
     CONF_ACCESS_TOKEN_EXPIRY,
     CONF_ACCOUNT_NUMBER,
     CONF_CONTRACT_NUMBER,
+    CONF_PINNED_SPKI_AUTH,
+    CONF_PINNED_SPKI_BFF,
     CONF_REFRESH_TOKEN,
     DOMAIN,
 )
@@ -102,8 +110,12 @@ def _extract_code(
     return (code or None), None
 
 
-async def _exchange_code(code: str, verifier: str) -> tuple[str, str]:
-    """POST /oauth/token and return (access_token, refresh_token).
+async def _exchange_code(code: str, verifier: str) -> tuple[str, str, str]:
+    """POST /oauth/token and return (access_token, refresh_token, auth_spki).
+
+    `auth_spki` is the SHA-256 hex of the leaf-cert SPKI for secure.agl.com.au,
+    captured from the live TLS connection. Empty string if introspection fails
+    (degrades to no-pin, never blocks the install).
 
     Raises AGLAuthError on 4xx auth errors, AGLError on other failures.
     """
@@ -122,6 +134,7 @@ async def _exchange_code(code: str, verifier: str) -> tuple[str, str]:
         "Content-Type": "application/x-www-form-urlencoded",
         "Accept": "application/json",
     }
+    auth_spki = ""
     async with (
         aiohttp.ClientSession() as session,
         session.post(url, data=payload, headers=headers) as resp,
@@ -130,6 +143,10 @@ async def _exchange_code(code: str, verifier: str) -> tuple[str, str]:
             raise AGLAuthError(f"Token exchange failed: HTTP {resp.status}")
         if not resp.ok:
             raise AGLError(f"Token exchange error: HTTP {resp.status}")
+        try:
+            auth_spki = get_peer_spki_hash(resp) or ""
+        except Exception:
+            _LOGGER.debug("SPKI capture failed during token exchange", exc_info=True)
         body: dict[str, Any] = await resp.json()
 
     access_token: str = body.get("access_token", "")
@@ -137,17 +154,19 @@ async def _exchange_code(code: str, verifier: str) -> tuple[str, str]:
     if not access_token or not refresh_token:
         raise AGLAuthError("Token response missing access_token or refresh_token")
 
-    return access_token, refresh_token
+    return access_token, refresh_token, auth_spki
 
 
-async def _fetch_contracts(access_token: str) -> list[Contract]:
-    """Fetch /api/v3/overview with the freshly-obtained access token.
+async def _fetch_contracts(access_token: str) -> tuple[list[Contract], str]:
+    """Fetch /api/v3/overview and return (contracts, bff_spki).
+
+    `bff_spki` is the SHA-256 hex of the leaf-cert SPKI for
+    api.platform.agl.com.au. Empty string if capture fails.
 
     Uses aiohttp directly rather than AglAuth/AglClient: AglAuth always calls
     async_force_refresh on first use (token_set is None on construction), which
     would POST the access_token as a refresh_token to Auth0 and fail.
     """
-
     url = f"{AGL_API_HOST}/mobile/bff/api/v3/overview"
     headers = {
         "Authorization": f"Bearer {access_token}",
@@ -156,6 +175,7 @@ async def _fetch_contracts(access_token: str) -> list[Contract]:
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate, br",
     }
+    bff_spki = ""
     async with (
         aiohttp.ClientSession() as session,
         session.get(url, headers=headers) as resp,
@@ -166,8 +186,12 @@ async def _fetch_contracts(access_token: str) -> list[Contract]:
             text = await resp.text()
             _LOGGER.debug("HTTP %s on %s body: %s", resp.status, url, text[:200])
             raise AGLError(f"HTTP {resp.status} fetching AGL overview")
+        try:
+            bff_spki = get_peer_spki_hash(resp) or ""
+        except Exception:
+            _LOGGER.debug("SPKI capture failed during overview fetch", exc_info=True)
         data = await resp.json(content_type=None)
-    return parse_overview(data)
+    return parse_overview(data), bff_spki
 
 
 class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -181,6 +205,8 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
         self._oauth_state: str = ""
         self._access_token: str = ""
         self._refresh_token: str = ""
+        self._auth_spki: str = ""
+        self._bff_spki: str = ""
         self._contracts: list[Contract] = []
 
     # ------------------------------------------------------------------
@@ -231,7 +257,7 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
         schema = vol.Schema({vol.Required(CALLBACK_URL_FIELD): str})
 
         try:
-            access_token, refresh_token = await _exchange_code(
+            access_token, refresh_token, auth_spki = await _exchange_code(
                 code, self._pkce_verifier
             )
         except AGLAuthError:
@@ -251,6 +277,7 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._access_token = access_token
         self._refresh_token = refresh_token
+        self._auth_spki = auth_spki
         return await self.async_step_select_contract()
 
     # ------------------------------------------------------------------
@@ -265,7 +292,9 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if not self._contracts:
             try:
-                self._contracts = await _fetch_contracts(self._access_token)
+                self._contracts, self._bff_spki = await _fetch_contracts(
+                    self._access_token
+                )
             except Exception:
                 errors["base"] = "cannot_connect"
                 return self.async_show_form(
@@ -338,9 +367,11 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
         _LOGGER.info(
-            "Creating haggle entry: account=%s contract=%s",
+            "Creating haggle entry: account=%s contract=%s pin_auth=%s pin_bff=%s",
             account_number or "unknown",
             contract_number or "unknown",
+            "set" if self._auth_spki else "missing",
+            "set" if self._bff_spki else "missing",
         )
         return self.async_create_entry(
             title=title or f"AGL {contract_number or 'account'}",
@@ -350,5 +381,7 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ACCESS_TOKEN_EXPIRY: 0,
                 CONF_CONTRACT_NUMBER: contract_number,
                 CONF_ACCOUNT_NUMBER: account_number,
+                CONF_PINNED_SPKI_AUTH: self._auth_spki,
+                CONF_PINNED_SPKI_BFF: self._bff_spki,
             },
         )

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -97,6 +97,10 @@ CONF_ACCESS_TOKEN: Final = "access_token"
 CONF_ACCESS_TOKEN_EXPIRY: Final = "access_token_expiry"
 CONF_CONTRACT_NUMBER: Final = "contract_number"
 CONF_ACCOUNT_NUMBER: Final = "account_number"
+# SHA-256 hex of the leaf-cert SPKI captured at config-flow time. Empty string
+# = no pin yet (older entries pre-PR4 / capture failed at install time).
+CONF_PINNED_SPKI_AUTH: Final = "pinned_spki_auth"  # secure.agl.com.au
+CONF_PINNED_SPKI_BFF: Final = "pinned_spki_bff"  # api.platform.agl.com.au
 
 # Coordinator data attribute names — must match HaggleData field names exactly.
 DATA_CONSUMPTION_KWH: Final = "latest_cumulative_kwh"  # TOTAL_INCREASING sensor

--- a/tests/test_agl_client.py
+++ b/tests/test_agl_client.py
@@ -379,3 +379,100 @@ class TestAglClient:
         assert "MARKER2-SHOULD-NOT-LEAK" not in msg  # body not in exception
         # But both are present in DEBUG.
         assert any("9999999999_PII" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Pin-check wiring (PR 4 — TOFU SPKI pinning)
+# ---------------------------------------------------------------------------
+
+
+class TestPinCheckWiring:
+    """AglAuth and AglClient invoke the pin_check callback after successful TLS."""
+
+    async def test_force_refresh_invokes_pin_check_with_auth_host(self) -> None:
+        from custom_components.haggle.agl.pinning import AGL_AUTH_HOST_NAME
+
+        observed: list[tuple[str, str]] = []
+
+        def pin_check(host: str, spki: str) -> None:
+            observed.append((host, spki))
+
+        session = _make_session(_TOKEN_RESPONSE)
+        with patch(
+            "custom_components.haggle.agl.client.get_peer_spki_hash",
+            return_value="abc123" * 10 + "deadbe",
+        ):
+            auth = AglAuth("v1.initial", AsyncMock(), pin_check=pin_check)
+            await auth.async_force_refresh(session)
+
+        assert observed == [(AGL_AUTH_HOST_NAME, "abc123" * 10 + "deadbe")]
+
+    async def test_get_invokes_pin_check_with_bff_host(self) -> None:
+        from custom_components.haggle.agl.pinning import AGL_BFF_HOST_NAME
+
+        observed: list[tuple[str, str]] = []
+
+        def pin_check(host: str, spki: str) -> None:
+            observed.append((host, spki))
+
+        session = _make_session(_OVERVIEW_RESPONSE)
+        auth = AglAuth("v1.tok", AsyncMock())
+        client = AglClient(auth, session, pin_check=pin_check)
+
+        with (
+            patch.object(
+                client._auth,
+                "async_ensure_valid_token",
+                new_callable=AsyncMock,
+                return_value="tok",
+            ),
+            patch(
+                "custom_components.haggle.agl.client.get_peer_spki_hash",
+                return_value="bffspki" * 9 + "x",
+            ),
+        ):
+            await client.async_get_overview()
+
+        assert observed == [(AGL_BFF_HOST_NAME, "bffspki" * 9 + "x")]
+
+    async def test_pin_check_callback_exception_does_not_break_request(self) -> None:
+        """A throwing pin_check must not poison the data path."""
+
+        def bad_pin(host: str, spki: str) -> None:
+            raise RuntimeError("validator on fire")
+
+        session = _make_session(_OVERVIEW_RESPONSE)
+        auth = AglAuth("v1.tok", AsyncMock())
+        client = AglClient(auth, session, pin_check=bad_pin)
+
+        with (
+            patch.object(
+                client._auth,
+                "async_ensure_valid_token",
+                new_callable=AsyncMock,
+                return_value="tok",
+            ),
+            patch(
+                "custom_components.haggle.agl.client.get_peer_spki_hash",
+                return_value="x" * 64,
+            ),
+        ):
+            contracts = await client.async_get_overview()
+
+        assert len(contracts) == 1  # request still succeeded
+
+    async def test_no_pin_check_when_callback_is_none(self) -> None:
+        """Default (no callback) path runs cleanly even when SPKI returns None."""
+        session = _make_session(_OVERVIEW_RESPONSE)
+        auth = AglAuth("v1.tok", AsyncMock())
+        client = AglClient(auth, session)  # pin_check=None default
+
+        with patch.object(
+            client._auth,
+            "async_ensure_valid_token",
+            new_callable=AsyncMock,
+            return_value="tok",
+        ):
+            contracts = await client.async_get_overview()
+
+        assert len(contracts) == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -60,12 +60,12 @@ async def test_user_flow_single_contract_creates_entry(hass: HomeAssistant) -> N
         patch(
             "custom_components.haggle.config_flow._exchange_code",
             new_callable=AsyncMock,
-            return_value=("access_tok", "refresh_tok"),
+            return_value=("access_tok", "refresh_tok", "deadbeef" * 8),
         ),
         patch(
             "custom_components.haggle.config_flow._fetch_contracts",
             new_callable=AsyncMock,
-            return_value=[_CONTRACT],
+            return_value=([_CONTRACT], "cafef00d" * 8),
         ),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -132,7 +132,7 @@ async def test_fetch_contracts_failure_shows_cannot_connect(
         patch(
             "custom_components.haggle.config_flow._exchange_code",
             new_callable=AsyncMock,
-            return_value=("access_tok", "refresh_tok"),
+            return_value=("access_tok", "refresh_tok", "deadbeef" * 8),
         ),
         patch(
             "custom_components.haggle.config_flow._fetch_contracts",
@@ -171,12 +171,12 @@ async def test_unique_id_fallback_hashes_refresh_token(hass: HomeAssistant) -> N
         patch(
             "custom_components.haggle.config_flow._exchange_code",
             new_callable=AsyncMock,
-            return_value=("access_tok", refresh_token),
+            return_value=("access_tok", refresh_token, "deadbeef" * 8),
         ),
         patch(
             "custom_components.haggle.config_flow._fetch_contracts",
             new_callable=AsyncMock,
-            return_value=[],  # no contracts → fallback path
+            return_value=([], "cafef00d" * 8),  # no contracts → fallback path
         ),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -212,12 +212,12 @@ async def test_user_flow_multiple_contracts_shows_selector(hass: HomeAssistant) 
         patch(
             "custom_components.haggle.config_flow._exchange_code",
             new_callable=AsyncMock,
-            return_value=("access_tok", "refresh_tok"),
+            return_value=("access_tok", "refresh_tok", "deadbeef" * 8),
         ),
         patch(
             "custom_components.haggle.config_flow._fetch_contracts",
             new_callable=AsyncMock,
-            return_value=[_CONTRACT, second],
+            return_value=([_CONTRACT, second], "cafef00d" * 8),
         ),
     ):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -135,3 +135,120 @@ async def test_persist_failure_triggers_reauth(hass: HomeAssistant) -> None:
             await persist("v1.rotated_new_token")
 
         mock_start_reauth.assert_called_once_with(hass)
+
+
+async def test_pin_mismatch_emits_persistent_notification(hass: HomeAssistant) -> None:
+    """SPKI mismatch must surface via HA persistent notification, not block the request.
+
+    Closes AP-1: a LAN-MITM serving a different cert post-install is observable
+    through this notification path. Match path stays silent.
+    """
+    from custom_components.haggle.agl.pinning import AGL_AUTH_HOST_NAME
+    from custom_components.haggle.const import (
+        CONF_PINNED_SPKI_AUTH,
+        CONF_PINNED_SPKI_BFF,
+    )
+
+    pinned_data = {
+        **_ENTRY_DATA,
+        CONF_PINNED_SPKI_AUTH: "a" * 64,
+        CONF_PINNED_SPKI_BFF: "b" * 64,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=pinned_data,
+        unique_id="1234567890_9999999999",
+    )
+    entry.add_to_hass(hass)
+
+    mock_session = MagicMock()
+    mock_session.close = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.haggle.aiohttp.ClientSession",
+            return_value=mock_session,
+        ),
+        patch(
+            "custom_components.haggle.agl.client.AglAuth.async_ensure_valid_token",
+            new_callable=AsyncMock,
+            return_value="access_token",
+        ),
+        patch(
+            "custom_components.haggle.coordinator.HaggleCoordinator._async_setup",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.haggle.coordinator.HaggleCoordinator._async_update_data",
+            new_callable=AsyncMock,
+            return_value=_COORDINATOR_DATA,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        pin_check = entry.runtime_data.auth._pin_check
+        assert pin_check is not None
+
+        # Match: no notification.
+        with patch(
+            "custom_components.haggle.persistent_notification.async_create"
+        ) as mock_notify:
+            pin_check(AGL_AUTH_HOST_NAME, "a" * 64)
+        mock_notify.assert_not_called()
+
+        # Mismatch: notification fires with deterministic notification_id.
+        with patch(
+            "custom_components.haggle.persistent_notification.async_create"
+        ) as mock_notify:
+            pin_check(AGL_AUTH_HOST_NAME, "f" * 64)
+        mock_notify.assert_called_once()
+        kwargs = mock_notify.call_args.kwargs
+        assert kwargs["notification_id"] == f"haggle_pin_mismatch_{AGL_AUTH_HOST_NAME}"
+        assert AGL_AUTH_HOST_NAME in kwargs["message"]
+
+
+async def test_pin_check_with_no_pin_stays_silent(hass: HomeAssistant) -> None:
+    """Legacy entries (pre-TOFU, empty stored pins) must not warn on every poll."""
+    from custom_components.haggle.agl.pinning import AGL_AUTH_HOST_NAME
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=_ENTRY_DATA,  # no CONF_PINNED_SPKI_* keys
+        unique_id="legacy",
+    )
+    entry.add_to_hass(hass)
+
+    mock_session = MagicMock()
+    mock_session.close = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.haggle.aiohttp.ClientSession",
+            return_value=mock_session,
+        ),
+        patch(
+            "custom_components.haggle.agl.client.AglAuth.async_ensure_valid_token",
+            new_callable=AsyncMock,
+            return_value="access_token",
+        ),
+        patch(
+            "custom_components.haggle.coordinator.HaggleCoordinator._async_setup",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.haggle.coordinator.HaggleCoordinator._async_update_data",
+            new_callable=AsyncMock,
+            return_value=_COORDINATOR_DATA,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        pin_check = entry.runtime_data.auth._pin_check
+        assert pin_check is not None
+        with patch(
+            "custom_components.haggle.persistent_notification.async_create"
+        ) as mock_notify:
+            pin_check(AGL_AUTH_HOST_NAME, "anything")
+        mock_notify.assert_not_called()

--- a/tests/test_pinning.py
+++ b/tests/test_pinning.py
@@ -1,0 +1,110 @@
+"""Tests for the Trust-On-First-Use SPKI pinning helpers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+from unittest.mock import MagicMock
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.x509.oid import NameOID
+
+from custom_components.haggle.agl.pinning import (
+    AGL_AUTH_HOST_NAME,
+    AGL_BFF_HOST_NAME,
+    get_peer_spki_hash,
+)
+
+
+def _make_self_signed_cert() -> tuple[bytes, str]:
+    """Generate a fresh self-signed cert and return (DER bytes, expected SPKI hex)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "haggle-test.invalid")])
+    now = dt.datetime.now(dt.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(days=1))
+        .not_valid_after(now + dt.timedelta(days=30))
+        .sign(key, hashes.SHA256())
+    )
+    der_cert = cert.public_bytes(Encoding.DER)
+    spki_der = key.public_key().public_bytes(
+        Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+    )
+    expected_spki = hashlib.sha256(spki_der).hexdigest()
+    return der_cert, expected_spki
+
+
+def _make_response_with_cert(der_cert: bytes | None) -> MagicMock:
+    """Build a MagicMock aiohttp.ClientResponse that exposes the given cert."""
+    ssl_object = MagicMock()
+    ssl_object.getpeercert = MagicMock(return_value=der_cert)
+    transport = MagicMock()
+    transport.get_extra_info = MagicMock(return_value=ssl_object)
+    connection = MagicMock()
+    connection.transport = transport
+    resp = MagicMock()
+    resp.connection = connection
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# get_peer_spki_hash
+# ---------------------------------------------------------------------------
+
+
+class TestGetPeerSpkiHash:
+    def test_extracts_sha256_of_spki_from_real_cert(self) -> None:
+        """Hash a real DER cert and confirm it matches the cryptography-derived SPKI."""
+        der_cert, expected_spki = _make_self_signed_cert()
+        resp = _make_response_with_cert(der_cert)
+
+        observed = get_peer_spki_hash(resp)
+
+        assert observed == expected_spki
+        assert observed is not None
+        assert len(observed) == 64  # sha256 hex digest
+
+    def test_returns_none_when_connection_is_none(self) -> None:
+        resp = MagicMock()
+        resp.connection = None
+
+        assert get_peer_spki_hash(resp) is None
+
+    def test_returns_none_when_transport_is_none(self) -> None:
+        resp = MagicMock()
+        resp.connection = MagicMock()
+        resp.connection.transport = None
+
+        assert get_peer_spki_hash(resp) is None
+
+    def test_returns_none_when_ssl_object_is_none(self) -> None:
+        resp = MagicMock()
+        resp.connection = MagicMock()
+        resp.connection.transport = MagicMock()
+        resp.connection.transport.get_extra_info = MagicMock(return_value=None)
+
+        assert get_peer_spki_hash(resp) is None
+
+    def test_returns_none_when_cert_is_empty(self) -> None:
+        resp = _make_response_with_cert(b"")
+
+        assert get_peer_spki_hash(resp) is None
+
+
+# ---------------------------------------------------------------------------
+# Host names — guard against accidental rename
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_host_constants_match_agl_endpoints() -> None:
+    """If these change, every existing entry's pin becomes stale silently."""
+    assert AGL_AUTH_HOST_NAME == "secure.agl.com.au"
+    assert AGL_BFF_HOST_NAME == "api.platform.agl.com.au"


### PR DESCRIPTION
## Summary

Closes the **AP-1 LAN-MITM token-capture** chain from the 2026-05-02 security review (`security/2026-05-02T04-43Z/`) by introducing Trust-On-First-Use TLS pinning for both AGL hosts. The user-confirmed design from the planning round: capture the leaf-cert SPKI hash on first successful PKCE, persist to `entry.data`, validate every subsequent request against the pin, **warn-on-mismatch** (HA persistent notification + WARNING log) without blocking the request.

### Why TOFU and not hard-coded SPKI

Hard-coding `secure.agl.com.au`'s SPKI in `const.py` would brick every HACS install whenever AGL rotates. TOFU lets each install pin what it observes at install time — when the user has presumably verified the AGL hostname in their browser (PKCE happens browser-side, with system trust + lock indicator). The HA-side pin then locks down post-install requests.

### Why warn-only (not raise)

Strict-reject mode would also brick users on legitimate AGL rotations. Warn-only surfaces the event so the user can react (re-run Reconfigure to re-pin) without bricking the integration. Strict-reject is reserved for v0.2.x once we have a feel for AGL's rotation cadence. Documented in `agl/pinning.py` module docstring + `project_tls_tofu_design.md` memory.

### What lands

| File | Change |
|---|---|
| `custom_components/haggle/agl/pinning.py` | **new** — `get_peer_spki_hash(resp)` extracts SHA-256 of leaf SPKI; host-name constants. |
| `custom_components/haggle/agl/client.py` | `AglAuth.__init__` and `AglClient.__init__` accept optional `pin_check: Callable[[str, str], None]`. New `_safe_pin_check` helper invokes it after every successful 200, swallowing callback exceptions so a buggy validator cannot poison the data path. |
| `custom_components/haggle/config_flow.py` | `_exchange_code` returns `(access, refresh, auth_spki)`; `_fetch_contracts` returns `(contracts, bff_spki)`. Both capture inside the response `async with`. `_async_create_entry` persists both hashes. |
| `custom_components/haggle/__init__.py` | Wires the `_check_pin` callback into `AglAuth` + `AglClient`: matches → silent; mismatch → WARNING + `persistent_notification.async_create(notification_id=haggle_pin_mismatch_<host>)`. |
| `custom_components/haggle/const.py` | New `CONF_PINNED_SPKI_AUTH` / `CONF_PINNED_SPKI_BFF` keys. |
| `tests/test_pinning.py` | **new** — 6 tests covering SPKI extraction (real cert + 4 edge cases) and host-name guards. |
| `tests/test_agl_client.py` | 4 new tests covering pin-check wiring on the auth + data paths and callback exception isolation. |
| `tests/test_init.py` | 2 new tests covering mismatch notification + legacy no-pin silence. |
| `tests/test_config_flow.py` | Updated existing fixtures to match the new `_exchange_code` / `_fetch_contracts` return shapes. |

### Re-pin path

Existing HA Reconfigure flow re-runs `_exchange_code` → naturally re-captures both SPKIs. No new UI surface needed.

### Legacy entries (pre-PR4)

Empty `CONF_PINNED_SPKI_*` strings are interpreted as "no pin yet" — the validator is a no-op. Existing entries silently upgrade on next Reconfigure.

### First-install caveat

A LAN MITM during the initial PKCE flow could pin the attacker's cert. PKCE happens in the user's browser (system trust + lock indicator) so this requires compromising both browser and HA host simultaneously. Documented in `AGENTS.md` AGL API section + `agl/pinning.py` docstring.

## Test plan

- [x] 12 new tests; **89 passing total** (was 77). `uv run pytest`.
- [x] `uv run ruff check`, `uv run mypy custom_components/haggle`, `uv run pre-commit run --all-files` — all clean.
- [x] `pinning.py` at 100% coverage.
- [ ] CI workflow green on PR.
- [ ] Hassfest green.
- [ ] HACS validation green.
- [ ] Live install soak: complete PKCE on home network, observe both SPKIs persisted to `.storage/core.config_entries`, run for 24 h with no `pinning` warnings; manually corrupt one stored hash and confirm the WARNING + persistent notification fire on next poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
