### PR TITLE
chore(deps): roll Dependabot batch 2026-05-21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Platform floor bumped to Home Assistant 2026.5.3** (was `2026.5.1`).
+  Tracks the `pytest-homeassistant-custom-component` test harness
+  (`0.13.332` pins `homeassistant==2026.5.3`); the test fixture and the
+  runtime floor stay aligned. `hacs.json:homeassistant` updated to match.
+- **Dev-tooling floor bumped**: `pytest-cov>=7.1.0` (was `>=5.0`).
+- **CI action SHAs rolled forward**: `codecov/codecov-action v6.0.0 → v6.0.1`,
+  `github/codeql-action v4.35.4 → v4.35.5`. Both pinned to 40-char SHAs.
+- **`uv.lock` regeneration deferred to CI** — Python 3.14.2 unavailable in
+  the triage environment; `uv sync --extra dev` in CI will regenerate.
+
+Closes #75, #76, #77, #78, #79.
+
 ---
 
 ## [0.2.3] — 2026-05-15

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.5.3",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
+    "homeassistant>=2026.5.3",
     "aiohttp>=3.13.5",
 ]
 
@@ -34,10 +34,10 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
-    "pytest-cov>=5.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
+    "pytest-cov>=7.1.0",
+    # 0.13.332 pins homeassistant==2026.5.3 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
+    "pytest-homeassistant-custom-component>=0.13.332,<0.13.333",
     "ruff>=0.15.13",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",


### PR DESCRIPTION
Superseded by #81, which consolidates all six outstanding Dependabot PRs (this PR was a strict subset). Closing to keep the dep-rollup queue clean.