### PR TITLE
chore(deps): roll Dependabot batch 2026-05-28 (safe subset)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:python"

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b # master@2026-04-07
+      - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658 # master@2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Platform floor bumped to Home Assistant 2026.5.4** (was `2026.5.1`).
+  Tracks the `pytest-homeassistant-custom-component` test harness
+  (`0.13.334` pins `homeassistant==2026.5.4`); the test fixture and the
+  runtime floor stay aligned. `hacs.json:homeassistant` updated to match.
+- **Dev-tooling floors bumped**: `ruff>=0.15.14` (was `>=0.15.13`),
+  `pytest-asyncio>=1.4.0` (was `>=0.24`), `pytest-cov>=7.1.0` (was `>=5.0`).
+  Pipeline runs clean against the existing codebase.
+- **Security patch**: `idna` 3.13 → 3.15 (uv.lock) — resolves CVE-2026-45409.
+- **GitHub Actions pinned SHAs updated**: `codeql-action` v4.35.4 → v4.36.0,
+  `codecov-action` v6.0.0 → v6.0.1, `home-assistant/actions/hassfest`
+  SHA updated to `868e6cb4`.
+
+Closes #73, #75, #77, #83, #84, #85, #86, #87, #88.
+
 ---
 
 ## [0.2.3] — 2026-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Platform floor bumped to Home Assistant 2026.5.4** (was `2026.5.1`).
-  Tracks the `pytest-homeassistant-custom-component` test harness
-  (`0.13.334` pins `homeassistant==2026.5.4`); the test fixture and the
-  runtime floor stay aligned. `hacs.json:homeassistant` updated to match.
-- **Dev-tooling floors bumped**: `ruff>=0.15.14` (was `>=0.15.13`),
-  `pytest-asyncio>=1.4.0` (was `>=0.24`), `pytest-cov>=7.1.0` (was `>=5.0`).
-  Pipeline runs clean against the existing codebase.
+- **Dev-tooling floor bumped**: `pytest-cov>=7.1.0` (was `>=5.0`); the
+  lock already had 7.1.0 so no re-resolve needed.
 - **Security patch**: `idna` 3.13 → 3.15 (uv.lock) — resolves CVE-2026-45409.
 - **GitHub Actions pinned SHAs updated**: `codeql-action` v4.35.4 → v4.36.0,
   `codecov-action` v6.0.0 → v6.0.1, `home-assistant/actions/hassfest`
   SHA updated to `868e6cb4`.
 
-Closes #73, #75, #77, #83, #84, #85, #86, #87, #88.
+Closes #73, #75, #77, #83, #85.
 
 ---
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.5.4",
   "render_readme": true,
   "zip_release": false
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.4",
+  "homeassistant": "2026.5.1",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,19 +26,19 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
+    "homeassistant>=2026.5.4",
     "aiohttp>=3.13.5",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "pytest-asyncio>=0.24",
-    "pytest-cov>=5.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
+    # 0.13.334 pins homeassistant==2026.5.4 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
-    "ruff>=0.15.13",
+    "pytest-homeassistant-custom-component>=0.13.334,<0.13.335",
+    "ruff>=0.15.14",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,19 +26,19 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.4",
+    "homeassistant>=2026.5.1",
     "aiohttp>=3.13.5",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "pytest-asyncio>=1.4.0",
+    "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
-    # 0.13.334 pins homeassistant==2026.5.4 — keep test harness aligned with
+    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.334,<0.13.335",
-    "ruff>=0.15.14",
+    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
+    "ruff>=0.15.13",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1220,11 +1220,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.383Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Automated Dependabot rollup for 2026-05-28. Applies the five lock-safe Dependabot PRs; four others are blocked (see below).

### Changes bundled

| PR | Change |
|---|---|
| #77 | `pytest-cov>=5.0` → `>=7.1.0` (lock already had 7.1.0; safe) |
| #73 | `idna` 3.13 → 3.15 (uv.lock hash from Dependabot diff; resolves CVE-2026-45409) |
| #85 | `github/codeql-action` v4.35.4 → v4.36.0 (SHA-pinned) |
| #75 | `codecov/codecov-action` v6.0.0 → v6.0.1 (SHA-pinned) |
| #83 | `home-assistant/actions/hassfest` SHA updated to `868e6cb4` |

### Blocked — needs human decision or Python 3.14.2

| PR | Reason |
|---|---|
| #88 | `phcc==0.13.334` requires `homeassistant==2026.6.0b0` (HA 2026.6 beta, not yet published on PyPI). Dependabot bumped too far. |
| #84 | `pytest-asyncio>=1.4.0` conflicts with phcc 0.13.334's hard pin of `pytest-asyncio==1.3.0`. Blocked until phcc ships a compatible version. |
| #86 | `homeassistant>=2026.5.4` — valid change, but bumping the floor makes `uv.lock` stale (locked at 2026.5.1) and `uv lock` requires Python 3.14.2 to re-resolve; triage env only has 3.14.0rc2. |
| #87 | `ruff>=0.15.14` — same: lock has 0.15.13, re-resolve needs Python 3.14.2. |

> **To unblock #86 and #87**: run `uv lock && uv sync --extra dev` locally (needs Python 3.14.2), then push the updated `uv.lock`.
>
> **To unblock #88/#84**: wait for phcc to release a version that pins a stable HA release; Dependabot will reopen with a compatible version.

### Supersedes

PR #81 (`chore/auto-deps-roll-2026-05-22`) is a strict subset of this branch and can be closed.

### Pipeline status

- Ruff check + format: ✅ (no .py files changed)
- Manifest validation: ✅ valid
- GitHub Actions CI: re-running after fix (initial run failed due to uv.lock/pyproject.toml inconsistency from the incompatible bumps, now reverted)

Closes #73, #75, #77, #83, #85.