### PR TITLE
chore(deps): dependency rollup 2026-06-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:python"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -13,7 +13,7 @@ jobs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main@2026-01-26
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -13,5 +13,5 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658 # master@2026-04-07
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master@2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Closes #73, #75, #77, #83, #85.
 
+- **Platform floor bumped to Home Assistant 2026.6.2** (was `2026.5.1`).
+  `pytest-homeassistant-custom-component` bumped to `0.13.338` (pins
+  `homeassistant==2026.6.2`); test harness and runtime floor stay aligned.
+  `hacs.json:homeassistant` updated to match.
+- **Dev-tooling floor bumped**: `ruff>=0.15.16` (was `>=0.15.13`). Pipeline
+  runs clean against the existing codebase.
+- **GitHub Actions pinned SHAs updated**: `actions/checkout` v6.0.2 → v6.0.3,
+  `astral-sh/setup-uv` v8.1.0 → v8.2.0, `codecov/codecov-action` v6.0.1 →
+  v7.0.0, `github/codeql-action` v4.36.0 → v4.36.2,
+  `home-assistant/actions/hassfest` SHA updated to `e91ad194`.
+- **`aiohttp` floor held at `>=3.13.5`** — `homeassistant==2026.6.2` still
+  pins `aiohttp==3.13.5`; bumping to `>=3.14.1` (#106) produces an
+  unsatisfiable resolution. Revisit when HA ships with aiohttp≥3.14.x.
+
+Closes #93, #96, #102, #103, #104, #105, #107, #108. Supersedes #100.
+
 ---
 
 ## [0.2.3] — 2026-05-15

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.6.2",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,10 @@ dependencies = [
     # so editor tooling resolves imports. HA installs from manifest at runtime.
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
-    # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
+    # 2026.6.2 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
+    # aiohttp floor held at >=3.13.5 — HA 2026.6.2 pins aiohttp==3.13.5; bumping to
+    # >=3.14.1 (#106) produces an unsatisfiable resolution (same as #97 against 2026.6.0).
+    "homeassistant>=2026.6.2",
     "aiohttp>=3.13.5",
 ]
 
@@ -35,10 +37,10 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
+    # 0.13.338 pins homeassistant==2026.6.2 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
-    "ruff>=0.15.13",
+    "pytest-homeassistant-custom-component>=0.13.338,<0.13.339",
+    "ruff>=0.15.16",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]


### PR DESCRIPTION
Automated dependency rollup — bundles open Dependabot PRs into one reviewable change. Supersedes #100.

## Python / HACS deps

| Package | Old | New | PR |
|---|---|---|---|
| `homeassistant` floor | `>=2026.5.1` | `>=2026.6.2` | Closes #105 |
| `pytest-homeassistant-custom-component` | `>=0.13.330,<0.13.331` | `>=0.13.338,<0.13.339` | Closes #107 |
| `ruff` floor | `>=0.15.13` | `>=0.15.16` | Closes #108 |
| `hacs.json homeassistant` | `2026.5.1` | `2026.6.2` | (floor alignment) |

**Alignment invariant preserved**: `pytest-homeassistant-custom-component==0.13.338` pins `homeassistant==2026.6.2`, matching the runtime floor and `hacs.json`. Comment in `pyproject.toml` updated to reflect the new pin.

## GitHub Actions SHA bumps

| Action | Old | New | PR |
|---|---|---|---|
| `actions/checkout` | v6.0.2 | v6.0.3 | Closes #96 |
| `astral-sh/setup-uv` | v8.1.0 | v8.2.0 | Closes #93 |
| `codecov/codecov-action` | v6.0.1 | v7.0.0 | Closes #102 |
| `github/codeql-action` | v4.36.0 | v4.36.2 | Closes #104 |
| `home-assistant/actions/hassfest` | `868e6cb4` | `e91ad194` | Closes #103 |

Note: `actions/checkout` is bumped in `ci.yml`, `codeql.yml`, `hacs.yml`, and `hassfest.yml`. `release.yml` is excluded from automated edits per project policy.

## Excluded: #106 (aiohttp >=3.14.1)

`homeassistant==2026.6.2` pins `aiohttp==3.13.5` — bumping the floor to `>=3.14.1` produces an unsatisfiable resolution (same incompatibility as #97 against 2026.6.0). The `aiohttp` floor is held at `>=3.13.5`. PR #106 should be closed as superseded-but-incompatible; maintainer to confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_011rSao5rbpiRGNbjAqFYoLX)_