### PR TITLE
feat: Time-of-Use tariff support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,7 @@ well-documented per-interval `consumption.type`. Only the per-tariff *rate
 sensors* rely on the plan-text heuristic. `tests/fixtures/tou_plan_response.json`
 is shape-extrapolated from `plan_response.json` (headers "Peak"/"Shoulder"/
 "Off Peak"); validate against a real ToU plan capture and correct the heuristic
-if AGL labels bands differently.
+if AGL labels bands differently (tracked in #90).
 
 ### TLS pinning (Trust-On-First-Use)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,15 +65,18 @@ tests/
 ├── fixtures/
 │   ├── hourly_response.json         # 30-min interval data (Current/Hourly)
 │   ├── overview_response.json       # /v3/overview with accounts + contracts
-│   ├── plan_response.json           # /v2/plan/energy with gstInclusiveRates
+│   ├── plan_response.json           # /v2/plan/energy with gstInclusiveRates (flat rate)
+│   ├── tou_plan_response.json       # Time-of-Use plan — per-band gstInclusiveRates
+│   ├── tou_hourly_response.json     # mixed peak/offpeak/shoulder/normal intervals
 │   └── bill_period_response.json    # usage summary
 ├── test_init.py                     # setup/unload smoke tests
 ├── test_config_flow.py              # PKCE step navigation (user → exchange → select_contract)
 ├── test_agl_client.py               # AglAuth token rotation + AglClient HTTP methods + pin-check wiring
 ├── test_const.py                    # base64 sanity-check on AGL_AUTH0_CLIENT
-├── test_parser.py                   # parse_interval_readings, parse_overview, parse_plan, _safe_float
+├── test_parser.py                   # parse_interval_readings, parse_overview, parse_plan, ToU rate mapping, _safe_float
 ├── test_pinning.py                  # SPKI extraction + host-name guards
-└── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, numeric guards
+├── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, ToU per-tariff series, numeric guards
+└── test_sensor.py                   # sensor descriptions + conditional ToU rate-sensor registration
 
 scripts/
 ├── wt                   # bash worktree helper (new / list / rm)
@@ -301,6 +304,19 @@ GET /mobile/bff/api/v2/plan/energy/{contractNumber}
 Returns `gstInclusiveRates` list with `c/kWh` and `c/day` entries. Supply charge
 is a `c/day` entry with `title` containing "Supply charge".
 
+**Time-of-Use rate mapping (heuristic — needs real-capture validation)**: AGL
+does not return a machine `tariffType` field on plan rates. ToU bands are
+inferred from the free-text `kind:"header"` row and the per-rate `title` via a
+keyword match (`parser._classify_tariff`: `shoulder` → shoulder; `off peak`/
+`off-peak`/`offpeak` → offpeak; then bare `peak` → peak; anything else → None,
+so unmatched bands surface as `unavailable`, never a misleading `0.0`). The
+**statistics split does NOT depend on this** — it is driven entirely by the
+well-documented per-interval `consumption.type`. Only the per-tariff *rate
+sensors* rely on the plan-text heuristic. `tests/fixtures/tou_plan_response.json`
+is shape-extrapolated from `plan_response.json` (headers "Peak"/"Shoulder"/
+"Off Peak"); validate against a real ToU plan capture and correct the heuristic
+if AGL labels bands differently.
+
 ### TLS pinning (Trust-On-First-Use)
 
 Both `secure.agl.com.au` and `api.platform.agl.com.au` are pinned by SPKI hash.
@@ -352,6 +368,20 @@ The HA Energy dashboard requires:
 - **`unit_class="energy"` is required** on the consumption statistic for it to appear in
   the Energy dashboard's "add consumption source" picker. `unit_class=None` silently excludes
   it from the UI filter even though the data is in the DB.
+- **Time-of-Use (ToU) per-tariff series**: on a contract whose interval data carries
+  `consumption.type` values other than `normal` (i.e. `peak`/`offpeak`/`shoulder`), the
+  coordinator ALSO writes one series per tariff type present, named band-distinctly:
+  - `haggle:consumption_<tariff>_<contract_number>` — kWh, `unit_class="energy"`, `has_sum=True`
+  - `haggle:cost_<tariff>_<contract_number>` — AUD, `unit_class=None`, `has_sum=True`
+
+  where `<tariff> ∈ {peak, offpeak, shoulder, normal}`. The per-tariff series sum back to
+  the aggregate (the `normal`/anytime band is included precisely so no kWh is lost). The
+  aggregate series is always written too, for backward compatibility.
+  - **Double-count warning**: a ToU user must add ONLY the per-tariff consumption series to
+    the Energy dashboard, NOT the aggregate `haggle:consumption_<contract>` as well — adding
+    both counts every kWh twice. Flat-rate users add only the aggregate (no per-tariff series
+    exist for them). Each band uses a stable, band-labelled `StatisticMetaData.name`
+    (`TARIFF_LABELS` in `const.py`) so the picker can tell them apart.
 - Resume point: `get_last_statistics(hass, 1, stat_id, True, {"start", "sum"})` — returns
   the last-imported hour so incremental updates don't re-import already-stored rows.
 - Each import call is idempotent: `(statistic_id, start)` updates in place.
@@ -376,6 +406,13 @@ The HA Energy dashboard requires:
   from Hourly or Daily usage requests returns HTTP 500 with no useful error body.
 - **Don't set `unit_class=None` on the consumption statistic** — HA's Energy dashboard
   consumption picker filters by `unit_class="energy"`. `None` silently hides the statistic.
+- **Don't add BOTH the aggregate and the per-tariff consumption series to the Energy
+  dashboard for one ToU contract** — they overlap (per-tariff series are a partition of the
+  aggregate), so adding both double-counts every kWh. The integration writes both for
+  backward compatibility; the docs/CHANGELOG tell ToU users to add only the per-tariff
+  series and flat-rate users to add only the aggregate. When adding a new per-tariff series,
+  always emit the `normal`/anytime band too (`TOU_SERIES_TARIFFS`) so the partition is
+  complete and no kWh silently vanishes from the breakdown.
 - **No committing directly to `main`** — the `guard-main-branch` hook blocks it.
   Use a feature branch + PR.
 - **No mutable GitHub Action refs** — pin every `uses: owner/action@…` to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Targets for next sprint
+
+- Promote `0.3.0-beta.1` to stable `0.3.0` after a live ToU soak.
+- #90 — validate the ToU plan rate-mapping heuristic against a real capture.
+- #91 — clear external statistics on integration removal.
+
+---
+
+## [0.3.0-beta.1] — 2026-05-29
+
 ### Added
 
 - **Time-of-Use (ToU) tariff support** (#82). On contracts whose AGL interval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Time-of-Use (ToU) tariff support** (#82). On contracts whose AGL interval
+  data is tagged with `peak`/`offpeak`/`shoulder` tariff types, the integration
+  now writes a separate consumption + cost statistic per tariff band
+  (`haggle:consumption_peak_<contract>`, `…_offpeak_…`, `…_shoulder_…`, plus a
+  `…_normal_…`/anytime band so the parts sum back to the aggregate). Each is an
+  independent Energy-dashboard source with `unit_class="energy"`.
+  - Adds per-tariff unit-rate sensors (peak/off-peak/shoulder, `AUD/kWh`,
+    `state_class=MEASUREMENT`), registered only on ToU contracts so flat-rate
+    users see no empty sensors.
+  - Flat-rate contracts are unchanged — only the existing aggregate
+    `haggle:consumption_<contract>` / `cost_<contract>` series are written.
+  - **Energy dashboard**: ToU users should add only the per-tariff consumption
+    series (not the aggregate as well) to avoid double-counting; flat-rate users
+    add only the aggregate.
+  - Switching an existing flat-rate contract to a ToU plan: the per-tariff
+    statistics appear automatically on the next poll; the integration schedules
+    a one-off reload so the new per-tariff rate sensors register.
+
+### Fixed
+
+- Corrected stale code comments that named `consumption.values.quantity` (inner,
+  DPI-scaled) as the kWh source of truth in `models.py` and `client.py`; the
+  metered value is `consumption.quantity` (outer), as the parser already used.
+
 ---
 
 ## [0.2.3] — 2026-05-15

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -281,7 +281,8 @@ class AglClient:
         """Fetch /Hourly for a single day (30-min intervals).
 
         Use `day == yesterday` for reliable data; today will be empty.
-        Field to use: consumption.values.quantity (kWh), NOT consumption.quantity.
+        Field to use: consumption.quantity (outer) for kWh, NOT
+        consumption.values.quantity (inner DPI/chart-scaled helper).
         dateTime is slot-start in UTC.
         """
         period = f"{day}_{day}"

--- a/custom_components/haggle/agl/models.py
+++ b/custom_components/haggle/agl/models.py
@@ -37,8 +37,8 @@ class IntervalReading:
     """One 30-minute interval reading from /Hourly."""
 
     dt: datetime  # slot start, UTC
-    kwh: float  # consumption.values.quantity — source of truth
-    cost_aud: float  # consumption.amount
+    kwh: float  # consumption.quantity (outer) — source of truth, matches AEMO/CSV
+    cost_aud: float  # consumption.amount (outer)
     rate_type: str  # "normal" | "peak" | "offpeak" | "shoulder" | "none"
 
 
@@ -69,3 +69,7 @@ class PlanRates:
     product_name: str
     unit_rates: list[dict[str, Any]] = field(default_factory=list)
     supply_charge_cents_per_day: float = 0.0
+    # Time-of-Use unit rates, tariff type → c/kWh, e.g. {"peak": 41.9, ...}.
+    # Empty for flat-rate plans. Populated by parse_plan's title/header
+    # heuristic (see parser.py); absent bands are simply not keyed.
+    tou_unit_rates: dict[str, float] = field(default_factory=dict)

--- a/custom_components/haggle/agl/models.py
+++ b/custom_components/haggle/agl/models.py
@@ -69,7 +69,5 @@ class PlanRates:
     product_name: str
     unit_rates: list[dict[str, Any]] = field(default_factory=list)
     supply_charge_cents_per_day: float = 0.0
-    # Time-of-Use unit rates, tariff type → c/kWh, e.g. {"peak": 41.9, ...}.
-    # Empty for flat-rate plans. Populated by parse_plan's title/header
-    # heuristic (see parser.py); absent bands are simply not keyed.
+    # Time-of-Use unit rates, tariff type → c/kWh; empty for flat-rate plans.
     tou_unit_rates: dict[str, float] = field(default_factory=dict)

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -35,11 +35,10 @@ def _classify_tariff(text: str) -> str | None:
     Heuristic — AGL's plan endpoint groups c/kWh detail rows under free-text
     `kind:"header"` rows (e.g. "Peak", "Off Peak", "Shoulder") rather than a
     machine tariff-type field. Order matters: "off peak" must be tested before
-    the bare "peak" substring. Returns None for general/flat usage rows so the
-    caller leaves the band unkeyed (a missing rate surfaces as `unavailable`,
-    never a misleading 0.0). See AGENTS.md §AGL API — this mapping is
-    extrapolated from the documented response shape and wants validation
-    against a real ToU plan capture (tracked upstream).
+    the bare "peak" substring. Returns None for general/flat usage rows so an
+    unmatched band surfaces as `unavailable`, never a misleading 0.0. The
+    keyword mapping is extrapolated from the documented response shape (see
+    AGENTS.md §AGL API).
     """
     t = text.lower()
     if "shoulder" in t:

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -23,9 +23,32 @@ import math
 from datetime import UTC, date, datetime
 from typing import Any
 
+from ..const import TARIFF_OFFPEAK, TARIFF_PEAK, TARIFF_SHOULDER
 from .models import BillPeriod, Contract, DailyReading, IntervalReading, PlanRates
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _classify_tariff(text: str) -> str | None:
+    """Map a plan rate's header/title text to a ToU tariff band, or None.
+
+    Heuristic — AGL's plan endpoint groups c/kWh detail rows under free-text
+    `kind:"header"` rows (e.g. "Peak", "Off Peak", "Shoulder") rather than a
+    machine tariff-type field. Order matters: "off peak" must be tested before
+    the bare "peak" substring. Returns None for general/flat usage rows so the
+    caller leaves the band unkeyed (a missing rate surfaces as `unavailable`,
+    never a misleading 0.0). See AGENTS.md §AGL API — this mapping is
+    extrapolated from the documented response shape and wants validation
+    against a real ToU plan capture (tracked upstream).
+    """
+    t = text.lower()
+    if "shoulder" in t:
+        return TARIFF_SHOULDER
+    if "off peak" in t or "off-peak" in t or "offpeak" in t:
+        return TARIFF_OFFPEAK
+    if "peak" in t:
+        return TARIFF_PEAK
+    return None
 
 
 def _safe_float(raw: Any) -> float:
@@ -174,21 +197,37 @@ def parse_plan(data: dict[str, Any]) -> PlanRates:
     product_name: str = data.get("productName", "")
     unit_rates: list[dict[str, Any]] = []
     supply_charge: float = 0.0
+    tou_unit_rates: dict[str, float] = {}
+    # AGL groups detail rows under free-text `kind:"header"` rows; track the
+    # most recent header so a ToU band ("Peak"/"Off Peak"/"Shoulder") can be
+    # inferred even when the per-rate title is generic ("First N kWh").
+    current_header = ""
 
     for rate in data.get("gstInclusiveRates") or []:
-        if rate.get("kind") != "detail":
+        kind = rate.get("kind")
+        if kind == "header":
+            current_header = rate.get("title") or ""
+            continue
+        if kind != "detail":
             continue
         rate_type: str = rate.get("type", "")
         price = _safe_float(rate.get("price"))
-        if rate_type == "c/day" and "supply" in (rate.get("title") or "").lower():
+        title: str = rate.get("title") or ""
+        if rate_type == "c/day" and "supply" in title.lower():
             supply_charge = price
+        if rate_type == "c/kWh":
+            band = _classify_tariff(f"{current_header} {title}")
+            # First matching rate per band wins; AGL repeats the same c/kWh
+            # across tiered "First N kWh" / "Thereafter" rows.
+            if band is not None and band not in tou_unit_rates:
+                tou_unit_rates[band] = price
         # Allowlist the four fields the coordinator actually consumes — drops
         # any extra keys an attacker-controlled (MITM) response could inject.
         unit_rates.append(
             {
-                "kind": rate.get("kind"),
+                "kind": kind,
                 "type": rate_type,
-                "title": rate.get("title"),
+                "title": title,
                 "price": price,
             }
         )
@@ -197,4 +236,5 @@ def parse_plan(data: dict[str, Any]) -> PlanRates:
         product_name=product_name,
         unit_rates=unit_rates,
         supply_charge_cents_per_day=supply_charge,
+        tou_unit_rates=tou_unit_rates,
     )

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -93,6 +93,33 @@ AGL_SCALING: Final = "36.514404_108.057_40.670903_120.357_0_0_0_0"
 STAT_CONSUMPTION: Final = "consumption"  # → haggle:consumption_{contract}
 STAT_COST: Final = "cost"  # → haggle:cost_{contract}
 
+# Time-of-Use tariff types — the value of `consumption.type` on each interval.
+TARIFF_PEAK: Final = "peak"
+TARIFF_OFFPEAK: Final = "offpeak"
+TARIFF_SHOULDER: Final = "shoulder"
+TARIFF_NORMAL: Final = "normal"
+# Presence of ANY of these in interval data marks the contract as Time-of-Use.
+TOU_BANDS: Final = (TARIFF_PEAK, TARIFF_OFFPEAK, TARIFF_SHOULDER)
+# On a ToU contract, every tariff type that appears gets its own statistic
+# series (incl. `normal`/anytime) so the per-tariff series sum back to the
+# aggregate with no lost kWh. Per-tariff statistic IDs are
+# f"{DOMAIN}:{STAT_CONSUMPTION}_{tariff}_{contract}" / "..._{STAT_COST}_...".
+TOU_SERIES_TARIFFS: Final = (
+    TARIFF_PEAK,
+    TARIFF_OFFPEAK,
+    TARIFF_SHOULDER,
+    TARIFF_NORMAL,
+)
+# Stable, band-distinct labels embedded in StatisticMetaData.name so the
+# Energy dashboard picker can tell the per-tariff series apart. MUST be stable
+# across calls — the recorder updates metadata in place on every import.
+TARIFF_LABELS: Final = {
+    TARIFF_PEAK: "Peak",
+    TARIFF_OFFPEAK: "Off-Peak",
+    TARIFF_SHOULDER: "Shoulder",
+    TARIFF_NORMAL: "Anytime",
+}
+
 # Config-entry keys.
 # CONF_EMAIL / CONF_PASSWORD are NOT used — auth is via refresh token.
 CONF_REFRESH_TOKEN: Final = "refresh_token"  # ← it IS a token key
@@ -110,3 +137,7 @@ DATA_CONSUMPTION_COST: Final = "consumption_period_cost_aud"  # cumulative AUD c
 DATA_BILL_PROJECTION: Final = "bill_projection_aud"  # AUD forecast for current period
 DATA_UNIT_RATE: Final = "unit_rate_aud_per_kwh"  # AUD/kWh
 DATA_SUPPLY_CHARGE: Final = "supply_charge_aud_per_day"  # AUD/day
+# Per-tariff unit rates (AUD/kWh) — only populated/registered on ToU contracts.
+DATA_UNIT_RATE_PEAK: Final = "unit_rate_peak_aud_per_kwh"
+DATA_UNIT_RATE_OFFPEAK: Final = "unit_rate_offpeak_aud_per_kwh"
+DATA_UNIT_RATE_SHOULDER: Final = "unit_rate_shoulder_aud_per_kwh"

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -85,9 +85,9 @@ class HaggleData:
     unit_rate_aud_per_kwh: float | None
     supply_charge_aud_per_day: float | None
     latest_cumulative_kwh: float  # for the TOTAL_INCREASING sensor
-    # ToU extras (defaulted so existing construction sites/tests are unaffected).
-    # active_tariffs drives conditional ToU rate-sensor registration in
-    # sensor.py; empty on a flat-rate contract so those sensors never appear.
+    # ToU extras, defaulted to keep the dataclass backward-compatible.
+    # active_tariffs gates conditional ToU rate-sensor registration; empty on a
+    # flat-rate contract so those sensors never appear.
     active_tariffs: frozenset[str] = frozenset()
     unit_rate_peak_aud_per_kwh: float | None = None
     unit_rate_offpeak_aud_per_kwh: float | None = None
@@ -376,27 +376,32 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     ) -> tuple[set[str], dict[str, tuple[float, float]]]:
         """Return (known ToU bands, per-tariff baseline sums) for this cycle.
 
-        Single recorder-touching entry point for the ToU machinery, so unit
-        tests can stub it in one place. `known_bands` marks the contract as
-        Time-of-Use across restarts; the baselines resume each per-tariff
-        series from its OWN stored cumulative at the SAME fetch_start as the
-        aggregate (never the aggregate's sum, never the per-tariff series' own
-        last date). First install (no prior aggregate row) → no baselines.
+        Single recorder-touching entry point for the ToU machinery.
+        `known_bands` marks the contract as Time-of-Use across restarts; the
+        baselines resume each per-tariff series from its OWN stored cumulative
+        at the SAME fetch_start as the aggregate (never the aggregate's sum,
+        never the per-tariff series' own last date). First install (no prior
+        aggregate row) → no baselines needed.
         """
-        known_bands = await self._get_stored_tou_bands()
-        tariff_initial_sums: dict[str, tuple[float, float]] = {}
-        if last_stat_date is not None:
-            fetch_start_utc = datetime.combine(fetch_start, time.min, tzinfo=UTC)
-            band_ids: set[str] = set()
-            for tariff in TOU_SERIES_TARIFFS:
-                band_ids.update(self._tariff_stat_ids(tariff))
-            band_sums = await self._get_tariff_baseline_sums(band_ids, fetch_start_utc)
-            for tariff in TOU_SERIES_TARIFFS:
-                cons_id, cost_id = self._tariff_stat_ids(tariff)
-                tariff_initial_sums[tariff] = (
-                    band_sums.get(cons_id, 0.0),
-                    band_sums.get(cost_id, 0.0),
-                )
+        if last_stat_date is None:
+            return await self._get_stored_tou_bands(), {}
+
+        fetch_start_utc = datetime.combine(fetch_start, time.min, tzinfo=UTC)
+        band_ids: set[str] = set()
+        for tariff in TOU_SERIES_TARIFFS:
+            band_ids.update(self._tariff_stat_ids(tariff))
+        # Independent lookups — overlap them on the executor.
+        known_bands, band_sums = await asyncio.gather(
+            self._get_stored_tou_bands(),
+            self._get_tariff_baseline_sums(band_ids, fetch_start_utc),
+        )
+        tariff_initial_sums = {
+            tariff: (
+                band_sums.get(self._tariff_stat_ids(tariff)[0], 0.0),
+                band_sums.get(self._tariff_stat_ids(tariff)[1], 0.0),
+            )
+            for tariff in TOU_SERIES_TARIFFS
+        }
         return known_bands, tariff_initial_sums
 
     async def _get_tariff_baseline_sums(
@@ -528,8 +533,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     ) -> None:
         """Aggregate 30-min intervals to hourly and push to recorder statistics.
 
-        Always writes the aggregate consumption + cost series (consumption
-        first, cost second — callers/tests depend on that order). On a ToU
+        Always writes the aggregate consumption + cost series. On a ToU
         contract — when any peak/offpeak/shoulder interval has ever been seen
         (`known_bands`) or appears in this batch — it ALSO writes a per-tariff
         series for every tariff type present, so the per-tariff series sum back
@@ -568,63 +572,57 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 bk[h] = bk.get(h, 0.0) + r.cost_aud
                 bands_this_batch.add(r.rate_type)
 
-        def _build(
-            hourly: dict[datetime, float], initial_sum: float
-        ) -> tuple[list[StatisticData], float]:
+        def _emit_series(
+            stat_id: str,
+            name: str,
+            unit: str,
+            unit_class: str | None,
+            hourly: dict[datetime, float],
+            initial_sum: float,
+        ) -> float:
+            """Build the cumulative hourly rows for one series and import them."""
             running = initial_sum
             stats: list[StatisticData] = []
             for h in sorted(hourly):
                 running += hourly[h]
                 stats.append(StatisticData(start=h, state=hourly[h], sum=running))
-            return stats, running
-
-        def _emit_consumption(
-            stat_id: str, name: str, stats: list[StatisticData]
-        ) -> None:
             async_add_external_statistics(
                 self.hass,
                 StatisticMetaData(
                     mean_type=StatisticMeanType.NONE,
-                    unit_class="energy",
+                    unit_class=unit_class,
                     has_sum=True,
                     name=name,
                     source=DOMAIN,
                     statistic_id=stat_id,
-                    unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                    unit_of_measurement=unit,
                 ),
                 stats,
             )
+            return running
 
-        def _emit_cost(stat_id: str, name: str, stats: list[StatisticData]) -> None:
-            async_add_external_statistics(
-                self.hass,
-                StatisticMetaData(
-                    mean_type=StatisticMeanType.NONE,
-                    unit_class=None,
-                    has_sum=True,
-                    name=name,
-                    source=DOMAIN,
-                    statistic_id=stat_id,
-                    unit_of_measurement="AUD",
-                ),
-                stats,
-            )
+        kwh = UnitOfEnergy.KILO_WATT_HOUR
+        contract = self.contract_number
 
-        # --- Aggregate series (always; consumption first, cost second). ---
-        cons_stats, cons_sum = _build(hour_cons, initial_cons_sum)
-        cost_stats, _ = _build(hour_cost, initial_cost_sum)
-        _emit_consumption(
-            f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}",
-            f"AGL Electricity Consumption ({self.contract_number})",
-            cons_stats,
+        # Aggregate series (always; consumption first, then cost).
+        cons_sum = _emit_series(
+            f"{DOMAIN}:{STAT_CONSUMPTION}_{contract}",
+            f"AGL Electricity Consumption ({contract})",
+            kwh,
+            "energy",
+            hour_cons,
+            initial_cons_sum,
         )
-        _emit_cost(
-            f"{DOMAIN}:{STAT_COST}_{self.contract_number}",
-            f"AGL Electricity Cost ({self.contract_number})",
-            cost_stats,
+        _emit_series(
+            f"{DOMAIN}:{STAT_COST}_{contract}",
+            f"AGL Electricity Cost ({contract})",
+            "AUD",
+            None,
+            hour_cost,
+            initial_cost_sum,
         )
 
-        # --- Per-tariff series (ToU contracts only). ---
+        # Per-tariff series (ToU contracts only).
         tou_seen = (set(known_bands) | bands_this_batch) & set(TOU_BANDS)
         if tou_seen:
             self._active_tou_bands |= tou_seen
@@ -633,20 +631,24 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                     continue
                 cons_id, cost_id = self._tariff_stat_ids(tariff)
                 base_cons, base_cost = tariff_initial_sums.get(tariff, (0.0, 0.0))
-                t_cons_stats, _ = _build(band_cons[tariff], base_cons)
-                t_cost_stats, _ = _build(band_cost[tariff], base_cost)
                 label = TARIFF_LABELS.get(tariff, tariff.title())
-                _emit_consumption(
+                _emit_series(
                     cons_id,
-                    f"AGL Electricity Consumption {label} ({self.contract_number})",
-                    t_cons_stats,
+                    f"AGL Electricity Consumption {label} ({contract})",
+                    kwh,
+                    "energy",
+                    band_cons[tariff],
+                    base_cons,
                 )
-                _emit_cost(
+                _emit_series(
                     cost_id,
-                    f"AGL Electricity Cost {label} ({self.contract_number})",
-                    t_cost_stats,
+                    f"AGL Electricity Cost {label} ({contract})",
+                    "AUD",
+                    None,
+                    band_cost[tariff],
+                    base_cost,
                 )
 
         # Update the in-memory cumulative for the TOTAL_INCREASING sensor.
-        if cons_stats:
+        if hour_cons:
             self._latest_cumulative_kwh = cons_sum

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -45,6 +45,12 @@ from .const import (
     SCAN_INTERVAL_HOURLY,
     STAT_CONSUMPTION,
     STAT_COST,
+    TARIFF_LABELS,
+    TARIFF_OFFPEAK,
+    TARIFF_PEAK,
+    TARIFF_SHOULDER,
+    TOU_BANDS,
+    TOU_SERIES_TARIFFS,
 )
 
 if TYPE_CHECKING:
@@ -79,6 +85,13 @@ class HaggleData:
     unit_rate_aud_per_kwh: float | None
     supply_charge_aud_per_day: float | None
     latest_cumulative_kwh: float  # for the TOTAL_INCREASING sensor
+    # ToU extras (defaulted so existing construction sites/tests are unaffected).
+    # active_tariffs drives conditional ToU rate-sensor registration in
+    # sensor.py; empty on a flat-rate contract so those sensors never appear.
+    active_tariffs: frozenset[str] = frozenset()
+    unit_rate_peak_aud_per_kwh: float | None = None
+    unit_rate_offpeak_aud_per_kwh: float | None = None
+    unit_rate_shoulder_aud_per_kwh: float | None = None
 
 
 class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
@@ -103,6 +116,19 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         self.client = client
         self.contract_number = contract_number
         self._latest_cumulative_kwh: float = 0.0
+        # ToU bands (peak/offpeak/shoulder) known to have statistics for this
+        # contract. Monotonic within a process; seeded from stored rows each
+        # cycle so it survives restarts. Drives rate-sensor registration and
+        # the schedule-reload-on-growth path in _maybe_reload_for_new_tariffs.
+        self._active_tou_bands: set[str] = set()
+        self._prev_active_tou_bands: set[str] = set()
+
+    def _tariff_stat_ids(self, tariff: str) -> tuple[str, str]:
+        """Return (consumption_id, cost_id) for a per-tariff series."""
+        return (
+            f"{DOMAIN}:{STAT_CONSUMPTION}_{tariff}_{self.contract_number}",
+            f"{DOMAIN}:{STAT_COST}_{tariff}_{self.contract_number}",
+        )
 
     async def _async_setup(self) -> None:
         """No-op: first-install backfill is handled incrementally in _fetch_and_import."""
@@ -158,6 +184,19 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # bumps it forward when the import produces new rows.
         self._latest_cumulative_kwh = last_cons_sum or 0.0
 
+        # Resolve per-tariff baselines at the SAME fetch_start as the aggregate
+        # so each per-tariff series resumes from its own stored cumulative
+        # (never the aggregate's, and never the per-tariff series' own last
+        # date). Skipped on first install (no prior rows anywhere → all 0.0).
+        # known_bands = ToU bands that already have stored statistics, so the
+        # `normal`/anytime per-tariff series is only emitted on a contract that
+        # has been seen using ToU (keeps flat-rate contracts on the aggregate
+        # series alone).
+        known_bands, tariff_initial_sums = await self._resolve_tou_state(
+            fetch_start, last_stat_date
+        )
+        self._active_tou_bands |= known_bands
+
         if fetch_start <= yesterday:
             await self._fetch_range(
                 fetch_start,
@@ -165,6 +204,8 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 bill_start,
                 initial_cons_sum=initial_cons_sum,
                 initial_cost_sum=initial_cost_sum,
+                tariff_initial_sums=tariff_initial_sums,
+                known_bands=frozenset(self._active_tou_bands),
             )
 
         # Extract rates from plan.
@@ -178,6 +219,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         supply_charge_aud: float | None = None
         if plan.supply_charge_cents_per_day:
             supply_charge_aud = plan.supply_charge_cents_per_day / 100.0
+
+        # Per-tariff rates: cents/kWh → AUD/kWh. Absent bands stay None (the
+        # sensor reads `unavailable`), never a misleading 0.0.
+        def _tou_rate(tariff: str) -> float | None:
+            cents = plan.tou_unit_rates.get(tariff)
+            return cents / 100.0 if cents is not None else None
+
+        # A new ToU band appearing after first refresh means rate sensors need
+        # to be added; schedule a (loop-safe, monotonic-growth) reload.
+        self._maybe_reload_for_new_tariffs()
 
         # Parse bill-period totals.
         projection: float | None = None
@@ -196,7 +247,32 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             unit_rate_aud_per_kwh=unit_rate_aud,
             supply_charge_aud_per_day=supply_charge_aud,
             latest_cumulative_kwh=self._latest_cumulative_kwh,
+            active_tariffs=frozenset(self._active_tou_bands),
+            unit_rate_peak_aud_per_kwh=_tou_rate(TARIFF_PEAK),
+            unit_rate_offpeak_aud_per_kwh=_tou_rate(TARIFF_OFFPEAK),
+            unit_rate_shoulder_aud_per_kwh=_tou_rate(TARIFF_SHOULDER),
         )
+
+    def _maybe_reload_for_new_tariffs(self) -> None:
+        """Schedule a reload when a ToU band first appears after first refresh.
+
+        ToU rate sensors are registered conditionally at platform setup from
+        `active_tariffs`, so a flat-rate contract that later switches to a ToU
+        plan would not surface the new rate sensors until the entry reloads.
+        We schedule one then. Loop-safe: `_active_tou_bands` only ever grows
+        (it is seeded from stored statistics), so the growth condition fires at
+        most once per band. The very first refresh (`self.data is None`) never
+        reloads — the platform is set up fresh straight after it.
+        """
+        new_bands = self._active_tou_bands - self._prev_active_tou_bands
+        self._prev_active_tou_bands = set(self._active_tou_bands)
+        if self.data is not None and new_bands:
+            _LOGGER.info(
+                "New ToU tariff band(s) %s detected; scheduling reload to add "
+                "rate sensors",
+                sorted(new_bands),
+            )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
     async def _resolve_resume_point(
         self,
@@ -295,6 +371,97 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
 
         return _last_sum(stat_id_cons), _last_sum(stat_id_cost)
 
+    async def _resolve_tou_state(
+        self, fetch_start: date, last_stat_date: date | None
+    ) -> tuple[set[str], dict[str, tuple[float, float]]]:
+        """Return (known ToU bands, per-tariff baseline sums) for this cycle.
+
+        Single recorder-touching entry point for the ToU machinery, so unit
+        tests can stub it in one place. `known_bands` marks the contract as
+        Time-of-Use across restarts; the baselines resume each per-tariff
+        series from its OWN stored cumulative at the SAME fetch_start as the
+        aggregate (never the aggregate's sum, never the per-tariff series' own
+        last date). First install (no prior aggregate row) → no baselines.
+        """
+        known_bands = await self._get_stored_tou_bands()
+        tariff_initial_sums: dict[str, tuple[float, float]] = {}
+        if last_stat_date is not None:
+            fetch_start_utc = datetime.combine(fetch_start, time.min, tzinfo=UTC)
+            band_ids: set[str] = set()
+            for tariff in TOU_SERIES_TARIFFS:
+                band_ids.update(self._tariff_stat_ids(tariff))
+            band_sums = await self._get_tariff_baseline_sums(band_ids, fetch_start_utc)
+            for tariff in TOU_SERIES_TARIFFS:
+                cons_id, cost_id = self._tariff_stat_ids(tariff)
+                tariff_initial_sums[tariff] = (
+                    band_sums.get(cons_id, 0.0),
+                    band_sums.get(cost_id, 0.0),
+                )
+        return known_bands, tariff_initial_sums
+
+    async def _get_tariff_baseline_sums(
+        self, stat_ids: set[str], before_dt: datetime
+    ) -> dict[str, float]:
+        """Return {stat_id: cumulative sum at the last hour strictly before before_dt}.
+
+        Batched (one recorder call for all per-tariff series) so adding ToU
+        doesn't multiply executor round-trips. Looks back BACKFILL_DAYS — wide
+        enough that a sparse band (e.g. shoulder only on weekdays) still finds
+        its true last sum rather than resetting to 0.0. Series with no rows in
+        the window return 0.0.
+        """
+        if not stat_ids:
+            return {}
+        from homeassistant.components.recorder.statistics import (
+            statistics_during_period,
+        )
+        from homeassistant.helpers.recorder import get_instance
+
+        look_back = before_dt - timedelta(days=BACKFILL_DAYS)
+        result = await get_instance(self.hass).async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            look_back,
+            before_dt,
+            set(stat_ids),
+            "hour",
+            None,
+            {"sum"},
+        )
+        out: dict[str, float] = {}
+        for stat_id in stat_ids:
+            rows = result.get(stat_id) or []
+            last = rows[-1].get("sum") if rows else None
+            out[stat_id] = float(last) if last is not None else 0.0
+        return out
+
+    async def _get_stored_tou_bands(self) -> set[str]:
+        """Return the ToU bands (peak/offpeak/shoulder) that already have stats.
+
+        Used to mark a contract as Time-of-Use across restarts: a band is
+        "stored" if its consumption series has any rows within the backfill
+        window. One batched recorder call over the three band series.
+        """
+        from homeassistant.components.recorder.statistics import (
+            statistics_during_period,
+        )
+        from homeassistant.helpers.recorder import get_instance
+
+        id_to_band = {self._tariff_stat_ids(band)[0]: band for band in TOU_BANDS}
+        now = datetime.now(UTC)
+        look_back = now - timedelta(days=BACKFILL_DAYS + 1)
+        result = await get_instance(self.hass).async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            look_back,
+            now,
+            set(id_to_band),
+            "hour",
+            None,
+            {"sum"},
+        )
+        return {band for stat_id, band in id_to_band.items() if result.get(stat_id)}
+
     async def _fetch_range(
         self,
         start: date,
@@ -302,6 +469,8 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         bill_start: date | None,
         initial_cons_sum: float,
         initial_cost_sum: float,
+        tariff_initial_sums: dict[str, tuple[float, float]] | None = None,
+        known_bands: frozenset[str] = frozenset(),
     ) -> None:
         """Fetch [start..end] with smart endpoint selection, then import.
 
@@ -338,7 +507,11 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
 
         if all_intervals:
             await self._import_intervals(
-                all_intervals, initial_cons_sum, initial_cost_sum
+                all_intervals,
+                initial_cons_sum,
+                initial_cost_sum,
+                tariff_initial_sums=tariff_initial_sums,
+                known_bands=known_bands,
             )
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave _latest_cumulative_kwh as the caller seeded it — the
@@ -349,8 +522,20 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         intervals: list[IntervalReading],
         initial_cons_sum: float,
         initial_cost_sum: float,
+        *,
+        tariff_initial_sums: dict[str, tuple[float, float]] | None = None,
+        known_bands: frozenset[str] = frozenset(),
     ) -> None:
-        """Aggregate 30-min intervals to hourly and push to recorder statistics."""
+        """Aggregate 30-min intervals to hourly and push to recorder statistics.
+
+        Always writes the aggregate consumption + cost series (consumption
+        first, cost second — callers/tests depend on that order). On a ToU
+        contract — when any peak/offpeak/shoulder interval has ever been seen
+        (`known_bands`) or appears in this batch — it ALSO writes a per-tariff
+        series for every tariff type present, so the per-tariff series sum back
+        to the aggregate with no lost kWh. Flat-rate contracts (only `normal`)
+        get the aggregate series alone, exactly as before.
+        """
         # Local imports: recorder must not be imported at module level.
         from homeassistant.components.recorder.models import (
             StatisticData,
@@ -362,56 +547,105 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         from homeassistant.const import UnitOfEnergy
 
-        # Aggregate 30-min slots into hourly UTC buckets.
+        tariff_initial_sums = tariff_initial_sums or {}
+
+        # Aggregate hourly buckets (all intervals) + per-tariff hourly buckets.
         hour_cons: dict[datetime, float] = {}
         hour_cost: dict[datetime, float] = {}
+        band_cons: dict[str, dict[datetime, float]] = {}
+        band_cost: dict[str, dict[datetime, float]] = {}
+        bands_this_batch: set[str] = set()
         for r in intervals:
             h = r.dt.replace(minute=0, second=0, microsecond=0)
             hour_cons[h] = hour_cons.get(h, 0.0) + r.kwh
             hour_cost[h] = hour_cost.get(h, 0.0) + r.cost_aud
+            if r.rate_type in TOU_SERIES_TARIFFS:
+                band_cons.setdefault(r.rate_type, {})
+                band_cost.setdefault(r.rate_type, {})
+                bc = band_cons[r.rate_type]
+                bk = band_cost[r.rate_type]
+                bc[h] = bc.get(h, 0.0) + r.kwh
+                bk[h] = bk.get(h, 0.0) + r.cost_aud
+                bands_this_batch.add(r.rate_type)
 
-        sorted_hours = sorted(hour_cons)
-        cons_sum = initial_cons_sum
-        cost_sum = initial_cost_sum
-        cons_stats: list[StatisticData] = []
-        cost_stats: list[StatisticData] = []
+        def _build(
+            hourly: dict[datetime, float], initial_sum: float
+        ) -> tuple[list[StatisticData], float]:
+            running = initial_sum
+            stats: list[StatisticData] = []
+            for h in sorted(hourly):
+                running += hourly[h]
+                stats.append(StatisticData(start=h, state=hourly[h], sum=running))
+            return stats, running
 
-        for h in sorted_hours:
-            cons_sum += hour_cons[h]
-            cost_sum += hour_cost[h]
-            cons_stats.append(StatisticData(start=h, state=hour_cons[h], sum=cons_sum))
-            cost_stats.append(StatisticData(start=h, state=hour_cost[h], sum=cost_sum))
+        def _emit_consumption(
+            stat_id: str, name: str, stats: list[StatisticData]
+        ) -> None:
+            async_add_external_statistics(
+                self.hass,
+                StatisticMetaData(
+                    mean_type=StatisticMeanType.NONE,
+                    unit_class="energy",
+                    has_sum=True,
+                    name=name,
+                    source=DOMAIN,
+                    statistic_id=stat_id,
+                    unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                ),
+                stats,
+            )
 
-        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}"
-        stat_id_cost = f"{DOMAIN}:{STAT_COST}_{self.contract_number}"
+        def _emit_cost(stat_id: str, name: str, stats: list[StatisticData]) -> None:
+            async_add_external_statistics(
+                self.hass,
+                StatisticMetaData(
+                    mean_type=StatisticMeanType.NONE,
+                    unit_class=None,
+                    has_sum=True,
+                    name=name,
+                    source=DOMAIN,
+                    statistic_id=stat_id,
+                    unit_of_measurement="AUD",
+                ),
+                stats,
+            )
 
-        async_add_external_statistics(
-            self.hass,
-            StatisticMetaData(
-                mean_type=StatisticMeanType.NONE,
-                unit_class="energy",
-                has_sum=True,
-                name=f"AGL Electricity Consumption ({self.contract_number})",
-                source=DOMAIN,
-                statistic_id=stat_id_cons,
-                unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            ),
+        # --- Aggregate series (always; consumption first, cost second). ---
+        cons_stats, cons_sum = _build(hour_cons, initial_cons_sum)
+        cost_stats, _ = _build(hour_cost, initial_cost_sum)
+        _emit_consumption(
+            f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}",
+            f"AGL Electricity Consumption ({self.contract_number})",
             cons_stats,
         )
-
-        async_add_external_statistics(
-            self.hass,
-            StatisticMetaData(
-                mean_type=StatisticMeanType.NONE,
-                unit_class=None,
-                has_sum=True,
-                name=f"AGL Electricity Cost ({self.contract_number})",
-                source=DOMAIN,
-                statistic_id=stat_id_cost,
-                unit_of_measurement="AUD",
-            ),
+        _emit_cost(
+            f"{DOMAIN}:{STAT_COST}_{self.contract_number}",
+            f"AGL Electricity Cost ({self.contract_number})",
             cost_stats,
         )
+
+        # --- Per-tariff series (ToU contracts only). ---
+        tou_seen = (set(known_bands) | bands_this_batch) & set(TOU_BANDS)
+        if tou_seen:
+            self._active_tou_bands |= tou_seen
+            for tariff in TOU_SERIES_TARIFFS:
+                if tariff not in band_cons:
+                    continue
+                cons_id, cost_id = self._tariff_stat_ids(tariff)
+                base_cons, base_cost = tariff_initial_sums.get(tariff, (0.0, 0.0))
+                t_cons_stats, _ = _build(band_cons[tariff], base_cons)
+                t_cost_stats, _ = _build(band_cost[tariff], base_cost)
+                label = TARIFF_LABELS.get(tariff, tariff.title())
+                _emit_consumption(
+                    cons_id,
+                    f"AGL Electricity Consumption {label} ({self.contract_number})",
+                    t_cons_stats,
+                )
+                _emit_cost(
+                    cost_id,
+                    f"AGL Electricity Cost {label} ({self.contract_number})",
+                    t_cost_stats,
+                )
 
         # Update the in-memory cumulative for the TOTAL_INCREASING sensor.
         if cons_stats:

--- a/custom_components/haggle/manifest.json
+++ b/custom_components/haggle/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.haggle"],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.2.3"
+  "version": "0.3.0-beta.1"
 }

--- a/custom_components/haggle/sensor.py
+++ b/custom_components/haggle/sensor.py
@@ -34,7 +34,13 @@ from .const import (
     DATA_CONSUMPTION_PERIOD,
     DATA_SUPPLY_CHARGE,
     DATA_UNIT_RATE,
+    DATA_UNIT_RATE_OFFPEAK,
+    DATA_UNIT_RATE_PEAK,
+    DATA_UNIT_RATE_SHOULDER,
     DOMAIN,
+    TARIFF_OFFPEAK,
+    TARIFF_PEAK,
+    TARIFF_SHOULDER,
 )
 from .coordinator import HaggleCoordinator
 
@@ -102,6 +108,32 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+# Per-tariff unit-rate sensors, keyed by ToU band. Registered only when the
+# contract is on a Time-of-Use plan (the band is in coordinator.data
+# .active_tariffs) so flat-rate users never see empty peak/offpeak/shoulder
+# sensors. Same pattern as `unit_rate`: MEASUREMENT, AUD/kWh, NO device_class
+# (MONETARY is for cumulative amounts, not unit prices).
+TOU_RATE_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
+    TARIFF_PEAK: SensorEntityDescription(
+        key=DATA_UNIT_RATE_PEAK,
+        translation_key="unit_rate_peak",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="AUD/kWh",
+    ),
+    TARIFF_OFFPEAK: SensorEntityDescription(
+        key=DATA_UNIT_RATE_OFFPEAK,
+        translation_key="unit_rate_offpeak",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="AUD/kWh",
+    ),
+    TARIFF_SHOULDER: SensorEntityDescription(
+        key=DATA_UNIT_RATE_SHOULDER,
+        translation_key="unit_rate_shoulder",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="AUD/kWh",
+    ),
+}
+
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -110,8 +142,16 @@ async def async_setup_entry(
 ) -> None:
     """Set up haggle sensor entities for the entry."""
     coordinator = entry.runtime_data.coordinator
+    descriptions = list(SENSOR_DESCRIPTIONS)
+    # Add per-tariff rate sensors only for the bands this contract actually
+    # uses. active_tariffs is populated by the coordinator's first refresh,
+    # which runs before this platform setup.
+    active = coordinator.data.active_tariffs if coordinator.data else frozenset()
+    descriptions.extend(
+        desc for band, desc in TOU_RATE_DESCRIPTIONS.items() if band in active
+    )
     async_add_entities(
-        HaggleEnergySensor(coordinator, entry, desc) for desc in SENSOR_DESCRIPTIONS
+        HaggleEnergySensor(coordinator, entry, desc) for desc in descriptions
     )
 
 

--- a/custom_components/haggle/strings.json
+++ b/custom_components/haggle/strings.json
@@ -42,6 +42,15 @@
       "unit_rate": {
         "name": "Unit rate"
       },
+      "unit_rate_peak": {
+        "name": "Unit rate (peak)"
+      },
+      "unit_rate_offpeak": {
+        "name": "Unit rate (off-peak)"
+      },
+      "unit_rate_shoulder": {
+        "name": "Unit rate (shoulder)"
+      },
       "supply_charge": {
         "name": "Supply charge"
       }

--- a/custom_components/haggle/translations/en.json
+++ b/custom_components/haggle/translations/en.json
@@ -42,6 +42,15 @@
       "unit_rate": {
         "name": "Unit rate"
       },
+      "unit_rate_peak": {
+        "name": "Unit rate (peak)"
+      },
+      "unit_rate_offpeak": {
+        "name": "Unit rate (off-peak)"
+      },
+      "unit_rate_shoulder": {
+        "name": "Unit rate (shoulder)"
+      },
       "supply_charge": {
         "name": "Supply charge"
       }

--- a/tests/fixtures/tou_hourly_response.json
+++ b/tests/fixtures/tou_hourly_response.json
@@ -1,0 +1,66 @@
+{
+  "resourceType": "electricity",
+  "granularity": "hourly",
+  "timeZone": "Australia/Sydney",
+  "sections": [
+    {
+      "startDate": "2024-01-15",
+      "items": [
+        {
+          "dateTime": "2024-01-15T07:00:00Z",
+          "consumption": {
+            "values": {"amount": 0.5, "quantity": 0.5},
+            "amount": 0.42,
+            "quantity": 1.0,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2024-01-15T07:30:00Z",
+          "consumption": {
+            "values": {"amount": 0.5, "quantity": 0.5},
+            "amount": 0.21,
+            "quantity": 0.5,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2024-01-15T10:00:00Z",
+          "consumption": {
+            "values": {"amount": 0.4, "quantity": 0.4},
+            "amount": 0.18,
+            "quantity": 0.8,
+            "type": "shoulder"
+          }
+        },
+        {
+          "dateTime": "2024-01-15T18:00:00Z",
+          "consumption": {
+            "values": {"amount": 0.3, "quantity": 0.3},
+            "amount": 0.072,
+            "quantity": 0.4,
+            "type": "offpeak"
+          }
+        },
+        {
+          "dateTime": "2024-01-15T02:00:00Z",
+          "consumption": {
+            "values": {"amount": 0.2, "quantity": 0.2},
+            "amount": 0.036,
+            "quantity": 0.2,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2024-01-15T03:00:00Z",
+          "consumption": {
+            "values": {"amount": 0.0, "quantity": 0.0},
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "none"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/tou_plan_response.json
+++ b/tests/fixtures/tou_plan_response.json
@@ -1,0 +1,42 @@
+{
+  "contractNumber": "9999999999",
+  "fuelType": "Electricity",
+  "productCode": "AGLMKTRE0000001",
+  "productName": "Time of Use Saver",
+  "billFrequency": "Quarterly",
+  "gstInclusiveRates": [
+    {
+      "kind": "header",
+      "title": "T93 Time of Use**"
+    },
+    {
+      "validTo": "9999-12-31",
+      "type": "c/kWh",
+      "price": 41.9,
+      "kind": "detail",
+      "title": "Peak"
+    },
+    {
+      "validTo": "9999-12-31",
+      "type": "c/kWh",
+      "price": 22.55,
+      "kind": "detail",
+      "title": "Shoulder"
+    },
+    {
+      "validTo": "9999-12-31",
+      "type": "c/kWh",
+      "price": 18.04,
+      "kind": "detail",
+      "title": "Off Peak"
+    },
+    {
+      "validTo": "9999-12-31",
+      "timeBasis": "1",
+      "type": "c/day",
+      "price": 131.714,
+      "kind": "detail",
+      "title": "Supply charge"
+    }
+  ]
+}

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -865,3 +865,350 @@ class TestUTCDateBoundary:
         # The UTC `today` is 2026-05-02; backfill starts BACKFILL_DAYS earlier.
         expected_start = date(2026, 5, 2) - timedelta(days=BACKFILL_DAYS)
         assert mock_range.call_args[0][0] == expected_start
+
+
+# ---------------------------------------------------------------------------
+# Time-of-Use: per-tariff statistic series
+# ---------------------------------------------------------------------------
+
+
+def _iv(dt: datetime, kwh: float, cost: float, rate_type: str) -> IntervalReading:
+    return IntervalReading(dt=dt, kwh=kwh, cost_aud=cost, rate_type=rate_type)
+
+
+def _stat_ids(mock_add: MagicMock) -> list[str]:
+    """Statistic IDs across all async_add_external_statistics calls, in order."""
+    return [c[0][1]["statistic_id"] for c in mock_add.call_args_list]
+
+
+@pytest.fixture(autouse=True)
+def _stub_resolve_tou_state():
+    """Default the single ToU recorder entry point OFF for every test.
+
+    _fetch_and_import calls _resolve_tou_state, which touches the recorder;
+    these unit tests don't set one up. Tests exercising ToU wiring patch
+    coord._resolve_tou_state explicitly, shadowing this class-level default.
+    """
+    with patch.object(
+        HaggleCoordinator,
+        "_resolve_tou_state",
+        new_callable=AsyncMock,
+        return_value=(set(), {}),
+    ):
+        yield
+
+
+class TestImportIntervalsTou:
+    async def test_tou_intervals_emit_aggregate_plus_per_tariff(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Mixed tariff data → aggregate (2) + one cons+cost per present band (8)."""
+        coord = _make_coordinator(hass)
+        intervals = [
+            _iv(datetime(2026, 4, 28, 7, 0, tzinfo=UTC), 1.0, 0.42, "peak"),
+            _iv(datetime(2026, 4, 28, 10, 0, tzinfo=UTC), 0.8, 0.18, "shoulder"),
+            _iv(datetime(2026, 4, 28, 18, 0, tzinfo=UTC), 0.4, 0.07, "offpeak"),
+            _iv(datetime(2026, 4, 28, 2, 0, tzinfo=UTC), 0.2, 0.03, "normal"),
+        ]
+
+        with patch(_PATCH_ADD_STATS) as mock_add:
+            await coord._import_intervals(intervals, 0.0, 0.0)
+
+        ids = _stat_ids(mock_add)
+        assert mock_add.call_count == 10
+        # Aggregate emitted first (consumption then cost), preserving order.
+        assert ids[0] == f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+        for band in ("peak", "offpeak", "shoulder", "normal"):
+            assert f"{DOMAIN}:{STAT_CONSUMPTION}_{band}_{_CONTRACT}" in ids
+            assert f"{DOMAIN}:cost_{band}_{_CONTRACT}" in ids
+
+    async def test_flat_rate_only_emits_aggregate(self, hass: HomeAssistant) -> None:
+        """Only `normal` intervals and no known ToU bands → aggregate series only."""
+        coord = _make_coordinator(hass)
+        intervals = [
+            _iv(datetime(2026, 4, 28, 1, 0, tzinfo=UTC), 0.5, 0.16, "normal"),
+            _iv(datetime(2026, 4, 28, 2, 0, tzinfo=UTC), 0.3, 0.10, "normal"),
+        ]
+
+        with patch(_PATCH_ADD_STATS) as mock_add:
+            await coord._import_intervals(intervals, 0.0, 0.0)
+
+        assert mock_add.call_count == 2
+        assert not coord._active_tou_bands
+
+    async def test_known_band_makes_normal_a_tou_series(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A contract already seen on ToU emits the normal/anytime per-tariff series."""
+        coord = _make_coordinator(hass)
+        intervals = [_iv(datetime(2026, 4, 28, 1, 0, tzinfo=UTC), 0.5, 0.16, "normal")]
+
+        with patch(_PATCH_ADD_STATS) as mock_add:
+            await coord._import_intervals(
+                intervals, 0.0, 0.0, known_bands=frozenset({"peak"})
+            )
+
+        ids = _stat_ids(mock_add)
+        assert mock_add.call_count == 4  # aggregate(2) + normal per-tariff(2)
+        assert f"{DOMAIN}:{STAT_CONSUMPTION}_normal_{_CONTRACT}" in ids
+
+    async def test_per_tariff_baseline_offset_applied(
+        self, hass: HomeAssistant
+    ) -> None:
+        """tariff_initial_sums offsets the per-tariff cumulative sum."""
+        coord = _make_coordinator(hass)
+        intervals = [_iv(datetime(2026, 4, 28, 7, 0, tzinfo=UTC), 1.0, 0.42, "peak")]
+
+        with patch(_PATCH_ADD_STATS) as mock_add:
+            await coord._import_intervals(
+                intervals,
+                0.0,
+                0.0,
+                tariff_initial_sums={"peak": (10.0, 5.0)},
+                known_bands=frozenset({"peak"}),
+            )
+
+        peak_cons_id = f"{DOMAIN}:{STAT_CONSUMPTION}_peak_{_CONTRACT}"
+        for c in mock_add.call_args_list:
+            if c[0][1]["statistic_id"] == peak_cons_id:
+                assert c[0][2][0]["sum"] == pytest.approx(11.0)
+                break
+        else:  # pragma: no cover
+            pytest.fail("peak consumption series not emitted")
+
+    async def test_active_bands_updated_after_import(self, hass: HomeAssistant) -> None:
+        coord = _make_coordinator(hass)
+        intervals = [_iv(datetime(2026, 4, 28, 7, 0, tzinfo=UTC), 1.0, 0.42, "peak")]
+        with patch(_PATCH_ADD_STATS):
+            await coord._import_intervals(intervals, 0.0, 0.0)
+        assert "peak" in coord._active_tou_bands
+
+
+# ---------------------------------------------------------------------------
+# Time-of-Use: recorder helper methods
+# ---------------------------------------------------------------------------
+
+
+class TestTouRecorderHelpers:
+    async def test_baseline_sums_returns_last_sum_per_id(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        cons_id, cost_id = coord._tariff_stat_ids("peak")
+        rows = {
+            cons_id: [{"sum": 10.0}, {"sum": 22.0}],
+            cost_id: [{"sum": 3.0}, {"sum": 7.5}],
+        }
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance(rows)):
+            out = await coord._get_tariff_baseline_sums(
+                {cons_id, cost_id}, datetime(2026, 4, 28, tzinfo=UTC)
+            )
+        assert out[cons_id] == pytest.approx(22.0)
+        assert out[cost_id] == pytest.approx(7.5)
+
+    async def test_baseline_sums_empty_ids_short_circuits(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        assert await coord._get_tariff_baseline_sums(set(), datetime.now(UTC)) == {}
+
+    async def test_baseline_sums_missing_rows_default_zero(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        cons_id, _ = coord._tariff_stat_ids("shoulder")
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance({})):
+            out = await coord._get_tariff_baseline_sums({cons_id}, datetime.now(UTC))
+        assert out[cons_id] == 0.0
+
+    async def test_stored_tou_bands_detects_present_band(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        peak_cons_id, _ = coord._tariff_stat_ids("peak")
+        with patch(
+            _PATCH_GET_INSTANCE, _mock_get_instance({peak_cons_id: [{"sum": 1.0}]})
+        ):
+            bands = await coord._get_stored_tou_bands()
+        assert bands == {"peak"}
+
+    async def test_stored_tou_bands_empty_when_no_rows(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance({})):
+            assert await coord._get_stored_tou_bands() == set()
+
+
+# ---------------------------------------------------------------------------
+# Time-of-Use: _fetch_and_import wiring (rates, active_tariffs, reload)
+# ---------------------------------------------------------------------------
+
+
+def _tou_plan() -> PlanRates:
+    return PlanRates(
+        product_name="Time of Use Saver",
+        unit_rates=[
+            {"kind": "detail", "type": "c/kWh", "price": 41.9, "title": "Peak"}
+        ],
+        supply_charge_cents_per_day=131.714,
+        tou_unit_rates={"peak": 41.9, "offpeak": 18.04, "shoulder": 22.55},
+    )
+
+
+class TestFetchAndImportTou:
+    async def test_tou_rates_and_active_tariffs_in_data(
+        self, hass: HomeAssistant
+    ) -> None:
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _tou_plan()
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(100.0, yesterday),
+            ),
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new_callable=AsyncMock,
+                return_value=(80.0, 60.0),
+            ),
+            patch.object(
+                coord,
+                "_resolve_tou_state",
+                new_callable=AsyncMock,
+                return_value=({"peak", "offpeak"}, {}),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+        ):
+            result = await coord._fetch_and_import()
+
+        assert result.unit_rate_peak_aud_per_kwh == pytest.approx(0.419)
+        assert result.unit_rate_offpeak_aud_per_kwh == pytest.approx(0.1804)
+        assert result.unit_rate_shoulder_aud_per_kwh == pytest.approx(0.2255)
+        assert {"peak", "offpeak"} <= result.active_tariffs
+
+    async def test_flat_plan_leaves_tou_rates_none(self, hass: HomeAssistant) -> None:
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(100.0, yesterday),
+            ),
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new_callable=AsyncMock,
+                return_value=(80.0, 60.0),
+            ),
+            patch.object(
+                coord,
+                "_resolve_tou_state",
+                new_callable=AsyncMock,
+                return_value=(set(), {}),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+        ):
+            result = await coord._fetch_and_import()
+
+        assert result.unit_rate_peak_aud_per_kwh is None
+        assert result.active_tariffs == frozenset()
+
+    async def test_reload_scheduled_when_new_band_appears(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Non-first refresh + newly stored ToU band → schedule_reload fires once."""
+        from custom_components.haggle.coordinator import HaggleData
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _tou_plan()
+        coord = _make_coordinator(hass, client=mock_client)
+        # Simulate a prior successful refresh (so this is not the first one).
+        coord.data = HaggleData(0.0, 0.0, None, None, None, 0.0)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(100.0, yesterday),
+            ),
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new_callable=AsyncMock,
+                return_value=(80.0, 60.0),
+            ),
+            patch.object(
+                coord,
+                "_resolve_tou_state",
+                new_callable=AsyncMock,
+                return_value=({"peak"}, {}),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+            patch.object(
+                coord.hass.config_entries, "async_schedule_reload"
+            ) as mock_reload,
+        ):
+            await coord._fetch_and_import()
+
+        mock_reload.assert_called_once()
+
+    async def test_no_reload_on_first_refresh(self, hass: HomeAssistant) -> None:
+        """First refresh (coord.data is None) must not schedule a reload."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _tou_plan()
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(100.0, yesterday),
+            ),
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new_callable=AsyncMock,
+                return_value=(80.0, 60.0),
+            ),
+            patch.object(
+                coord,
+                "_resolve_tou_state",
+                new_callable=AsyncMock,
+                return_value=({"peak"}, {}),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+            patch.object(
+                coord.hass.config_entries, "async_schedule_reload"
+            ) as mock_reload,
+        ):
+            await coord._fetch_and_import()
+
+        mock_reload.assert_not_called()

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -918,6 +918,7 @@ class TestImportIntervalsTou:
         assert mock_add.call_count == 10
         # Aggregate emitted first (consumption then cost), preserving order.
         assert ids[0] == f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+        assert ids[1] == f"{DOMAIN}:cost_{_CONTRACT}"
         for band in ("peak", "offpeak", "shoulder", "normal"):
             assert f"{DOMAIN}:{STAT_CONSUMPTION}_{band}_{_CONTRACT}" in ids
             assert f"{DOMAIN}:cost_{band}_{_CONTRACT}" in ids

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -554,4 +554,4 @@ class TestParseIntervalReadingsTou:
         assert types == {"peak", "shoulder", "offpeak", "normal"}
         # kWh from outer consumption.quantity, not inner values.quantity.
         peak = [r for r in readings if r.rate_type == "peak"]
-        assert {r.kwh for r in peak} == {pytest.approx(1.0), pytest.approx(0.5)}
+        assert sorted(r.kwh for r in peak) == [pytest.approx(0.5), pytest.approx(1.0)]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -470,3 +470,88 @@ class TestParseDailyReadings:
         }
         readings = parse_daily_readings(data)
         assert readings == []
+
+
+# ---------------------------------------------------------------------------
+# Time-of-Use: tariff classification + plan rate mapping
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTariff:
+    """The free-text → ToU band heuristic (parser._classify_tariff)."""
+
+    def test_shoulder_matches(self) -> None:
+        from custom_components.haggle.agl.parser import _classify_tariff
+
+        assert _classify_tariff("Shoulder") == "shoulder"
+        assert _classify_tariff("T93 Shoulder usage") == "shoulder"
+
+    def test_offpeak_variants_match_before_peak(self) -> None:
+        from custom_components.haggle.agl.parser import _classify_tariff
+
+        # "off peak" contains the substring "peak"; off-peak must win.
+        assert _classify_tariff("Off Peak") == "offpeak"
+        assert _classify_tariff("off-peak") == "offpeak"
+        assert _classify_tariff("OFFPEAK") == "offpeak"
+
+    def test_peak_matches(self) -> None:
+        from custom_components.haggle.agl.parser import _classify_tariff
+
+        assert _classify_tariff("Peak") == "peak"
+
+    def test_general_usage_is_unmatched(self) -> None:
+        from custom_components.haggle.agl.parser import _classify_tariff
+
+        assert _classify_tariff("First 379 kWh") is None
+        assert _classify_tariff("Thereafter") is None
+        assert _classify_tariff("T11 General Usage**") is None
+
+
+class TestParsePlanTou:
+    def test_tou_plan_maps_all_three_bands(self) -> None:
+        plan = parse_plan(load_fixture("tou_plan_response.json"))
+        assert plan.tou_unit_rates == {
+            "peak": pytest.approx(41.9),
+            "shoulder": pytest.approx(22.55),
+            "offpeak": pytest.approx(18.04),
+        }
+        # Supply charge + flat unit_rates list still populated.
+        assert plan.supply_charge_cents_per_day == pytest.approx(131.714)
+        assert any(r["type"] == "c/kWh" for r in plan.unit_rates)
+
+    def test_flat_plan_has_no_tou_rates(self) -> None:
+        plan = parse_plan(load_fixture("plan_response.json"))
+        assert plan.tou_unit_rates == {}
+
+    def test_first_rate_per_band_wins(self) -> None:
+        """Tiered c/kWh rows under one header collapse to the first price."""
+        data = {
+            "gstInclusiveRates": [
+                {"kind": "header", "title": "Peak"},
+                {
+                    "kind": "detail",
+                    "type": "c/kWh",
+                    "price": 40.0,
+                    "title": "First 100",
+                },
+                {
+                    "kind": "detail",
+                    "type": "c/kWh",
+                    "price": 50.0,
+                    "title": "Thereafter",
+                },
+            ]
+        }
+        plan = parse_plan(data)
+        assert plan.tou_unit_rates == {"peak": pytest.approx(40.0)}
+
+
+class TestParseIntervalReadingsTou:
+    def test_mixed_tou_intervals_preserve_rate_type(self) -> None:
+        readings = parse_interval_readings(load_fixture("tou_hourly_response.json"))
+        # type=none is filtered; the four tariff types survive.
+        types = {r.rate_type for r in readings}
+        assert types == {"peak", "shoulder", "offpeak", "normal"}
+        # kWh from outer consumption.quantity, not inner values.quantity.
+        peak = [r for r in readings if r.rate_type == "peak"]
+        assert {r.kwh for r in peak} == {pytest.approx(1.0), pytest.approx(0.5)}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,143 @@
+"""Tests for custom_components/haggle/sensor.py.
+
+Focus: the base sensor set is always registered, and per-tariff ToU rate
+sensors are registered ONLY for the bands in coordinator.data.active_tariffs
+(so flat-rate contracts never get empty peak/offpeak/shoulder sensors).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haggle.const import (
+    CONF_ACCOUNT_NUMBER,
+    CONF_CONTRACT_NUMBER,
+    CONF_REFRESH_TOKEN,
+    DATA_UNIT_RATE_OFFPEAK,
+    DATA_UNIT_RATE_PEAK,
+    DATA_UNIT_RATE_SHOULDER,
+    DOMAIN,
+)
+from custom_components.haggle.coordinator import HaggleCoordinator, HaggleData
+from custom_components.haggle.sensor import (
+    SENSOR_DESCRIPTIONS,
+    TOU_RATE_DESCRIPTIONS,
+    HaggleEnergySensor,
+    async_setup_entry,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_CONTRACT = "9999999999"
+_BASE_KEYS = {d.key for d in SENSOR_DESCRIPTIONS}
+
+
+def _data(active: frozenset[str], **rates: float | None) -> HaggleData:
+    return HaggleData(
+        consumption_period_kwh=0.0,
+        consumption_period_cost_aud=0.0,
+        bill_projection_aud=None,
+        unit_rate_aud_per_kwh=0.3,
+        supply_charge_aud_per_day=1.0,
+        latest_cumulative_kwh=0.0,
+        active_tariffs=active,
+        unit_rate_peak_aud_per_kwh=rates.get("peak"),
+        unit_rate_offpeak_aud_per_kwh=rates.get("offpeak"),
+        unit_rate_shoulder_aud_per_kwh=rates.get("shoulder"),
+    )
+
+
+def _make_entry_with_coordinator(
+    hass: HomeAssistant, data: HaggleData | None
+) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_REFRESH_TOKEN: "v1.tok",
+            CONF_CONTRACT_NUMBER: _CONTRACT,
+            CONF_ACCOUNT_NUMBER: "1234567890",
+        },
+        unique_id="1234567890_9999999999",
+    )
+    entry.add_to_hass(hass)
+    coordinator = HaggleCoordinator(hass, entry, AsyncMock(), _CONTRACT)
+    coordinator.data = data  # type: ignore[assignment]
+    entry.runtime_data = SimpleNamespace(coordinator=coordinator)
+    return entry
+
+
+async def _setup_keys(hass: HomeAssistant, data: HaggleData | None) -> list[str]:
+    """Run async_setup_entry and return the keys of the entities it registered."""
+    entry = _make_entry_with_coordinator(hass, data)
+    captured: list[HaggleEnergySensor] = []
+
+    def _add(entities) -> None:
+        captured.extend(entities)
+
+    await async_setup_entry(hass, entry, _add)  # type: ignore[arg-type]
+    return [e.entity_description.key for e in captured]
+
+
+class TestConditionalRegistration:
+    async def test_flat_rate_registers_only_base_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        keys = await _setup_keys(hass, _data(frozenset()))
+        assert set(keys) == _BASE_KEYS
+        assert DATA_UNIT_RATE_PEAK not in keys
+        assert DATA_UNIT_RATE_OFFPEAK not in keys
+        assert DATA_UNIT_RATE_SHOULDER not in keys
+
+    async def test_no_coordinator_data_registers_only_base(
+        self, hass: HomeAssistant
+    ) -> None:
+        keys = await _setup_keys(hass, None)
+        assert set(keys) == _BASE_KEYS
+
+    async def test_two_active_bands_register_their_rate_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        keys = await _setup_keys(hass, _data(frozenset({"peak", "offpeak"})))
+        assert DATA_UNIT_RATE_PEAK in keys
+        assert DATA_UNIT_RATE_OFFPEAK in keys
+        assert DATA_UNIT_RATE_SHOULDER not in keys  # shoulder inactive
+        assert set(keys) >= _BASE_KEYS
+
+    async def test_all_three_bands_register(self, hass: HomeAssistant) -> None:
+        keys = await _setup_keys(
+            hass, _data(frozenset({"peak", "offpeak", "shoulder"}))
+        )
+        assert {
+            DATA_UNIT_RATE_PEAK,
+            DATA_UNIT_RATE_OFFPEAK,
+            DATA_UNIT_RATE_SHOULDER,
+        } <= set(keys)
+        assert len(keys) == len(SENSOR_DESCRIPTIONS) + 3
+
+
+class TestTouRateNativeValue:
+    async def test_native_value_none_when_rate_unknown(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A ToU band with no resolved rate reads unavailable (None), not 0.0."""
+        entry = _make_entry_with_coordinator(
+            hass, _data(frozenset({"peak"}), peak=None)
+        )
+        sensor = HaggleEnergySensor(
+            entry.runtime_data.coordinator, entry, TOU_RATE_DESCRIPTIONS["peak"]
+        )
+        assert sensor.native_value is None
+
+    async def test_native_value_returns_rate(self, hass: HomeAssistant) -> None:
+        entry = _make_entry_with_coordinator(
+            hass, _data(frozenset({"peak"}), peak=0.419)
+        )
+        sensor = HaggleEnergySensor(
+            entry.runtime_data.coordinator, entry, TOU_RATE_DESCRIPTIONS["peak"]
+        )
+        assert sensor.native_value == 0.419


### PR DESCRIPTION
## Summary

Adds Time-of-Use (ToU) tariff support requested in #82. On a ToU contract, AGL
interval data is split into separate per-tariff consumption + cost statistics so
each band (peak / off-peak / shoulder) is its own Home Assistant Energy-dashboard
source, and the per-tariff unit rates are surfaced as sensors. Flat-rate contracts
are completely unchanged.

The split is driven entirely by the well-documented per-interval `consumption.type`,
not by guessing at the plan's rate structure.

Closes #82.

## What changed

- **`coordinator.py`** — alongside the unchanged aggregate `haggle:consumption_<c>` /
  `haggle:cost_<c>` series, emit per-tariff series
  `haggle:{consumption,cost}_{peak,offpeak,shoulder,normal}_<contract>` on ToU
  contracts. Each per-tariff series carries its own cumulative sum, resumed from its
  own stored baseline (looked up at the **same** `fetch_start` as the aggregate, batched
  into one recorder call). The `normal`/anytime band is included so the per-tariff
  series **sum back to the aggregate with no lost kWh**.
- **`agl/parser.py` + `models.py`** — map `gstInclusiveRates` to per-band unit rates
  (`PlanRates.tou_unit_rates`) via a documented header/title keyword heuristic.
- **`sensor.py`** — three ToU unit-rate sensors (`MEASUREMENT`, `AUD/kWh`, no
  `device_class`), registered **only** for bands the contract actually uses, so
  flat-rate users get no empty sensors. A loop-safe `async_schedule_reload` surfaces the
  sensors if a contract later switches flat→ToU.
- **`const.py`** — tariff constants, per-band statistic-name labels, new `DATA_*` keys.
- **fix** — corrected stale comments in `models.py`/`client.py` that named the inner
  `consumption.values.quantity` as the kWh source of truth (the parser correctly uses the
  outer `consumption.quantity`).

## Design decisions (from a 2-critic plan review + 2-reviewer code review)

- **No double-counting by construction**: the aggregate series is kept for backward
  compatibility, and the per-tariff series form a complete partition of it. Docs tell ToU
  users to add only the per-tariff sources and flat-rate users only the aggregate; a
  "What NOT to Do" bullet + the CHANGELOG spell this out.
- **Detection is data-driven**, not plan-text-driven: a contract is ToU iff a
  non-`normal` `consumption.type` has ever been seen (stored or in-batch), so flat-rate
  behaviour is unchanged and robust.
- **Rate heuristic is isolated**: AGL exposes no machine tariff-type field, so the
  per-band rate mapping is extrapolated from the response shape and unmatched bands read
  `unavailable` (never a misleading `0.0`). The statistics split does **not** depend on
  it. Validation against a real ToU plan capture is tracked in #90.

## Testing

- New `tests/test_sensor.py`: conditional ToU rate-sensor registration (flat-rate,
  per-band, all-bands, no-data) + `native_value` None-on-unknown.
- `test_parser.py`: `_classify_tariff` edges, ToU rate mapping, flat-rate → no ToU rates,
  mixed-tariff interval parsing.
- `test_coordinator_statistics.py`: aggregate + per-tariff emission, flat-rate negative
  case, per-tariff baseline offset, the ToU recorder helpers, rate/`active_tariffs`
  wiring, and reload-on-new-band (fires on later cycles, not first refresh).
- Anonymised fixtures `tou_plan_response.json` / `tou_hourly_response.json`.
- `ruff check` + `ruff format` clean. The real parser was exercised against both fixtures
  locally. `pytest`/`mypy` run under CI (Python 3.14) per repo convention.

## Docs

CHANGELOG `[Unreleased]`, AGENTS.md Repo Map, Energy Dashboard Contract (per-tariff IDs +
double-count warning), AGL API (ToU rate-heuristic caveat), and a new "What NOT to Do"
bullet.

## Follow-ups

- #90 — validate the rate-mapping heuristic against a real ToU plan capture.
- #91 — clear external statistics on integration removal (pre-existing gap, surfaced by
  the extra series here).

https://claude.ai/code/session_01GUzS8vps8N6JgbaX9j7gwv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUzS8vps8N6JgbaX9j7gwv)_