### PR TITLE
fix(sensor): use MEASUREMENT for unit_rate / supply_charge; drop MONETARY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,14 @@ The HA Energy dashboard requires:
 - **Don't pair `state_class=MEASUREMENT` with `device_class=MONETARY`.**
   HA validates this combination and logs a WARNING on every state update;
   only `None` or `TOTAL` are valid for MONETARY. Use `TOTAL` for cumulative
-  cost-over-period, leave unset for one-shots (forecast, current rate).
+  cost-over-period, leave unset for one-shot forecasts.
+- **Don't use `device_class=MONETARY` for unit prices.** MONETARY is for
+  cumulative amounts (`$87.38 of cost so far`), not rates (`$0.34/kWh`).
+  Pair the rate sensor with `state_class=MEASUREMENT` and a unit string
+  like `"AUD/kWh"` instead — HA's price-tracking integrations (Nordpool,
+  Tibber) follow the same pattern. Mixing MONETARY with no `state_class`
+  *also* triggers HA's `state_class_removed` Repair if the entity ever
+  reported stats under an earlier release.
 - **Implement `async_remove_entry` if the integration creates entities.**
   Otherwise deleting the integration leaves orphan entity-registry rows
   whose `config_entry_id` references the now-gone entry; reinstall causes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Fixed
+- **Clear `state_class_removed` Repairs on `unit_rate` / `supply_charge`.**
+  v0.2.0-beta.2 dropped `state_class=MEASUREMENT` from these to fix the
+  inverse warning (#49), but that triggered HA's `state_class_removed`
+  Repair on installs that had previously recorded stats. Root cause was
+  using `device_class=MONETARY` for unit prices in the first place —
+  MONETARY is for cumulative amounts, not rates. Drop MONETARY from
+  `unit_rate` / `supply_charge` and restore `state_class=MEASUREMENT`;
+  HA's price-tracking integrations (Nordpool, Tibber) use the same
+  pattern. `bill_projection` keeps MONETARY without `state_class` —
+  it's a forecast total, not a rate. Repairs banner clears on the next
+  coordinator update.
 
 ---
 

--- a/custom_components/haggle/sensor.py
+++ b/custom_components/haggle/sensor.py
@@ -73,25 +73,31 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement="AUD",
         suggested_display_precision=2,
     ),
-    # --- Forecast / rates (monetary) ---
-    # MONETARY device_class only accepts state_class None or TOTAL; these are
-    # one-shot values (forecast, current rate), so leave state_class unset.
+    # --- Forecast (monetary, no state_class) ---
+    # MONETARY device_class accepts only state_class None or TOTAL. The bill
+    # projection is a one-shot forecast (not a cumulative total), so unset.
     SensorEntityDescription(
         key=DATA_BILL_PROJECTION,
         translation_key="bill_projection",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="AUD",
     ),
+    # --- Rates (instantaneous prices) ---
+    # NOT MONETARY — that device_class is for cumulative amounts ($87.38 of
+    # cost so far this period), not unit prices. Keep state_class=MEASUREMENT
+    # so HA's recorder tracks min/mean/max in long-term statistics. Removing
+    # `device_class` loses the $-chip in the entity card UI; the unit string
+    # ("AUD/kWh", "AUD/day") still makes the meaning clear.
     SensorEntityDescription(
         key=DATA_UNIT_RATE,
         translation_key="unit_rate",
-        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="AUD/kWh",
     ),
     SensorEntityDescription(
         key=DATA_SUPPLY_CHARGE,
         translation_key="supply_charge",
-        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="AUD/day",
     ),
 )


### PR DESCRIPTION
## Summary

Closes the two `state_class_removed` Repairs on `sensor.*_unit_rate` and
`sensor.*_supply_charge` reported on the live install within hours of the
v0.2.0-beta.2 update.

## Root cause

beta.2 fixed #49 by dropping `state_class=MEASUREMENT` from three monetary
sensors, because HA rejects `MONETARY + MEASUREMENT` as an invalid combination.
That cleared the per-poll WARNING — but triggered a follow-on Repair on any
install that had previously recorded long-term statistics for those entities,
because removing `state_class` from a sensor that had been generating stats
orphans the historical rows.

Deeper cause: `device_class=MONETARY` was the wrong choice for `unit_rate`
and `supply_charge` from the start. MONETARY is for **cumulative amounts**
(`$87.38 of cost so far this period`), not **unit prices** (`$0.34 per kWh`).
HA's price-tracking integrations (Nordpool, Tibber) all use no `device_class`
+ `state_class=MEASUREMENT` + a unit string carrying the rate suffix.

## Changes

- `unit_rate` — drop `device_class=MONETARY`, add `state_class=MEASUREMENT`.
- `supply_charge` — drop `device_class=MONETARY`, add `state_class=MEASUREMENT`.
- `bill_projection` — unchanged. It IS a cumulative forecast amount, so
  `MONETARY` without `state_class` is the right pairing.
- `AGENTS.md § What NOT to Do` — new entry: "Don't use `MONETARY` for unit
  prices." Cross-links the Repair behaviour back to the design lesson.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Documentation updated
- [x] CHANGELOG.md — `[Unreleased] / Fixed`
- [x] AGENTS.md — new "What NOT to Do" prohibition
- [x] AGL API facts — N/A; integration code unchanged
- [x] Memory files — N/A

## Test plan
- [x] ruff check + format clean
- [x] mypy `--strict --warn-unreachable` clean
- [ ] CI green (Test/Hassfest/HACS/CodeQL/Analyze)
- [ ] After merge → cut `v0.2.0-beta.3` → reinstall on live HA →
      Repairs banner clears within one coordinator cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiDS76VJkRQcFCBr8PHnPN)_