### PR TITLE
fix: close issue tail — monetary state_class, backfill 429, orphan cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,11 @@ docker run --rm \
 
 ```
 custom_components/haggle/
-├── __init__.py          # async_setup_entry / async_unload_entry + HaggleRuntimeData
+├── __init__.py          # async_setup_entry / async_unload_entry / async_remove_entry + HaggleRuntimeData
 ├── manifest.json        # HACS/HA metadata; hassfest validates this
 ├── const.py             # all constants — DOMAIN, API hosts, config-entry keys, data keys
 ├── config_flow.py       # PKCE authorize URL → user pastes callback → exchange → select_contract
-├── coordinator.py       # HaggleCoordinator: 30-day backfill + incremental statistics import
+├── coordinator.py       # HaggleCoordinator: 30-day backfill (throttled, 429-aware) + incremental statistics import
 ├── sensor.py            # 6 SensorEntityDescription entries; HaggleEnergySensor
 ├── agl/
 │   ├── __init__.py
@@ -382,6 +382,19 @@ The HA Energy dashboard requires:
   `manufacturer="Haggle"`. AGL's name belongs only in `model`/docs as a
   factual description of the upstream service. Regression test:
   `tests/test_init.py::test_device_info_does_not_claim_agl_authorship`.
+- **Don't pair `state_class=MEASUREMENT` with `device_class=MONETARY`.**
+  HA validates this combination and logs a WARNING on every state update;
+  only `None` or `TOTAL` are valid for MONETARY. Use `TOTAL` for cumulative
+  cost-over-period, leave unset for one-shots (forecast, current rate).
+- **Implement `async_remove_entry` if the integration creates entities.**
+  Otherwise deleting the integration leaves orphan entity-registry rows
+  whose `config_entry_id` references the now-gone entry; reinstall causes
+  `_2`-suffixed sensor IDs that linger as `unavailable` forever. See
+  `__init__.py::async_remove_entry`.
+- **Don't fire backfill requests in a tight loop.** AGL's BFF will 429
+  if 7 sequential GETs land in <1 s. `_fetch_range` sleeps
+  `BACKFILL_INTER_REQUEST_DELAY` between days and breaks out of the chunk
+  on `AGLRateLimitError`; the next 24 h cycle resumes from the gap.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Fixed
+- **MONETARY sensors no longer log a state-class warning on every poll.**
+  HA rejects `state_class=MEASUREMENT` on `device_class=MONETARY`; drop
+  the invalid `state_class` from `bill_projection`, `unit_rate`, and
+  `supply_charge`. Closes #49.
+- **Backfill loop now sleeps between per-day fetches and halts on 429.**
+  First-install backfill no longer fires up to 7 GETs in <1 s; on
+  rate-limit the loop stops so the next 24 h cycle resumes from the
+  gap rather than silently dropping post-429 days. Closes #34.
+- **Removing the integration now purges its entity-registry rows.**
+  `async_remove_entry` walks the registry and deletes orphans for the
+  config entry, preventing `_2`-suffixed re-installs. Closes #50.
+
+### Changed
+- **Coordinator overlaps recorder reads.** Both `get_last_statistics`
+  lookups (consumption + cost) now run via `asyncio.gather`, halving
+  the wall time of the resume-point computation. Closes #35.
+- **Code cleanup.** Drop unused `SCAN_INTERVAL_DAILY`,
+  `SCAN_INTERVAL_PLAN`, `TOKEN_REFRESH_MARGIN_SECONDS` constants; drop
+  the `__all__` re-export block from `agl/client.py`; correct the
+  `agl/__init__.py` docstring to reference `agl-api-explorer`. Remove
+  defensive `NotImplementedError` catches in the coordinator and the
+  dict-fallback branch in `HaggleEnergySensor.native_value` — neither
+  path is reachable from production code. Closes #37, #38.
 
 ---
 

--- a/custom_components/haggle/__init__.py
+++ b/custom_components/haggle/__init__.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 from homeassistant.components import persistent_notification
 from homeassistant.const import Platform
+from homeassistant.helpers import entity_registry as er
 
 from .agl.client import AglAuth, AglClient
 from .agl.pinning import AGL_AUTH_HOST_NAME, HagglePinningConnector
@@ -141,3 +142,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> b
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         await entry.runtime_data.session.close()
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> None:
+    """Drop entity-registry rows for this entry on integration removal.
+
+    Without this, deleting the integration leaves orphan rows whose
+    `config_entry_id` references the now-gone entry. On reinstall, HA
+    sees an entity_id collision and renames the new sensors with a `_2`
+    suffix; the orphans then linger forever as `unavailable`.
+    """
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    for entity in entries:
+        registry.async_remove(entity.entity_id)

--- a/custom_components/haggle/agl/__init__.py
+++ b/custom_components/haggle/agl/__init__.py
@@ -1,6 +1,6 @@
-"""AGL portal client + NEM12 parser.
+"""AGL Energy API client + JSON parser.
 
-Owned by the `agl-portal-explorer` subagent. Everything that talks to
+Owned by the `agl-api-explorer` subagent. Everything that talks to
 agl.com.au lives here; the rest of the integration treats this package
 as an opaque async client.
 """

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -38,7 +38,6 @@ from ..const import (
 from .models import (
     BillPeriod,
     Contract,
-    DailyReading,
     IntervalReading,
     PlanRates,
     TokenSet,
@@ -62,21 +61,6 @@ _LOGGER = logging.getLogger(__name__)
 _REFRESH_MARGIN_SECONDS = 120
 
 TOKEN_ENDPOINT = f"{AGL_AUTH_HOST}/oauth/token"
-
-# Re-export models so callers can import from client (backward compat).
-__all__ = [
-    "AGLAuthError",
-    "AGLError",
-    "AGLRateLimitError",
-    "AglAuth",
-    "AglClient",
-    "BillPeriod",
-    "Contract",
-    "DailyReading",
-    "IntervalReading",
-    "PlanRates",
-    "TokenSet",
-]
 
 
 class AGLError(Exception):

--- a/custom_components/haggle/config_flow.py
+++ b/custom_components/haggle/config_flow.py
@@ -25,15 +25,18 @@ import base64
 import hashlib
 import logging
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import aiohttp
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
-from .agl.client import AGLAuthError, AGLError, Contract
+from .agl.client import AGLAuthError, AGLError
 from .agl.parser import parse_overview
+
+if TYPE_CHECKING:
+    from .agl.models import Contract
 from .agl.pinning import (
     AGL_AUTH_HOST_NAME,
     AGL_BFF_HOST_NAME,

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -25,20 +25,17 @@ AGL_REDIRECT_URI: Final = "https://secure.agl.com.au/ios/au.com.agl.mobile/callb
 AGL_OAUTH_SCOPE: Final = "openid profile email offline_access"
 AGL_OAUTH_AUDIENCE: Final = "https://api.platform.agl.com.au/"
 
-# Polling cadences.
+# Polling cadence.
 # AGL interval data is delayed 24-48 h from the meter (AEMO feed lag).
 SCAN_INTERVAL_HOURLY: Final = timedelta(hours=24)  # 30-min intervals: fetch yesterday
-SCAN_INTERVAL_DAILY: Final = timedelta(hours=6)  # daily series: pick up new days
-SCAN_INTERVAL_PLAN: Final = timedelta(days=7)  # plan/rates: rarely changes
-
-# How many seconds before access-token expiry to proactively refresh.
-# AGL access tokens expire at ~15 min; refresh 2 min early.
-TOKEN_REFRESH_MARGIN_SECONDS: Final = 120
 
 # Number of days of history to backfill on first install.
 BACKFILL_DAYS: Final = 30
 # Maximum days to fetch per 24 h poll cycle (throttles first-install backfill).
 BACKFILL_CHUNK_DAYS: Final = 7
+# Seconds to sleep between per-day fetches in a backfill chunk so we don't
+# fire 7 requests in under a second.
+BACKFILL_INTER_REQUEST_DELAY: Final = 0.5
 
 # AGL BFF requires these headers on Hourly/Daily usage endpoints (HTTP 500 without them).
 # Documented from AGL mobile app 8.38.0-531 — 2026-05-01.

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -45,7 +45,8 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
-    from .agl.client import AglClient, IntervalReading
+    from .agl.client import AglClient
+    from .agl.models import IntervalReading
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,7 +119,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         summary = await self.client.async_get_usage_summary(self.contract_number)
         plan = await self.client.async_get_plan(self.contract_number)
 
-        bill_start: date | None = summary.start if summary is not None else None
+        bill_start: date = summary.start
 
         # Determine resume point — overlap both recorder lookups on the executor.
         (last_cons_sum, last_stat_date), (last_cost_sum, _) = await asyncio.gather(
@@ -154,30 +155,25 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
 
         # Extract rates from plan.
         unit_rate_aud: float | None = None
-        if plan is not None:
-            for rate in plan.unit_rates:
-                if rate.get("type") == "c/kWh":
-                    cents = _safe_float(rate.get("price"))
-                    unit_rate_aud = cents / 100.0
-                    break
+        for rate in plan.unit_rates:
+            if rate.get("type") == "c/kWh":
+                cents = _safe_float(rate.get("price"))
+                unit_rate_aud = cents / 100.0
+                break
 
         supply_charge_aud: float | None = None
-        if plan is not None and plan.supply_charge_cents_per_day:
+        if plan.supply_charge_cents_per_day:
             supply_charge_aud = plan.supply_charge_cents_per_day / 100.0
 
         # Parse bill-period totals.
-        period_kwh: float = 0.0
-        period_cost: float = 0.0
         projection: float | None = None
-
-        if summary is not None:
-            period_kwh = _safe_float(summary.consumption_kwh)
-            period_cost = _safe_float(
-                (summary.cost_label or "").lstrip("$").replace(",", "")
-            )
-            proj_label = (summary.projection_label or "").lstrip("$").replace(",", "")
-            if proj_label:
-                projection = _safe_float(proj_label)
+        period_kwh = _safe_float(summary.consumption_kwh)
+        period_cost = _safe_float(
+            (summary.cost_label or "").lstrip("$").replace(",", "")
+        )
+        proj_label = (summary.projection_label or "").lstrip("$").replace(",", "")
+        if proj_label:
+            projection = _safe_float(proj_label)
 
         return HaggleData(
             consumption_period_kwh=period_kwh,

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -17,6 +17,7 @@ billing period use Current/Hourly; older days use Previous/Hourly.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 from dataclasses import dataclass
@@ -29,10 +30,11 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .agl.client import AGLAuthError, AGLError
+from .agl.client import AGLAuthError, AGLError, AGLRateLimitError
 from .const import (
     BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
+    BACKFILL_INTER_REQUEST_DELAY,
     DOMAIN,
     SCAN_INTERVAL_HOURLY,
     STAT_CONSUMPTION,
@@ -113,21 +115,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         stat_id_cost = f"{DOMAIN}:{STAT_COST}_{self.contract_number}"
 
         # Fetch live sensor data first — summary gives bill_start for endpoint selection.
-        try:
-            summary = await self.client.async_get_usage_summary(self.contract_number)
-        except NotImplementedError:
-            summary = None
-
-        try:
-            plan = await self.client.async_get_plan(self.contract_number)
-        except NotImplementedError:
-            plan = None
+        summary = await self.client.async_get_usage_summary(self.contract_number)
+        plan = await self.client.async_get_plan(self.contract_number)
 
         bill_start: date | None = summary.start if summary is not None else None
 
-        # Determine resume point.
-        last_cons_sum, last_stat_date = await self._get_last_stat(stat_id_cons)
-        last_cost_sum, _ = await self._get_last_stat(stat_id_cost)
+        # Determine resume point — overlap both recorder lookups on the executor.
+        (last_cons_sum, last_stat_date), (last_cost_sum, _) = await asyncio.gather(
+            self._get_last_stat(stat_id_cons),
+            self._get_last_stat(stat_id_cost),
+        )
 
         # AGL `dateTime` slots are UTC; using `date.today()` (OS local time)
         # would skew the fetch range by a day around midnight in non-UTC zones.
@@ -223,10 +220,20 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         initial_cons_sum: float,
         initial_cost_sum: float,
     ) -> None:
-        """Fetch [start..end] with smart endpoint selection, then import."""
+        """Fetch [start..end] with smart endpoint selection, then import.
+
+        Sleeps between per-day requests so a chunk-of-7 first-install backfill
+        doesn't hammer AGL's BFF in under a second. On rate-limit the loop
+        stops early — the next 24h poll cycle will resume from the last
+        successfully imported date.
+        """
         all_intervals: list[IntervalReading] = []
         current = start
+        first = True
         while current <= end:
+            if not first:
+                await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
+            first = False
             try:
                 if bill_start is not None and current < bill_start:
                     readings = await self.client.async_get_usage_hourly_previous(
@@ -237,7 +244,12 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                         self.contract_number, current
                     )
                 all_intervals.extend(readings)
-            except (AGLError, NotImplementedError) as err:
+            except AGLRateLimitError as err:
+                _LOGGER.warning(
+                    "AGL rate-limited at %s; halting backfill chunk: %s", current, err
+                )
+                break
+            except AGLError as err:
                 _LOGGER.debug("Fetch skip %s: %s", current, err)
             current += timedelta(days=1)
 

--- a/custom_components/haggle/sensor.py
+++ b/custom_components/haggle/sensor.py
@@ -139,8 +139,5 @@ class HaggleEnergySensor(CoordinatorEntity[HaggleCoordinator], SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current sensor value from coordinator data."""
-        data = self.coordinator.data
-        if data is None:
-            return None
-        value = getattr(data, self.entity_description.key)
+        value = getattr(self.coordinator.data, self.entity_description.key)
         return float(value) if value is not None else None

--- a/custom_components/haggle/sensor.py
+++ b/custom_components/haggle/sensor.py
@@ -10,12 +10,12 @@ by live coordinator data use the standard CoordinatorEntity pattern.
 state_class choices:
   - TOTAL_INCREASING for cumulative kWh / cost (monotonic, HA tracks resets)
   - TOTAL for period / today totals (reset at known boundary)
-  - MEASUREMENT for instantaneous / forecast values
+  - unset on MONETARY one-shots (forecast / rate); MEASUREMENT is invalid there
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -73,26 +73,25 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement="AUD",
         suggested_display_precision=2,
     ),
-    # --- Forecast / rates (monetary, measurement) ---
+    # --- Forecast / rates (monetary) ---
+    # MONETARY device_class only accepts state_class None or TOTAL; these are
+    # one-shot values (forecast, current rate), so leave state_class unset.
     SensorEntityDescription(
         key=DATA_BILL_PROJECTION,
         translation_key="bill_projection",
         device_class=SensorDeviceClass.MONETARY,
-        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="AUD",
     ),
     SensorEntityDescription(
         key=DATA_UNIT_RATE,
         translation_key="unit_rate",
         device_class=SensorDeviceClass.MONETARY,
-        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="AUD/kWh",
     ),
     SensorEntityDescription(
         key=DATA_SUPPLY_CHARGE,
         translation_key="supply_charge",
         device_class=SensorDeviceClass.MONETARY,
-        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="AUD/day",
     ),
 )
@@ -140,15 +139,8 @@ class HaggleEnergySensor(CoordinatorEntity[HaggleCoordinator], SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current sensor value from coordinator data."""
-        data: Any = self.coordinator.data
+        data = self.coordinator.data
         if data is None:
             return None
-        # HaggleData is a dataclass; fall back gracefully if a stub/mock
-        # returns a plain dict during tests.
-        if hasattr(data, self.entity_description.key):
-            value = getattr(data, self.entity_description.key)
-        elif isinstance(data, dict):
-            value = data.get(self.entity_description.key)
-        else:
-            return None
+        value = getattr(data, self.entity_description.key)
         return float(value) if value is not None else None

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haggle.agl.models import IntervalReading
+from custom_components.haggle.agl.models import BillPeriod, IntervalReading, PlanRates
 from custom_components.haggle.const import (
     BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
@@ -46,6 +46,26 @@ _ENTRY_DATA = {
 
 def _make_interval(dt: datetime, kwh: float, cost: float = 0.05) -> IntervalReading:
     return IntervalReading(dt=dt, kwh=kwh, cost_aud=cost, rate_type="normal")
+
+
+def _empty_summary() -> BillPeriod:
+    """Default BillPeriod that flows through coordinator without contributing data."""
+    today = datetime.now(UTC).date()
+    return BillPeriod(
+        start=today,
+        end=today,
+        consumption_kwh=0.0,
+        cost_label="$0.00",
+        projection_label="",
+    )
+
+
+def _empty_plan() -> PlanRates:
+    return PlanRates(
+        product_name="",
+        unit_rates=[],
+        supply_charge_cents_per_day=0.0,
+    )
 
 
 def _make_coordinator(
@@ -415,14 +435,78 @@ class TestFetchRange:
         start = today - timedelta(days=3)
         end = today - timedelta(days=1)
 
-        with patch.object(
-            coord, "_import_intervals", new_callable=AsyncMock
-        ) as mock_imp:
+        with (
+            patch.object(
+                coord, "_import_intervals", new_callable=AsyncMock
+            ) as mock_imp,
+            patch(
+                "custom_components.haggle.coordinator.asyncio.sleep", new=AsyncMock()
+            ),
+        ):
             await coord._fetch_range(start, end, None, 0.0, 0.0)  # must not raise
 
         # All days attempted despite errors; no intervals → _import_intervals not called
         assert mock_client.async_get_usage_hourly.call_count == 3
         mock_imp.assert_not_called()
+
+    async def test_fetch_range_halts_on_rate_limit(self, hass: HomeAssistant) -> None:
+        """A 429 mid-chunk halts the loop so the next poll resumes from the gap.
+
+        Closes #34: silently dropping post-429 days corrupts the backfill resume
+        point because get_last_statistics returns the last *successful* import,
+        skipping any failures after the 429.
+        """
+        from custom_components.haggle.agl.client import AGLRateLimitError
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.side_effect = [
+            [],  # day 1 ok
+            AGLRateLimitError("HTTP 429"),  # day 2 — halt
+            [],  # day 3 — must not be attempted
+        ]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        start = today - timedelta(days=3)
+        end = today - timedelta(days=1)
+
+        with (
+            patch.object(coord, "_import_intervals", new_callable=AsyncMock),
+            patch(
+                "custom_components.haggle.coordinator.asyncio.sleep", new=AsyncMock()
+            ),
+        ):
+            await coord._fetch_range(start, end, None, 0.0, 0.0)
+
+        # Two attempts only: day 1 succeeded, day 2 halted the loop.
+        assert mock_client.async_get_usage_hourly.call_count == 2
+
+    async def test_fetch_range_sleeps_between_requests(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Per-day fetches are spaced so a chunk-of-7 doesn't fire in <1 s.
+
+        Closes #34: no inter-request sleep == 7 sequential GETs in a tight
+        loop, which AGL's BFF can rate-limit.
+        """
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.return_value = []
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        start = today - timedelta(days=3)
+        end = today - timedelta(days=1)  # 3 days → expect 2 sleeps
+
+        sleep_mock = AsyncMock()
+        with (
+            patch.object(coord, "_import_intervals", new_callable=AsyncMock),
+            patch("custom_components.haggle.coordinator.asyncio.sleep", new=sleep_mock),
+        ):
+            await coord._fetch_range(start, end, None, 0.0, 0.0)
+
+        # 3 fetches, 2 inter-request sleeps (no sleep before first).
+        assert mock_client.async_get_usage_hourly.call_count == 3
+        assert sleep_mock.await_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -436,8 +520,8 @@ class TestFetchAndImport:
     ) -> None:
         """First install: fetch_start = today - BACKFILL_DAYS."""
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -461,8 +545,8 @@ class TestFetchAndImport:
     async def test_chunk_limit_applied_to_range(self, hass: HomeAssistant) -> None:
         """fetch_end must be at most fetch_start + BACKFILL_CHUNK_DAYS - 1."""
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -489,8 +573,8 @@ class TestFetchAndImport:
     ) -> None:
         """When last_stat_date is 3 days ago, fetch_start = 2 days ago."""
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -513,8 +597,8 @@ class TestFetchAndImport:
     async def test_already_up_to_date_no_fetch(self, hass: HomeAssistant) -> None:
         """If last stat is yesterday, _fetch_range is not called."""
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -537,8 +621,8 @@ class TestFetchAndImport:
         from custom_components.haggle.coordinator import HaggleData
 
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -561,7 +645,7 @@ class TestFetchAndImport:
         from custom_components.haggle.agl.models import PlanRates
 
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
         mock_client.async_get_plan.return_value = PlanRates(
             product_name="Smart Saver",
             unit_rates=[
@@ -608,7 +692,7 @@ class TestNumericGuards:
             cost_label="$inf",
             projection_label="$nan",
         )
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -644,7 +728,7 @@ class TestNumericGuards:
             cost_label="$-99.99",
             projection_label="",
         )
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         today = datetime.now(UTC).date()
@@ -690,8 +774,8 @@ class TestUTCDateBoundary:
                 return fixed_utc.astimezone(tz) if tz else fixed_utc
 
         mock_client = AsyncMock()
-        mock_client.async_get_usage_summary.side_effect = NotImplementedError
-        mock_client.async_get_plan.side_effect = NotImplementedError
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
         coord = _make_coordinator(hass, client=mock_client)
 
         with (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -252,6 +252,44 @@ async def test_pin_check_with_no_pin_stays_silent(hass: HomeAssistant) -> None:
         mock_notify.assert_not_called()
 
 
+async def test_async_remove_entry_clears_orphan_entities(hass: HomeAssistant) -> None:
+    """Removing the integration must purge entity-registry rows for the entry.
+
+    Without this, reinstalling the integration finds a colliding entity_id
+    and renames the new sensor with a `_2` suffix, leaving an `unavailable`
+    orphan forever.
+    """
+    from homeassistant.helpers import entity_registry as er
+
+    from custom_components.haggle import async_remove_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=_ENTRY_DATA,
+        unique_id="1234567890_9999999999",
+    )
+    entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{entry.entry_id}_consumption_period_kwh",
+        config_entry=entry,
+    )
+    registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{entry.entry_id}_consumption_period_cost_aud",
+        config_entry=entry,
+    )
+    assert len(er.async_entries_for_config_entry(registry, entry.entry_id)) == 2
+
+    await async_remove_entry(hass, entry)
+
+    assert er.async_entries_for_config_entry(registry, entry.entry_id) == []
+
+
 def test_device_info_does_not_claim_agl_authorship() -> None:
     """HA's Service-info card renders DeviceInfo as `model by manufacturer`.
 


### PR DESCRIPTION
## Summary

Closes the open issue tail (excluding #54 license) in one branch.

- **#49** — drop invalid `state_class=MEASUREMENT` on the three MONETARY sensors (HA logs a warning every poll otherwise).
- **#34** — backfill loop now sleeps 0.5 s between per-day fetches and halts on `AGLRateLimitError` so the next 24 h cycle can resume from the gap.
- **#50** — implement `async_remove_entry` to purge entity-registry rows on integration removal, preventing `_2`-suffixed orphan sensors on reinstall.
- **#35** — overlap the two `_get_last_stat` calls via `asyncio.gather`. (HA's `get_last_statistics` only takes a single `statistic_id` — verified against 2026.4.4 source — so true batching wasn't possible.)
- **#37, #38** — drop unused `SCAN_INTERVAL_DAILY` / `_PLAN` / `TOKEN_REFRESH_MARGIN_SECONDS`; drop `__all__` re-export from `agl/client.py`; fix `agl/__init__.py` docstring; remove `NotImplementedError` catches and the `dict`-fallback branch in `HaggleEnergySensor.native_value` — neither was reachable from production code.

## Documentation updated
- [x] CHANGELOG.md — new entries under `[Unreleased]` (Fixed + Changed)
- [x] AGENTS.md — Repo Map updated (`__init__.py` exports `async_remove_entry`, coordinator description notes 429-aware throttled backfill)
- [x] AGENTS.md — three new "What NOT to Do" entries (MONETARY+MEASUREMENT, missing `async_remove_entry`, tight backfill loop)
- [x] AGL API facts — no changes needed; this branch did not alter API understanding
- [x] Memory files — N/A; nothing non-obvious to record beyond the AGENTS.md entries

## Test plan
- [ ] All existing tests pass (`uv run pytest`) — could not run locally (this sandbox lacks Python 3.14.2); CI will verify.
- [ ] mypy clean (`uv run mypy custom_components/haggle`)
- [x] Pre-commit hooks pass (ruff check + format clean locally)
- [x] New regression coverage:
  - `tests/test_init.py::test_async_remove_entry_clears_orphan_entities`
  - `tests/test_coordinator_statistics.py::TestFetchRange::test_fetch_range_halts_on_rate_limit`
  - `tests/test_coordinator_statistics.py::TestFetchRange::test_fetch_range_sleeps_between_requests`
- Existing coordinator tests updated: the prior `mock_client.async_get_usage_summary.side_effect = NotImplementedError` pattern relied on the dead catches removed in #38; tests now return real `BillPeriod` / `PlanRates` instances via `_empty_summary()` / `_empty_plan()` helpers.

Closes #34, #35, #37, #38, #49, #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiDS76VJkRQcFCBr8PHnPN)_