### PR TITLE
chore(deps): dependency rollup 2026-06-05

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           category: "/language:python"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -13,7 +13,7 @@ jobs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main@2026-01-26
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -13,5 +13,5 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658 # master@2026-04-07

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Closes #73, #75, #77, #83, #85.
 
+- **Platform floor bumped to Home Assistant 2026.6.0** (was `2026.5.1`).
+  Tracks `pytest-homeassistant-custom-component==0.13.336` which pins
+  `homeassistant==2026.6.0`; `hacs.json:homeassistant` updated to match.
+- **Dev-tooling floors bumped**: `ruff>=0.15.15` (was `>=0.15.13`).
+- **GitHub Actions pinned SHAs updated**: `actions/checkout` v6.0.2 → v6.0.3
+  (all workflows), `github/codeql-action` v4.36.0 → v4.36.1,
+  `astral-sh/setup-uv` v8.1.0 → v8.2.0.
+- **aiohttp floor held at `>=3.13.5`**: Dependabot PR #97 proposed bumping to
+  `>=3.14.0` but `homeassistant==2026.6.0` pins `aiohttp==3.13.5`, making the
+  two constraints mutually exclusive. PR #97 excluded from this rollup.
+
+Closes #93, #94, #95, #96, #98, #99.
+
 ---
 
 ## [0.2.3] — 2026-05-15

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.6.0",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     # so editor tooling resolves imports. HA installs from manifest at runtime.
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
-    # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
+    # 2026.6.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
+    "homeassistant>=2026.6.0",
     "aiohttp>=3.13.5",
 ]
 
@@ -35,10 +35,10 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
+    # 0.13.336 pins homeassistant==2026.6.0 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
-    "ruff>=0.15.13",
+    "pytest-homeassistant-custom-component>=0.13.336,<0.13.337",
+    "ruff>=0.15.15",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]


### PR DESCRIPTION
Automated dependency rollup — bundles open Dependabot PRs into one reviewable change.

## Python / HACS deps

| Package | Old | New | PR |
|---|---|---|---|
| `homeassistant` floor | `>=2026.5.1` | `>=2026.6.0` | Closes #99 |
| `pytest-homeassistant-custom-component` | `>=0.13.330,<0.13.331` | `>=0.13.336,<0.13.337` | Closes #98 |
| `ruff` floor | `>=0.15.13` | `>=0.15.15` | Closes #95 |
| `hacs.json homeassistant` | `2026.5.1` | `2026.6.0` | (floor alignment) |

**Alignment invariant preserved**: `pytest-homeassistant-custom-component==0.13.336` pins `homeassistant==2026.6.0`, matching the runtime floor and `hacs.json`. Comment in `pyproject.toml` updated to reflect the new pin.

## GitHub Actions SHA bumps

| Action | Old | New | PR |
|---|---|---|---|
| `actions/checkout` | v6.0.2 | v6.0.3 | Closes #96 |
| `github/codeql-action` | v4.36.0 | v4.36.1 | Closes #94 |
| `astral-sh/setup-uv` | v8.1.0 | v8.2.0 | Closes #93 |

## Excluded: #97 (aiohttp >=3.14.0)

`homeassistant==2026.6.0` pins `aiohttp==3.13.5` — bumping the floor to `>=3.14.0` produces an unsatisfiable resolution. The `aiohttp` floor is held at `>=3.13.5`. PR #97 should be closed as superseded-but-incompatible; maintainer to confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf9B5EiRhWCafu3VZzowLB)_