### PR TITLE
chore(release): v0.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes yet._
+
+---
+
+## [0.2.0-beta.1] — 2026-05-04
+
+First post-flip beta. Major work since v0.1.0:
+
+- **Trust-On-First-Use TLS pinning** for both AGL hosts (closes AP-1
+  from `security/2026-05-02T04-43Z/`).
+- **14-finding SAST sweep** addressing AP-2/AP-4/AP-6 chains.
+- **Supply-chain hardening**: all GitHub Actions SHA-pinned;
+  workflow-level `permissions: read-all`; HACS validation gate
+  un-suppressed; release.yml hardened against changelog interpolation.
+- **Repo posture files**: `SECURITY.md`, `CODEOWNERS`,
+  `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, weekly CodeQL scan,
+  build-provenance attestations on release.
+- **Platform bump** to Python 3.14.2 / HA 2026.4.4 — closes the 13
+  outstanding aiohttp/cryptography/orjson CVEs at the source.
+- **Branding correction**: `DeviceInfo.manufacturer` no longer
+  claims AGL Energy authorship.
+
+This is the first version intended for HACS submission. Marked beta
+until it has soak-time on independent installs.
+
 ### Changed
 - **Platform floor bumped to Python 3.14.2 + Home Assistant 2026.4.4.**
   HA 2026.4 ships `aiohttp==3.13.5` (closes 9 CVEs in SCA-M01..M04 +

--- a/custom_components/haggle/manifest.json
+++ b/custom_components/haggle/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.haggle"],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.1.0"
+  "version": "0.2.0-beta.1"
 }

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -21,7 +21,12 @@ def _ok(msg: str) -> None:
     print(f"[validate_manifest] OK: {msg}")
 
 
-SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+# SemVer 2.0.0 with optional pre-release identifier:
+#   1.2.3
+#   1.2.3-beta.1
+#   1.2.3-rc.0
+# Build metadata (`+build.42`) is not used here.
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-(?:[0-9a-zA-Z-]+)(?:\.[0-9a-zA-Z-]+)*)?$")
 DOMAIN_RE = re.compile(r"^[a-z0-9_]+$")
 CODEOWNER_RE = re.compile(r"^@[A-Za-z0-9_\-]+$")
 

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -355,7 +355,7 @@ class TestFetchRange:
         mock_client.async_get_usage_hourly_previous.return_value = []
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         bill_start = today - timedelta(days=2)
         start = today - timedelta(days=5)
         end = today - timedelta(days=3)  # all days are before bill_start
@@ -374,7 +374,7 @@ class TestFetchRange:
         mock_client.async_get_usage_hourly.return_value = []
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         bill_start = today - timedelta(days=5)
         start = today - timedelta(days=3)  # start is after bill_start
         end = today - timedelta(days=1)
@@ -393,7 +393,7 @@ class TestFetchRange:
         mock_client.async_get_usage_hourly.return_value = []
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         start = today - timedelta(days=2)
         end = today - timedelta(days=1)
 
@@ -411,7 +411,7 @@ class TestFetchRange:
         mock_client.async_get_usage_hourly.side_effect = AGLError("timeout")
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         start = today - timedelta(days=3)
         end = today - timedelta(days=1)
 
@@ -440,7 +440,7 @@ class TestFetchAndImport:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         expected_start = today - timedelta(days=BACKFILL_DAYS)
 
         with (
@@ -465,7 +465,7 @@ class TestFetchAndImport:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         # last stat was long ago → big gap; chunk should cap the end
         last_date = today - timedelta(days=BACKFILL_DAYS)
 
@@ -493,7 +493,7 @@ class TestFetchAndImport:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         last_date = today - timedelta(days=3)
         expected_start = today - timedelta(days=2)
 
@@ -517,7 +517,7 @@ class TestFetchAndImport:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
         with (
@@ -541,7 +541,7 @@ class TestFetchAndImport:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
         with (
@@ -571,7 +571,7 @@ class TestFetchAndImport:
         )
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
         with (
@@ -611,7 +611,7 @@ class TestNumericGuards:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
         with (
@@ -647,7 +647,7 @@ class TestNumericGuards:
         mock_client.async_get_plan.side_effect = NotImplementedError
         coord = _make_coordinator(hass, client=mock_client)
 
-        today = date.today()
+        today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
         with (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -287,11 +287,11 @@ class TestParseBillPeriod:
 
     def test_missing_bill_period_returns_today_dates(self) -> None:
         """Empty response should not crash; dates fall back to today."""
-        from datetime import date as _date
+        from datetime import UTC, datetime as _dt
 
         bp = parse_bill_period({})
-        assert bp.start == _date.today()
-        assert bp.end == _date.today()
+        assert bp.start == _dt.now(UTC).date()
+        assert bp.end == _dt.now(UTC).date()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cuts **`v0.2.0-beta.1`** — the first post-flip beta release. After this PR merges, tagging `v0.2.0-beta.1` on the merge commit triggers `release.yml`, which publishes a GitHub Release with `prerelease: true` and an `actions/attest-build-provenance` attestation over `custom_components/haggle/`.

### Changes

| File | Change |
|---|---|
| `custom_components/haggle/manifest.json` | `version: "0.2.0-beta.1"` |
| `CHANGELOG.md` | `## [Unreleased]` block moved under `## [0.2.0-beta.1] — 2026-05-04` with a release summary |
| `scripts/validate_manifest.py` | SemVer regex now accepts optional pre-release suffix (`X.Y.Z-prerelease.N`), matching what HA/HACS Hassfest accepts |
| `tests/test_parser.py` + `tests/test_coordinator_statistics.py` | `date.today()` (local time) replaced with `datetime.now(UTC).date()` in test fixtures — they were going red at the AEST/UTC midnight boundary. Production code already uses UTC per #31. |

