### PR TITLE
docs(changelog): mark v0.1.0 as YANKED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,25 @@ until it has soak-time on independent installs.
 
 ---
 
-## [0.1.0] — 2026-05-02
+## [0.1.0] [YANKED] — 2026-05-02
+
+> **Withdrawn 2026-05-04.** The GitHub Release for `v0.1.0` was deleted from
+> https://github.com/NaanyaBiz/haggle/releases. The git tag `v0.1.0`
+> (`fb25813`) is preserved for history. Reasons:
+>
+> - Trust-On-First-Use TLS pinning was silently a no-op — `entry.data` was
+>   verified empty on the live install on 2026-05-03 — meaning installs
+>   accepted any AGL-presented certificate without comparison. Fixed in
+>   v0.2.0-beta.1.
+> - `DeviceInfo` rendered as `AGL Energy API by AGL Australia` in HA's
+>   Service info card, falsely implying official AGL authorship. Fixed in
+>   v0.2.0-beta.1.
+> - 13 unpatched CVEs against the bundled `aiohttp` / `cryptography` /
+>   `orjson` (all gated on the HA platform floor at the time). Closed by
+>   the Python 3.14.2 / HA 2026.4.4 bump in v0.2.0-beta.1.
+>
+> Anyone running v0.1.0 should reinstall from v0.2.0-beta.1 (HACS users:
+> enable "Show beta versions" or wait for v0.2.0 stable).
 
 ### Fixed
 - **`_fetch_contracts` token-type bug**: config flow was passing the short-lived


### PR DESCRIPTION
## Summary

Marks `[0.1.0]` as `YANKED` in `CHANGELOG.md` (Keep-a-Changelog convention) and adds a withdrawal block under the section header explaining what's wrong with v0.1.0.

The v0.1.0 GitHub Release was deleted on 2026-05-04. The tag (`fb25813`) is preserved for git history.

### Why

Three reasons the release should not be installed:

1. **Silent TOFU pin failure.** PR #45 captured SPKI from `resp.connection.transport`, but aiohttp had already released the Connection back to its pool by the time the response context entered — every install ran with empty stored SPKIs (verified live 2026-05-03). Fixed in v0.2.0-beta.1 via the `HagglePinningConnector` redesign (#48).
2. **`AGL Energy API by AGL Australia` rendered in HA's Service info card** — falsely implying official AGL authorship. Fixed in v0.2.0-beta.1 (#51).
3. **13 unpatched CVEs** against the bundled `aiohttp` / `cryptography` / `orjson`. Closed by the Python 3.14.2 / HA 2026.4.4 platform bump in v0.2.0-beta.1 (#52).

### What this PR does NOT do

- Does not delete the `v0.1.0` git tag — it stays at `fb25813` so the audit trail is intact.
- Does not edit any historical CHANGELOG content above the `### Fixed` line — the original release notes are preserved verbatim.
- Does not bump version or trigger a release.

## Test plan

- [x] `git diff CHANGELOG.md` — only adds the YANKED tag + 17-line block; original section content untouched.
- [x] Pre-commit hooks pass locally (no code in this PR; only docs).
- [ ] CI green on PR (CHANGELOG-only change; expected to pass trivially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
