### PR TITLE
fix(security): pre-flip code mop-up — close 6 must-fix issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   module `custom_components/haggle/agl/pinning.py`. Closes AP-1 from
   `security/2026-05-02T04-43Z/`.
 
+### Fixed
+- **`coordinator.py` uses UTC for the fetch range** instead of the OS local
+  date. AGL `dateTime` slots are UTC; `date.today()` on a non-UTC HA host
+  could fetch tomorrow's empty data or skip yesterday entirely around
+  midnight. (#31)
+- **`config_flow._exchange_code` and `_fetch_contracts` use HA's shared
+  aiohttp client** (`async_get_clientsession(hass)`) instead of creating a
+  throwaway `aiohttp.ClientSession()` per call. Inherits HA's TCP connector
+  pool. (#28)
+- **`__init__.py::async_setup_entry` uses `async_create_clientsession(hass)`**;
+  the manual `session.close()` in `async_unload_entry` is gone — HA owns the
+  session lifecycle now. The `session` field on `HaggleRuntimeData` is
+  removed since callers no longer need to reach for it. (#29)
+
 ### Removed
+- **Three never-called `AglClient` methods**: `async_get_servicehub`,
+  `async_get_usage_daily`, `async_close`. (#32)
+- **`CONF_ACCESS_TOKEN` and `CONF_ACCESS_TOKEN_EXPIRY` constants** from
+  `const.py` and the empty-string/zero values that were being written into
+  `entry.data` on creation. AGENTS.md already prohibited persisting access
+  tokens; the code was a footgun for future contributors. (#26)
 - **`beautifulsoup4` runtime dependency**. Zero call sites in
   `custom_components/`; was a dead dep that every HACS installer downloaded for
   no reason. Removed from `manifest.json` and `pyproject.toml` (also drops
@@ -28,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from `security/2026-05-02T04-43Z/`.
 
 ### Security
+- **PKCE verifier and challenge are zeroed after a successful exchange**.
+  The flow object can persist in memory across multi-step retries; a stale
+  one-shot verifier is one less secret to leak. (#27)
 - **Note on `aiohttp` CVE coverage**: the 9 CVEs against `aiohttp==3.13.3`
   flagged in the security review (SCA-M01, SCA-M04, SCA-L01..L06) are fixed in
   `aiohttp>=3.13.4`, which Home Assistant bundles starting with `2026.4.0`. HA

--- a/custom_components/haggle/__init__.py
+++ b/custom_components/haggle/__init__.py
@@ -11,9 +11,9 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import aiohttp
 from homeassistant.components import persistent_notification
 from homeassistant.const import Platform
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .agl.client import AglAuth, AglClient
 from .agl.pinning import AGL_AUTH_HOST_NAME
@@ -46,7 +46,6 @@ class HaggleRuntimeData:
     auth: AglAuth
     client: AglClient
     coordinator: HaggleCoordinator
-    session: aiohttp.ClientSession
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bool:
@@ -109,7 +108,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bo
             notification_id=f"haggle_pin_mismatch_{host}",
         )
 
-    session = aiohttp.ClientSession()
+    # async_create_clientsession returns an HA-managed aiohttp session that
+    # inherits HA's SSL trust bundle and TCP connector pool, and is
+    # auto-closed when the entry unloads — no manual session.close() needed.
+    session = async_create_clientsession(hass)
     auth = AglAuth(refresh_token, _persist_refresh_token, pin_check=_check_pin)
     client = AglClient(auth, session, pin_check=_check_pin)
     coordinator = HaggleCoordinator(hass, entry, client, contract_number)  # type: ignore[arg-type]
@@ -120,7 +122,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bo
         auth=auth,
         client=client,
         coordinator=coordinator,
-        session=session,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -129,6 +130,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        await entry.runtime_data.session.close()
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -45,7 +45,6 @@ from .models import (
 )
 from .parser import (
     parse_bill_period,
-    parse_daily_readings,
     parse_interval_readings,
     parse_overview,
     parse_plan,
@@ -320,12 +319,6 @@ class AglClient:
         data = await self._get(url)
         return parse_overview(data)
 
-    async def async_get_servicehub(self, contract_number: str) -> dict[str, Any]:
-        """Fetch /api/v1/servicehub/energy/{contractNumber} hyperlinks."""
-        url = f"{self.BASE_URL}/api/v1/servicehub/energy/{contract_number}"
-        data: dict[str, Any] = await self._get(url)
-        return {k: str(v) for k, v in data.items() if isinstance(v, str)}
-
     # --- Usage ---
 
     async def async_get_usage_summary(self, contract_number: str) -> BillPeriod:
@@ -348,15 +341,6 @@ class AglClient:
         data = await self._get(url)
         return parse_interval_readings(data)
 
-    async def async_get_usage_daily(
-        self, contract_number: str, start: date, end: date
-    ) -> list[DailyReading]:
-        """Fetch /Daily for a date range."""
-        period = f"{start}_{end}"
-        url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Current/Daily?period={period}&scaling={AGL_SCALING}"
-        data = await self._get(url)
-        return parse_daily_readings(data)
-
     async def async_get_usage_hourly_previous(
         self, contract_number: str, day: date
     ) -> list[IntervalReading]:
@@ -373,7 +357,3 @@ class AglClient:
         url = f"{self.BASE_URL}/api/v2/plan/energy/{contract_number}"
         data = await self._get(url)
         return parse_plan(data)
-
-    async def async_close(self) -> None:
-        """Close the underlying aiohttp session if we own it."""
-        await self._session.close()

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -127,14 +127,15 @@ def parse_bill_period(data: dict[str, Any]) -> BillPeriod:
 
     start_str: str = (current.get("start") or {}).get("date", "")
     end_str: str = (current.get("end") or {}).get("date", "")
+    today_utc = datetime.now(UTC).date()
     try:
         start = date.fromisoformat(start_str)
     except (ValueError, TypeError):
-        start = date.today()
+        start = today_utc
     try:
         end = date.fromisoformat(end_str)
     except (ValueError, TypeError):
-        end = date.today()
+        end = today_utc
 
     usage = current.get("usage") or {}
     cost_label: str = usage.get("amount", "$0.00")

--- a/custom_components/haggle/config_flow.py
+++ b/custom_components/haggle/config_flow.py
@@ -25,12 +25,13 @@ import base64
 import hashlib
 import logging
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import aiohttp
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .agl.client import AGLAuthError, AGLError, Contract
 from .agl.parser import parse_overview
@@ -45,8 +46,6 @@ from .const import (
     AGL_OAUTH_SCOPE,
     AGL_REDIRECT_URI,
     AGL_USER_AGENT,
-    CONF_ACCESS_TOKEN,
-    CONF_ACCESS_TOKEN_EXPIRY,
     CONF_ACCOUNT_NUMBER,
     CONF_CONTRACT_NUMBER,
     CONF_PINNED_SPKI_AUTH,
@@ -54,6 +53,9 @@ from .const import (
     CONF_REFRESH_TOKEN,
     DOMAIN,
 )
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,12 +112,15 @@ def _extract_code(
     return (code or None), None
 
 
-async def _exchange_code(code: str, verifier: str) -> tuple[str, str, str]:
-    """POST /oauth/token and return (access_token, refresh_token, auth_spki).
+async def _exchange_code(
+    hass: HomeAssistant, code: str, verifier: str
+) -> tuple[str, str, str]:
+    """POST /oauth/token via HA's shared aiohttp client.
 
-    `auth_spki` is the SHA-256 hex of the leaf-cert SPKI for secure.agl.com.au,
-    captured from the live TLS connection. Empty string if introspection fails
-    (degrades to no-pin, never blocks the install).
+    Returns (access_token, refresh_token, auth_spki). `auth_spki` is the
+    SHA-256 hex of the leaf-cert SPKI for secure.agl.com.au, captured from
+    the live TLS connection. Empty string if introspection fails (degrades
+    to no-pin, never blocks the install).
 
     Raises AGLAuthError on 4xx auth errors, AGLError on other failures.
     """
@@ -135,10 +140,8 @@ async def _exchange_code(code: str, verifier: str) -> tuple[str, str, str]:
         "Accept": "application/json",
     }
     auth_spki = ""
-    async with (
-        aiohttp.ClientSession() as session,
-        session.post(url, data=payload, headers=headers) as resp,
-    ):
+    session = async_get_clientsession(hass)
+    async with session.post(url, data=payload, headers=headers) as resp:
         if resp.status in (400, 401, 403):
             raise AGLAuthError(f"Token exchange failed: HTTP {resp.status}")
         if not resp.ok:
@@ -157,11 +160,13 @@ async def _exchange_code(code: str, verifier: str) -> tuple[str, str, str]:
     return access_token, refresh_token, auth_spki
 
 
-async def _fetch_contracts(access_token: str) -> tuple[list[Contract], str]:
-    """Fetch /api/v3/overview and return (contracts, bff_spki).
+async def _fetch_contracts(
+    hass: HomeAssistant, access_token: str
+) -> tuple[list[Contract], str]:
+    """Fetch /api/v3/overview via HA's shared aiohttp client.
 
-    `bff_spki` is the SHA-256 hex of the leaf-cert SPKI for
-    api.platform.agl.com.au. Empty string if capture fails.
+    Returns (contracts, bff_spki). `bff_spki` is the SHA-256 hex of the
+    leaf-cert SPKI for api.platform.agl.com.au. Empty string if capture fails.
 
     Uses aiohttp directly rather than AglAuth/AglClient: AglAuth always calls
     async_force_refresh on first use (token_set is None on construction), which
@@ -176,10 +181,8 @@ async def _fetch_contracts(access_token: str) -> tuple[list[Contract], str]:
         "Accept-Encoding": "gzip, deflate, br",
     }
     bff_spki = ""
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(url, headers=headers) as resp,
-    ):
+    session = async_get_clientsession(hass)
+    async with session.get(url, headers=headers) as resp:
         if resp.status >= 400:
             # Body kept out of the exception so it doesn't surface in
             # ConfigEntryAuthFailed → HA Persistent Notifications.
@@ -258,7 +261,7 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             access_token, refresh_token, auth_spki = await _exchange_code(
-                code, self._pkce_verifier
+                self.hass, code, self._pkce_verifier
             )
         except AGLAuthError:
             return self.async_show_form(
@@ -274,6 +277,12 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
                 description_placeholders={"authorize_url": authorize_url},
                 errors={"base": "cannot_connect"},
             )
+
+        # Clear PKCE material now that the one-shot exchange has consumed it.
+        # The flow object can persist in memory across multi-step retries; a
+        # stale verifier is no longer useful and is one less secret to leak.
+        self._pkce_verifier = ""
+        self._pkce_challenge = ""
 
         self._access_token = access_token
         self._refresh_token = refresh_token
@@ -293,7 +302,7 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
         if not self._contracts:
             try:
                 self._contracts, self._bff_spki = await _fetch_contracts(
-                    self._access_token
+                    self.hass, self._access_token
                 )
             except Exception:
                 errors["base"] = "cannot_connect"
@@ -373,12 +382,12 @@ class HaggleConfigFlow(ConfigFlow, domain=DOMAIN):
             "set" if self._auth_spki else "missing",
             "set" if self._bff_spki else "missing",
         )
+        # Only refresh_token is persisted as a credential. The short-lived
+        # access_token (15 min) must never live on disk per AGENTS.md.
         return self.async_create_entry(
             title=title or f"AGL {contract_number or 'account'}",
             data={
                 CONF_REFRESH_TOKEN: self._refresh_token,
-                CONF_ACCESS_TOKEN: "",
-                CONF_ACCESS_TOKEN_EXPIRY: 0,
                 CONF_CONTRACT_NUMBER: contract_number,
                 CONF_ACCOUNT_NUMBER: account_number,
                 CONF_PINNED_SPKI_AUTH: self._auth_spki,

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -93,8 +93,6 @@ STAT_COST: Final = "cost"  # → haggle:cost_{contract}
 # Config-entry keys.
 # CONF_EMAIL / CONF_PASSWORD are NOT used — auth is via refresh token.
 CONF_REFRESH_TOKEN: Final = "refresh_token"  # ← it IS a token key
-CONF_ACCESS_TOKEN: Final = "access_token"
-CONF_ACCESS_TOKEN_EXPIRY: Final = "access_token_expiry"
 CONF_CONTRACT_NUMBER: Final = "contract_number"
 CONF_ACCOUNT_NUMBER: Final = "account_number"
 # SHA-256 hex of the leaf-cert SPKI captured at config-flow time. Empty string

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -129,7 +129,9 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         last_cons_sum, last_stat_date = await self._get_last_stat(stat_id_cons)
         last_cost_sum, _ = await self._get_last_stat(stat_id_cost)
 
-        today = date.today()
+        # AGL `dateTime` slots are UTC; using `date.today()` (OS local time)
+        # would skew the fetch range by a day around midnight in non-UTC zones.
+        today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
         if last_stat_date is None:

--- a/tests/test_agl_client.py
+++ b/tests/test_agl_client.py
@@ -476,3 +476,15 @@ class TestPinCheckWiring:
             contracts = await client.async_get_overview()
 
         assert len(contracts) == 1
+
+
+# ---------------------------------------------------------------------------
+# #32: stale, never-called AglClient methods are gone
+# ---------------------------------------------------------------------------
+
+
+def test_unused_methods_removed_from_client() -> None:
+    """Belt-and-braces: re-introducing these without a caller is a regression."""
+    assert not hasattr(AglClient, "async_get_servicehub")
+    assert not hasattr(AglClient, "async_get_usage_daily")
+    assert not hasattr(AglClient, "async_close")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -76,6 +76,47 @@ async def test_user_flow_single_contract_creates_entry(hass: HomeAssistant) -> N
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_REFRESH_TOKEN] == "refresh_tok"
     assert result["data"][CONF_CONTRACT_NUMBER] == "9999999999"
+    # #26: only the refresh token should land on disk. The short-lived
+    # access_token has no business in entry.data.
+    assert "access_token" not in result["data"]
+    assert "access_token_expiry" not in result["data"]
+
+
+async def test_pkce_verifier_cleared_after_successful_exchange(
+    hass: HomeAssistant,
+) -> None:
+    """#27: PKCE verifier+challenge are zeroed once the exchange consumes them."""
+    flows = hass.config_entries.flow
+    result = await flows.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    flow_id = result["flow_id"]
+    flow = next(f for f in flows._progress.values() if f.flow_id == flow_id)
+
+    authorize_url: str = result["description_placeholders"]["authorize_url"]
+    assert flow._pkce_verifier  # populated on entry to async_step_user
+    assert flow._pkce_challenge
+
+    with (
+        patch(
+            "custom_components.haggle.config_flow._exchange_code",
+            new_callable=AsyncMock,
+            return_value=("access_tok", "refresh_tok", "deadbeef" * 8),
+        ),
+        patch(
+            "custom_components.haggle.config_flow._fetch_contracts",
+            new_callable=AsyncMock,
+            return_value=([_CONTRACT], "cafef00d" * 8),
+        ),
+    ):
+        await flows.async_configure(
+            flow_id,
+            user_input={CALLBACK_URL_FIELD: _make_callback_url(authorize_url)},
+        )
+
+    # Both PKCE secrets must be cleared once consumed.
+    assert flow._pkce_verifier == ""
+    assert flow._pkce_challenge == ""
 
 
 async def test_user_flow_bad_state_shows_error(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -20,8 +20,6 @@ from custom_components.haggle.agl.models import IntervalReading
 from custom_components.haggle.const import (
     BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
-    CONF_ACCESS_TOKEN,
-    CONF_ACCESS_TOKEN_EXPIRY,
     CONF_ACCOUNT_NUMBER,
     CONF_CONTRACT_NUMBER,
     CONF_REFRESH_TOKEN,
@@ -41,8 +39,6 @@ _CONTRACT = "9999999999"
 
 _ENTRY_DATA = {
     CONF_REFRESH_TOKEN: "v1.testtoken",
-    CONF_ACCESS_TOKEN: "",
-    CONF_ACCESS_TOKEN_EXPIRY: 0,
     CONF_CONTRACT_NUMBER: _CONTRACT,
     CONF_ACCOUNT_NUMBER: "1234567890",
 }
@@ -667,3 +663,49 @@ class TestNumericGuards:
 
         assert result.consumption_period_kwh == 0.0
         assert result.consumption_period_cost_aud == 0.0
+
+
+# ---------------------------------------------------------------------------
+# #31: fetch range is computed from UTC, not OS local time
+# ---------------------------------------------------------------------------
+
+
+class TestUTCDateBoundary:
+    async def test_fetch_uses_utc_today_not_local(self, hass: HomeAssistant) -> None:
+        """When UTC and OS local date differ, the integration must follow UTC.
+
+        AGL `dateTime` slots are UTC; using `date.today()` on a non-UTC OS
+        could fetch tomorrow's empty data or skip yesterday entirely.
+        """
+        from custom_components.haggle import coordinator as coord_mod
+
+        # 14:30 UTC on 2026-05-02 → in Sydney (UTC+10) it is already
+        # 00:30 on 2026-05-03. `date.today()` (local) would say 5/3 here;
+        # `datetime.now(UTC).date()` correctly says 5/2.
+        fixed_utc = datetime(2026, 5, 2, 14, 30, 0, tzinfo=UTC)
+
+        class _FrozenDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):  # type: ignore[override]
+                return fixed_utc.astimezone(tz) if tz else fixed_utc
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.side_effect = NotImplementedError
+        mock_client.async_get_plan.side_effect = NotImplementedError
+        coord = _make_coordinator(hass, client=mock_client)
+
+        with (
+            patch.object(coord_mod, "datetime", _FrozenDateTime),
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        # The UTC `today` is 2026-05-02; backfill starts BACKFILL_DAYS earlier.
+        expected_start = date(2026, 5, 2) - timedelta(days=BACKFILL_DAYS)
+        assert mock_range.call_args[0][0] == expected_start

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.haggle.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_ACCESS_TOKEN_EXPIRY,
     CONF_ACCOUNT_NUMBER,
     CONF_CONTRACT_NUMBER,
     CONF_REFRESH_TOKEN,
@@ -22,8 +20,6 @@ if TYPE_CHECKING:
 
 _ENTRY_DATA = {
     CONF_REFRESH_TOKEN: "v1.testtoken",
-    CONF_ACCESS_TOKEN: "",
-    CONF_ACCESS_TOKEN_EXPIRY: 0,
     CONF_CONTRACT_NUMBER: "9999999999",
     CONF_ACCOUNT_NUMBER: "1234567890",
 }
@@ -52,7 +48,7 @@ async def test_setup_and_unload(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "custom_components.haggle.aiohttp.ClientSession",
+            "custom_components.haggle.async_create_clientsession",
             return_value=mock_session,
         ),
         patch(
@@ -78,7 +74,9 @@ async def test_setup_and_unload(hass: HomeAssistant) -> None:
 
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
-        mock_session.close.assert_called_once()
+        # async_create_clientsession registers an HA-managed session; we no
+        # longer call session.close() ourselves on unload.
+        mock_session.close.assert_not_called()
 
 
 async def test_persist_failure_triggers_reauth(hass: HomeAssistant) -> None:
@@ -101,7 +99,7 @@ async def test_persist_failure_triggers_reauth(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "custom_components.haggle.aiohttp.ClientSession",
+            "custom_components.haggle.async_create_clientsession",
             return_value=mock_session,
         ),
         patch(
@@ -166,7 +164,7 @@ async def test_pin_mismatch_emits_persistent_notification(hass: HomeAssistant) -
 
     with (
         patch(
-            "custom_components.haggle.aiohttp.ClientSession",
+            "custom_components.haggle.async_create_clientsession",
             return_value=mock_session,
         ),
         patch(
@@ -224,7 +222,7 @@ async def test_pin_check_with_no_pin_stays_silent(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "custom_components.haggle.aiohttp.ClientSession",
+            "custom_components.haggle.async_create_clientsession",
             return_value=mock_session,
         ),
         patch(


### PR DESCRIPTION
## Summary

Audit-driven sweep of the six "must-fix-before-public" code-review issues that weren't in the original 4-PR security plan. All six were verified open against `main` HEAD; this PR closes them in a single bundled change.

| # | Issue | Fix |
|---|---|---|
| **#26** | `CONF_ACCESS_TOKEN` / `CONF_ACCESS_TOKEN_EXPIRY` written to `entry.data` | Drop the constants from `const.py`; remove from the `entry.data` dict in `_async_create_entry`. AGENTS.md already prohibited persisting access tokens — the code was a footgun for future contributors. |
| **#27** | PKCE verifier never cleared after successful exchange | Zero `self._pkce_verifier` and `self._pkce_challenge` at the end of `async_step_exchange`. The flow object persists in memory across multi-step retries; a stale one-shot verifier is one less secret to leak. |
| **#28** | bare `aiohttp.ClientSession()` in `_exchange_code` + `_fetch_contracts` | Both now take `hass` and use `async_get_clientsession(hass)`. Drops connector-pool churn and inherits HA's TCP pool. |
| **#29** | bare `aiohttp.ClientSession()` in `__init__.py` | `async_setup_entry` uses `async_create_clientsession(hass)`; the manual `session.close()` in `async_unload_entry` is gone — HA owns lifecycle. The `session` field on `HaggleRuntimeData` is removed since callers don't need to reach for it. |
| **#31** | `date.today()` uses OS local time, not UTC | `coordinator._fetch_and_import` and `parser.parse_bill_period` now use `datetime.now(UTC).date()`. AGL `dateTime` slots are UTC; the previous code could fetch tomorrow's empty data or skip yesterday around midnight on non-UTC HA hosts. |
| **#32** | three never-called `AglClient` methods | Delete `async_get_servicehub`, `async_get_usage_daily`, `async_close`. The `parse_daily_readings` import in `client.py` got auto-cleaned by ruff. |

## Test plan

- [x] **80 tests passing** (was 77). 3 new regressions: access-token-not-in-data (#26), PKCE-cleared (#27), UTC-not-local-fetch-range (#31), method-removed guard (#32).
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy custom_components/haggle` — clean.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] Existing `test_init` mocks adjusted: now patch `async_create_clientsession` instead of `aiohttp.ClientSession`; the unload test asserts `mock_session.close` was **not** called (HA owns the session).
- [ ] CI workflow green on PR.
- [ ] Hassfest + HACS validation green.
- [ ] Live install soak: confirm `entry.data` after a fresh PKCE has only `refresh_token`, `contract_number`, `account_number` (and the SPKI pins from PR #45 once that lands).

## Coordination with PR #45

PR #45 (TOFU TLS pinning) is open and green; this PR (5a) was branched from `main` so it's independent. Whichever merges first, the other rebases mechanically — they touch overlapping files (`__init__.py`, `config_flow.py`) but do not conflict semantically. The TOFU PR captures SPKI from a live response object; that path is identical regardless of whether the underlying session was created via raw `aiohttp.ClientSession()` or `async_get_clientsession(hass)`.

## Issues left open after this PR (deferred to v0.2.x post-flip)

- **#34** — backfill `asyncio.sleep(0.5)` between days + retry-after on 429
- **#35** — batched `get_last_statistics` for both stat IDs
- **#37** (parts 2-4) — drop unused consts, prune `__all__` block, fix `agl/__init__.py` docstring
- **#38** (parts 1-2) — drop sensor `dict`-fallback + `except NotImplementedError` arms

These are quality items, not security gates. They can land as a single `chore: post-flip code-quality sweep` or as the first work of v0.2.x.

## Issues already closed by previous PRs (need explicit `gh issue close`)

`#21` (pre-existing AGENTS.md), `#25 #33 #36 #40` (PR #43), `#30` (PR #44), `#39` (PR #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
