### PR TITLE
docs(readme): add HACS "Open repository" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # haggle
 
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=NaanyaBiz&repository=haggle&category=integration)
+
 Home Assistant custom integration that pulls smart-meter usage from
 [AGL Australia](https://www.agl.com.au/) and feeds it into the HA Energy
 dashboard.
@@ -25,7 +27,11 @@ energy sensors (`device_class=energy`, `state_class=total_increasing`).
 
 ## Install
 
-> Not yet HACS-listed. Install via HACS *Custom repository*.
+> Not yet HACS-listed (PR queued). Install via HACS *Custom repository*.
+
+The fastest path is the badge above — click it on a machine with [My Home
+Assistant](https://my.home-assistant.io/) configured and HACS will open the
+"add repository" dialog pre-filled. Otherwise:
 
 1. HACS → *Integrations* → *Custom repositories* → add this repo URL → category **Integration**.
 2. Install **Haggle**, then restart Home Assistant.


### PR DESCRIPTION
## Summary

Adds the standard HACS "Open repository" deep-link badge to `README.md`, matching the pattern used by other HACS custom integrations (e.g. [kevinlester/ShadeAuto-HomeAssistant](https://github.com/kevinlester/ShadeAuto-HomeAssistant/blob/main/README.md)).

## Changes

- Badge inserted right under the `# haggle` title.
- One-line note in the **Install** section pointing users at the badge as the fast path, with the manual *Custom repositories* steps preserved for users without [My Home Assistant](https://my.home-assistant.io/) configured.
- Updated the "Not yet HACS-listed" note to mention the PR is queued.

## How it works

- Badge image: `https://my.home-assistant.io/badges/hacs_repository.svg` (canonical, served by Home Assistant infra — no third-party tracking).
- Click target: `https://my.home-assistant.io/redirect/hacs_repository/?owner=NaanyaBiz&repository=haggle&category=integration`. My HA resolves the redirect against the user's local HA URL (configured at `my.home-assistant.io`) and opens HACS with the *Add custom repository* dialog pre-filled.
- For users without My HA configured, the badge image still renders and the click leads to the My HA setup page — graceful fallback, not a broken link.

## Test plan

- [x] `git diff README.md` — additive only; no existing prose modified beyond the queue note.
- [x] Pre-commit hooks pass locally.
- [ ] CI green on PR (docs-only; expected to pass trivially).
- [ ] Manual: render the badge target locally to confirm the URL resolves to the haggle repo entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
