### PR TITLE
chore(deps): roll Dependabot batch 2026-05-22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Platform floor bumped to Home Assistant 2026.5.3** (was `2026.5.1`).
+  Tracks the `pytest-homeassistant-custom-component` test harness
+  (`0.13.332` pins `homeassistant==2026.5.3`); the test fixture and the
+  runtime floor stay aligned. `hacs.json:homeassistant` updated to match.
+- **`idna` bumped 3.13 → 3.15** (transitive dep via aiohttp).
+  3.14 closed CVE-2026-45409 (quadratic-time bypass of the CVE-2024-3651
+  mitigation); 3.15 adds DNS-label length enforcement.
+- **Dev-tooling floor bumped**: `pytest-cov>=7.1.0` (was `>=5.0`).
+- **CI action SHAs rolled forward**: `codecov/codecov-action v6.0.0 → v6.0.1`,
+  `github/codeql-action v4.35.4 → v4.35.5`. Both pinned to 40-char SHAs.
+
 ---
 
 ## [0.2.3] — 2026-05-15

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.5.3",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
+    "homeassistant>=2026.5.3",
     "aiohttp>=3.13.5",
 ]
 
@@ -34,10 +34,10 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
-    "pytest-cov>=5.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
+    "pytest-cov>=7.1.0",
+    # 0.13.332 pins homeassistant==2026.5.3 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
+    "pytest-homeassistant-custom-component>=0.13.332,<0.13.333",
     "ruff>=0.15.13",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1220,11 +1220,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Automated Dependabot rollup for 2026-05-22. Consolidates all six outstanding Dependabot PRs into a single branch, superseding the two partial rollups #74 and #80.

### Changes bundled

| PR | Change |
|---|---|
| #79 | `homeassistant>=2026.5.1` → `>=2026.5.3` (pyproject.toml + hacs.json) |
| #76 | `pytest-homeassistant-custom-component` `0.13.330..0.13.331` → `0.13.332..0.13.333` |
| #77 | `pytest-cov>=5.0` → `>=7.1.0` |
| #73 | `idna` 3.13 → 3.15 (uv.lock; closes CVE-2026-45409) |
| #75 | `codecov/codecov-action` v6.0.0 → v6.0.1 (SHA-pinned) |
| #78 | `github/codeql-action` v4.35.4 → v4.35.5 (SHA-pinned, 2 occurrences in codeql.yml) |

### Alignment invariant

`pytest-homeassistant-custom-component` 0.13.332 pins `homeassistant==2026.5.3`, matching the updated `homeassistant>=2026.5.3` runtime floor and `hacs.json:homeassistant`. Test harness and runtime floor remain in step (precedent: #70, #71, #74, #80).

### Pipeline status

- Ruff check + format: ✅ clean
- Manifest validation (hacs.json + manifest.json): ✅ valid
- mypy / pytest: deferred to CI — Python 3.14.2 unavailable in the triage environment
- `uv.lock`: hashes applied from Dependabot's verified diff; `uv sync --extra dev` in CI will re-resolve transitively

> **Note for reviewer**: PRs #74 and #80 can be closed once this PR merges (or earlier — they are strict subsets of this branch's changes).

Closes #73, #75, #76, #77, #78, #79.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uqW5qHbAAu4SpwJyJXQDM)_