### What's in this beta

The full diff from `v0.1.0` is **10 merged PRs**:
- **#42** — supply-chain hardening (SHA-pin Actions, workflow permissions, release-body hardening)
- **#43** — SAST sweep (7 findings closing AP-2/AP-4/AP-6 chains)
- **#44** — drop dead `beautifulsoup4`; document aiohttp CVE deferral
- **#45** — Trust-On-First-Use TLS pinning (initial cut)
- **#46** — pre-flip code mop-up (6 must-fix issues, including #26 entry.data hygiene)
- **#47** — repo posture (`SECURITY.md`, CodeQL, attestations)
- **#48** — TOFU pin connector redesign (closed v0.1.0 silent-no-op bug)
- **#51** — `DeviceInfo` no longer claims AGL Energy authorship
- **#52** — platform bump to Python 3.14.2 / HA 2026.4.4 (closes 13 CVEs at source)
- this PR — version bump + release prep

## Test plan

- [x] **93 tests passing** on Python 3.14.2.
- [x] `uv run ruff check`, `uv run mypy custom_components/haggle`, `uv run pre-commit run --all-files` — clean.
- [x] `python scripts/validate_manifest.py custom_components/haggle/manifest.json hacs.json` — both pass with new regex.
- [ ] CI workflow green on PR.
- [ ] Hassfest + HACS validation green (proves the pre-release version string is accepted by upstream tooling, not just our local validator).

## Post-merge plan

After CI is green and the PR merges:

```bash
git fetch origin main
git checkout origin/main
git tag -a v0.2.0-beta.1 -m "v0.2.0-beta.1 — first post-flip beta"
git push origin v0.2.0-beta.1
```

`release.yml` triggers on tag push, runs:
1. `actions/checkout` (SHA-pinned)
2. Extract changelog section for `0.2.0-beta.1`
3. `actions/attest-build-provenance@v4.1.0` over `custom_components/haggle/**/*`
4. `softprops/action-gh-release@v3.0.0` with `body_path: release_notes.txt` and `prerelease: true` (auto-detected because the tag has a `-`)

Verification: `gh release view v0.2.0-beta.1` should show the attestation badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
