### PR TITLE
fix: phantom midnight kWh spike — resolve baseline at earliest fetched hour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,9 +281,21 @@ poll re-fetches the trailing `REWINDOW_DAYS` (default 7). This makes the
 integration self-heal AGL's day-late AEMO backfills — a slot first returned as
 a `quantity=0` placeholder is overwritten with the real meter read on a later
 cycle. `async_add_external_statistics` is idempotent on `(statistic_id, start)`
-so the overwrite is safe; the baseline cumulative sum for the rewindow is
-looked up via `statistics_during_period` (the sum at the hour right before
-fetch_start UTC midnight), NOT the most-recent stored sum.
+so the overwrite is safe.
+
+The cumulative-sum baseline for the import (aggregate AND every per-tariff
+series) is looked up in `_import_intervals` via `statistics_during_period`
+using the **actual earliest fetched-interval hour** as the cutoff — NOT a
+`fetch_start`-derived UTC midnight, and NOT the most-recent stored sum. AGL's
+`period=` query is interpreted in the contract's local timezone, so the first
+interval of a day query lands at local midnight in UTC (e.g.
+`(fetch_start - 1)T14:00Z` for an AEST account). A cutoff fixed at
+`fetch_start T00:00Z` UTC folded ~10 h of about-to-be-overwritten old sums into
+the baseline and the new chain re-added those hours' deltas, producing a phantom
+`+N kWh` jump in the recorder `sum` column every local midnight (the Energy
+dashboard renders hourly deltas as `sum[h] - sum[h-1]`, so the spike was
+visible there). Using the earliest fetched hour is correct regardless of
+timezone or DST.
 
 ### Previous Bill Period
 
@@ -471,6 +483,22 @@ The HA Energy dashboard requires:
   if 7 sequential GETs land in <1 s. `_fetch_range` sleeps
   `BACKFILL_INTER_REQUEST_DELAY` between days and breaks out of the chunk
   on `AGLRateLimitError`; the next 24 h cycle resumes from the gap.
+- **Don't derive the cumulative-sum baseline cutoff from a `fetch_start` UTC
+  midnight.** AGL's `period=YYYY-MM-DD_YYYY-MM-DD` query is interpreted in the
+  contract's LOCAL timezone, so the first interval returned lands at local
+  midnight in UTC (e.g. `(fetch_start - 1)T14:00Z` for AEST). A baseline lookup
+  cut off at `fetch_start T00:00Z` folds ~10 h of about-to-be-overwritten old
+  sums into the baseline; the new chain re-adds those hours' deltas, producing
+  a phantom `+N kWh` jump in the recorder `sum` column every local-midnight UTC
+  row (visible on the Energy dashboard, which plots `sum[h] - sum[h-1]`).
+  `_import_intervals` looks the baseline up — for the aggregate AND every
+  per-tariff series — at the **actual earliest fetched-interval hour**, which
+  is correct regardless of timezone or DST. This is why baselines are resolved
+  AFTER the fetch (inside `_import_intervals`), not before it. Regression test:
+  `tests/test_coordinator_statistics.py::TestImportIntervalsAggregation::test_baseline_looked_up_at_earliest_fetched_hour`.
+  Fixed v0.3.0 → confirmed against the live recorder: 8 phantom spikes at
+  `T14:00Z` (AEST local midnight) of 10–27 kWh each, including in the ToU
+  `consumption_normal` series.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Phantom kWh spike in the cumulative sum at every local midnight.** The
+  trailing rewindow looked up its cumulative-sum baseline at `fetch_start`
+  UTC midnight, but AGL's `period=` query is interpreted in the contract's
+  local timezone — the first interval of a day query lands at
+  `(fetch_start - 1)T14:00Z` for an AEST account. The baseline therefore folded
+  ~10 h of about-to-be-overwritten old sums in, and the new chain re-added
+  those hours' deltas, producing a phantom `+N kWh` jump in the recorder `sum`
+  column every local-midnight UTC row. The per-hour `state` was always correct,
+  but the Energy dashboard plots hourly deltas as `sum[h] - sum[h-1]`, so the
+  spike was visible there. `_import_intervals` now resolves the baseline — for
+  the aggregate **and** every per-tariff ToU series — at the actual earliest
+  fetched-interval hour, which is correct regardless of timezone or DST.
+  Confirmed against the live recorder: 8 phantom spikes at `T14:00Z` of
+  10–27 kWh, including in the ToU `consumption_normal` series. Regression test:
+  `test_baseline_looked_up_at_earliest_fetched_hour`.
+- **Recovery for existing installs.** New rows inside the current 7-day
+  rewindow are rewritten with correct sums on the next poll. Older rows outside
+  the rewindow keep their historical phantom — to clear them, delete the
+  `haggle:*` rows from `statistics` / `statistics_short_term` and let the
+  30-day backfill rebuild from scratch (same procedure as the v0.2.1 undercount
+  recovery).
+
 ### Targets for next sprint
 
 - #90 — validate the ToU plan rate-mapping heuristic against a real ToU capture.

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -283,7 +283,12 @@ class AglClient:
         Use `day == yesterday` for reliable data; today will be empty.
         Field to use: consumption.quantity (outer) for kWh, NOT
         consumption.values.quantity (inner DPI/chart-scaled helper).
-        dateTime is slot-start in UTC.
+        dateTime is slot-start in UTC, but the `period=` parameter is
+        interpreted in the contract's LOCAL timezone, so a single-day query
+        returns intervals from local midnight that day to local midnight the
+        next day (spanning two UTC dates). The statistics importer relies on
+        this: it cuts the cumulative-sum baseline at the earliest returned
+        interval hour rather than a UTC-midnight derived from `day`.
         """
         period = f"{day}_{day}"
         url = f"{self.BASE_URL}/api/v2/usage/smart/Electricity/{contract_number}/Current/Hourly?period={period}&scaling={AGL_SCALING}"

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -26,7 +26,7 @@ import asyncio
 import logging
 import math
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -145,7 +145,6 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     async def _fetch_and_import(self) -> HaggleData:
         """Core update: fetch missing intervals + trailing rewindow, return data."""
         stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}"
-        stat_id_cost = f"{DOMAIN}:{STAT_COST}_{self.contract_number}"
 
         # Fetch live sensor data first — summary gives bill_start for endpoint selection.
         summary = await self.client.async_get_usage_summary(self.contract_number)
@@ -153,29 +152,18 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
 
         bill_start: date = summary.start
 
-        # Determine resume point — overlap both recorder lookups on the executor.
-        (last_cons_sum, last_stat_date), (last_cost_sum, _) = await asyncio.gather(
-            self._get_last_stat(stat_id_cons),
-            self._get_last_stat(stat_id_cost),
-        )
+        # Resume point comes from the consumption stat. The cost stat is written
+        # in lockstep, and every cumulative-sum baseline is now looked up inside
+        # _import_intervals (against the earliest fetched-interval hour), so the
+        # cost stat's last row is no longer needed here.
+        last_cons_sum, last_stat_date = await self._get_last_stat(stat_id_cons)
 
         # AGL `dateTime` slots are UTC; using `date.today()` (OS local time)
         # would skew the fetch range by a day around midnight in non-UTC zones.
         today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
-        (
-            fetch_start,
-            initial_cons_sum,
-            initial_cost_sum,
-        ) = await self._resolve_resume_point(
-            today,
-            last_stat_date,
-            last_cons_sum,
-            last_cost_sum,
-            stat_id_cons,
-            stat_id_cost,
-        )
+        fetch_start = self._resolve_fetch_start(today, last_stat_date)
         fetch_end = min(
             yesterday, fetch_start + timedelta(days=BACKFILL_CHUNK_DAYS - 1)
         )
@@ -184,27 +172,17 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # bumps it forward when the import produces new rows.
         self._latest_cumulative_kwh = last_cons_sum or 0.0
 
-        # Resolve per-tariff baselines at the SAME fetch_start as the aggregate
-        # so each per-tariff series resumes from its own stored cumulative
-        # (never the aggregate's, and never the per-tariff series' own last
-        # date). Skipped on first install (no prior rows anywhere → all 0.0).
-        # known_bands = ToU bands that already have stored statistics, so the
-        # `normal`/anytime per-tariff series is only emitted on a contract that
-        # has been seen using ToU (keeps flat-rate contracts on the aggregate
-        # series alone).
-        known_bands, tariff_initial_sums = await self._resolve_tou_state(
-            fetch_start, last_stat_date
-        )
-        self._active_tou_bands |= known_bands
+        # Mark which ToU bands already have stored statistics so the per-tariff
+        # series are emitted only for a contract that has been seen using ToU
+        # (flat-rate contracts stay on the aggregate series alone). The
+        # per-tariff baseline sums themselves are resolved in _import_intervals.
+        self._active_tou_bands |= await self._get_stored_tou_bands()
 
         if fetch_start <= yesterday:
             await self._fetch_range(
                 fetch_start,
                 fetch_end,
                 bill_start,
-                initial_cons_sum=initial_cons_sum,
-                initial_cost_sum=initial_cost_sum,
-                tariff_initial_sums=tariff_initial_sums,
                 known_bands=frozenset(self._active_tou_bands),
             )
 
@@ -274,40 +252,34 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
-    async def _resolve_resume_point(
+    def _resolve_fetch_start(
         self,
         today: date,
         last_stat_date: date | None,
-        last_cons_sum: float | None,
-        last_cost_sum: float | None,
-        stat_id_cons: str,
-        stat_id_cost: str,
-    ) -> tuple[date, float, float]:
-        """Choose fetch_start + initial sums per the resume-strategy decision tree.
+    ) -> date:
+        """Choose the first day to fetch per the resume-strategy decision tree.
 
-        - First install: backfill from BACKFILL_DAYS ago, sums start at 0.
+        - First install: backfill from BACKFILL_DAYS ago.
         - Big gap (> REWINDOW_DAYS behind): resume incrementally from
-          last_stat_date + 1, using the last stored cumulative as the baseline.
+          last_stat_date + 1.
         - Normal operation: re-fetch the trailing REWINDOW_DAYS so AGL's
-          day-late AEMO backfills self-heal. Baseline is the sum at the hour
-          right before fetch_start UTC midnight (looked up — NOT the latest
-          stored sum, which is several days ahead of the rewindow start).
+          day-late AEMO backfills self-heal.
+
+        The cumulative-sum baseline is NOT chosen here. _import_intervals looks
+        it up from the recorder using the actual earliest fetched-interval hour
+        as the cutoff. Deriving it from fetch_start UTC midnight was wrong:
+        AGL's period= query is interpreted in the contract's local timezone, so
+        the first new interval lands at (fetch_start - 1)T14:00Z for an AEST
+        account; a cutoff at fetch_start T00:00Z folded ~10 h of
+        about-to-be-overwritten old sums into the baseline, producing a phantom
+        kWh jump in the cumulative sum every local midnight.
         """
         backfill_floor = today - timedelta(days=BACKFILL_DAYS)
         if last_stat_date is None:
-            return backfill_floor, 0.0, 0.0
+            return backfill_floor
         if last_stat_date < today - timedelta(days=REWINDOW_DAYS):
-            return (
-                last_stat_date + timedelta(days=1),
-                last_cons_sum or 0.0,
-                last_cost_sum or 0.0,
-            )
-        fetch_start = max(today - timedelta(days=REWINDOW_DAYS), backfill_floor)
-        fetch_start_utc = datetime.combine(fetch_start, time.min, tzinfo=UTC)
-        baseline_cons, baseline_cost = await self._get_baseline_sums(
-            stat_id_cons, stat_id_cost, fetch_start_utc
-        )
-        return fetch_start, baseline_cons, baseline_cost
+            return last_stat_date + timedelta(days=1)
+        return max(today - timedelta(days=REWINDOW_DAYS), backfill_floor)
 
     async def _get_last_stat(self, stat_id: str) -> tuple[float | None, date | None]:
         """Return (last_sum, last_date) for stat_id, or (None, None) if no rows."""
@@ -370,39 +342,6 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             return float(last) if last is not None else 0.0
 
         return _last_sum(stat_id_cons), _last_sum(stat_id_cost)
-
-    async def _resolve_tou_state(
-        self, fetch_start: date, last_stat_date: date | None
-    ) -> tuple[set[str], dict[str, tuple[float, float]]]:
-        """Return (known ToU bands, per-tariff baseline sums) for this cycle.
-
-        Single recorder-touching entry point for the ToU machinery.
-        `known_bands` marks the contract as Time-of-Use across restarts; the
-        baselines resume each per-tariff series from its OWN stored cumulative
-        at the SAME fetch_start as the aggregate (never the aggregate's sum,
-        never the per-tariff series' own last date). First install (no prior
-        aggregate row) → no baselines needed.
-        """
-        if last_stat_date is None:
-            return await self._get_stored_tou_bands(), {}
-
-        fetch_start_utc = datetime.combine(fetch_start, time.min, tzinfo=UTC)
-        band_ids: set[str] = set()
-        for tariff in TOU_SERIES_TARIFFS:
-            band_ids.update(self._tariff_stat_ids(tariff))
-        # Independent lookups — overlap them on the executor.
-        known_bands, band_sums = await asyncio.gather(
-            self._get_stored_tou_bands(),
-            self._get_tariff_baseline_sums(band_ids, fetch_start_utc),
-        )
-        tariff_initial_sums = {
-            tariff: (
-                band_sums.get(self._tariff_stat_ids(tariff)[0], 0.0),
-                band_sums.get(self._tariff_stat_ids(tariff)[1], 0.0),
-            )
-            for tariff in TOU_SERIES_TARIFFS
-        }
-        return known_bands, tariff_initial_sums
 
     async def _get_tariff_baseline_sums(
         self, stat_ids: set[str], before_dt: datetime
@@ -472,9 +411,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         start: date,
         end: date,
         bill_start: date | None,
-        initial_cons_sum: float,
-        initial_cost_sum: float,
-        tariff_initial_sums: dict[str, tuple[float, float]] | None = None,
+        *,
         known_bands: frozenset[str] = frozenset(),
     ) -> None:
         """Fetch [start..end] with smart endpoint selection, then import.
@@ -511,24 +448,47 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             current += timedelta(days=1)
 
         if all_intervals:
-            await self._import_intervals(
-                all_intervals,
-                initial_cons_sum,
-                initial_cost_sum,
-                tariff_initial_sums=tariff_initial_sums,
-                known_bands=known_bands,
-            )
+            await self._import_intervals(all_intervals, known_bands=known_bands)
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave _latest_cumulative_kwh as the caller seeded it — the
         # most recent stored cumulative remains the sensor value.
 
+    @staticmethod
+    def _bucket_hourly(
+        intervals: list[IntervalReading],
+    ) -> tuple[
+        dict[datetime, float],
+        dict[datetime, float],
+        dict[str, dict[datetime, float]],
+        dict[str, dict[datetime, float]],
+        set[str],
+    ]:
+        """Bucket 30-min intervals into hourly aggregate + per-tariff sums.
+
+        Returns (hour_cons, hour_cost, band_cons, band_cost, bands_this_batch).
+        Per-tariff buckets are only populated for TOU_SERIES_TARIFFS rate types.
+        """
+        hour_cons: dict[datetime, float] = {}
+        hour_cost: dict[datetime, float] = {}
+        band_cons: dict[str, dict[datetime, float]] = {}
+        band_cost: dict[str, dict[datetime, float]] = {}
+        bands_this_batch: set[str] = set()
+        for r in intervals:
+            h = r.dt.replace(minute=0, second=0, microsecond=0)
+            hour_cons[h] = hour_cons.get(h, 0.0) + r.kwh
+            hour_cost[h] = hour_cost.get(h, 0.0) + r.cost_aud
+            if r.rate_type in TOU_SERIES_TARIFFS:
+                bc = band_cons.setdefault(r.rate_type, {})
+                bk = band_cost.setdefault(r.rate_type, {})
+                bc[h] = bc.get(h, 0.0) + r.kwh
+                bk[h] = bk.get(h, 0.0) + r.cost_aud
+                bands_this_batch.add(r.rate_type)
+        return hour_cons, hour_cost, band_cons, band_cost, bands_this_batch
+
     async def _import_intervals(
         self,
         intervals: list[IntervalReading],
-        initial_cons_sum: float,
-        initial_cost_sum: float,
         *,
-        tariff_initial_sums: dict[str, tuple[float, float]] | None = None,
         known_bands: frozenset[str] = frozenset(),
     ) -> None:
         """Aggregate 30-min intervals to hourly and push to recorder statistics.
@@ -539,6 +499,15 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         series for every tariff type present, so the per-tariff series sum back
         to the aggregate with no lost kWh. Flat-rate contracts (only `normal`)
         get the aggregate series alone, exactly as before.
+
+        Every series' cumulative-sum baseline (aggregate AND per-tariff) is
+        looked up against the recorder using the hour right before the EARLIEST
+        fetched interval as the cutoff — never a fetch_start-derived UTC
+        midnight. AGL's period= query is interpreted in the contract's local
+        timezone, so the first interval of a day query lands at local midnight
+        in UTC ((fetch_start - 1)T14:00Z for AEST), and a fixed-UTC cutoff would
+        fold ~10 h of about-to-be-overwritten old sums into the baseline and
+        re-add them — spiking the cumulative sum every local midnight.
         """
         # Local imports: recorder must not be imported at module level.
         from homeassistant.components.recorder.models import (
@@ -551,26 +520,37 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         from homeassistant.const import UnitOfEnergy
 
-        tariff_initial_sums = tariff_initial_sums or {}
-
         # Aggregate hourly buckets (all intervals) + per-tariff hourly buckets.
-        hour_cons: dict[datetime, float] = {}
-        hour_cost: dict[datetime, float] = {}
-        band_cons: dict[str, dict[datetime, float]] = {}
-        band_cost: dict[str, dict[datetime, float]] = {}
-        bands_this_batch: set[str] = set()
-        for r in intervals:
-            h = r.dt.replace(minute=0, second=0, microsecond=0)
-            hour_cons[h] = hour_cons.get(h, 0.0) + r.kwh
-            hour_cost[h] = hour_cost.get(h, 0.0) + r.cost_aud
-            if r.rate_type in TOU_SERIES_TARIFFS:
-                band_cons.setdefault(r.rate_type, {})
-                band_cost.setdefault(r.rate_type, {})
-                bc = band_cons[r.rate_type]
-                bk = band_cost[r.rate_type]
-                bc[h] = bc.get(h, 0.0) + r.kwh
-                bk[h] = bk.get(h, 0.0) + r.cost_aud
-                bands_this_batch.add(r.rate_type)
+        hour_cons, hour_cost, band_cons, band_cost, bands_this_batch = (
+            self._bucket_hourly(intervals)
+        )
+
+        # Nothing fetched → nothing to import, and no baseline lookup needed.
+        if not hour_cons:
+            return
+
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{self.contract_number}"
+        stat_id_cost = f"{DOMAIN}:{STAT_COST}_{self.contract_number}"
+
+        # Baseline cutoff = the earliest fetched interval hour. _get_baseline_sums
+        # returns the cumulative sum at the last hour strictly before it, so the
+        # to-be-overwritten rewindow rows are excluded regardless of timezone/DST.
+        cutoff = min(hour_cons)
+
+        # Per-tariff series to emit (and therefore to baseline-look-up).
+        tou_seen = (set(known_bands) | bands_this_batch) & set(TOU_BANDS)
+        band_ids: set[str] = set()
+        if tou_seen:
+            for tariff in TOU_SERIES_TARIFFS:
+                band_ids.update(self._tariff_stat_ids(tariff))
+
+        # Resolve aggregate + per-tariff baselines, overlapped on the executor.
+        # _get_tariff_baseline_sums short-circuits to {} for an empty band set
+        # (flat-rate contract), so no extra recorder round-trip is incurred.
+        (initial_cons_sum, initial_cost_sum), band_sums = await asyncio.gather(
+            self._get_baseline_sums(stat_id_cons, stat_id_cost, cutoff),
+            self._get_tariff_baseline_sums(band_ids, cutoff),
+        )
 
         def _emit_series(
             stat_id: str,
@@ -622,15 +602,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             initial_cost_sum,
         )
 
-        # Per-tariff series (ToU contracts only).
-        tou_seen = (set(known_bands) | bands_this_batch) & set(TOU_BANDS)
+        # Per-tariff series (ToU contracts only). tou_seen / band_ids were
+        # resolved above so the baselines could be looked up in one round-trip.
         if tou_seen:
             self._active_tou_bands |= tou_seen
             for tariff in TOU_SERIES_TARIFFS:
                 if tariff not in band_cons:
                     continue
                 cons_id, cost_id = self._tariff_stat_ids(tariff)
-                base_cons, base_cost = tariff_initial_sums.get(tariff, (0.0, 0.0))
+                base_cons = band_sums.get(cons_id, 0.0)
+                base_cost = band_sums.get(cost_id, 0.0)
                 label = TARIFF_LABELS.get(tariff, tariff.title())
                 _emit_series(
                     cons_id,
@@ -650,5 +631,5 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 )
 
         # Update the in-memory cumulative for the TOTAL_INCREASING sensor.
-        if hour_cons:
-            self._latest_cumulative_kwh = cons_sum
+        # hour_cons is non-empty here (we returned early otherwise).
+        self._latest_cumulative_kwh = cons_sum

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -29,6 +29,11 @@ from custom_components.haggle.const import (
 )
 from custom_components.haggle.coordinator import HaggleCoordinator
 
+# Capture the real coroutine function before any autouse fixture can patch the
+# class attribute.  Used by TestTouRecorderHelpers to restore the live
+# implementation on a per-instance basis while the autouse fixture is active.
+_REAL_GET_STORED_TOU_BANDS = HaggleCoordinator._get_stored_tou_bands
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
@@ -120,12 +125,15 @@ class TestImportIntervalsAggregation:
             _make_interval(datetime(2026, 4, 28, 13, 30, tzinfo=UTC), kwh=0.153),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         # Called twice: once for consumption, once for cost
         assert mock_add.call_count == 2
@@ -147,12 +155,15 @@ class TestImportIntervalsAggregation:
             _make_interval(datetime(2026, 4, 28, 13, 30, tzinfo=UTC), kwh=0.153),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         cons_stats = mock_add.call_args_list[0][0][2]
         assert len(cons_stats) == 2
@@ -165,31 +176,39 @@ class TestImportIntervalsAggregation:
             for h in range(3)
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         cons_stats = mock_add.call_args_list[0][0][2]
         assert len(cons_stats) == 3
         sums = [s["sum"] for s in cons_stats]
         assert sums == [pytest.approx(1.0), pytest.approx(2.0), pytest.approx(3.0)]
 
-    async def test_initial_sum_offset_applied(self, hass: HomeAssistant) -> None:
-        """initial_cons_sum is added as an offset to the running total."""
+    async def test_baseline_offset_applied_to_running_total(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Baseline from _get_baseline_sums is added as an offset to the running total."""
         coord = _make_coordinator(hass)
         intervals = [
             _make_interval(datetime(2026, 4, 28, 0, 0, tzinfo=UTC), kwh=0.5),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=100.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(100.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         cons_stats = mock_add.call_args_list[0][0][2]
         assert cons_stats[0]["sum"] == pytest.approx(100.5)
@@ -202,30 +221,70 @@ class TestImportIntervalsAggregation:
             for h in range(3)
         ]
 
-        with patch(_PATCH_ADD_STATS):
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=50.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS),
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(50.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         assert coord._latest_cumulative_kwh == pytest.approx(53.0)
 
-    async def test_empty_intervals_calls_add_with_empty_lists(
+    async def test_empty_intervals_skips_import(self, hass: HomeAssistant) -> None:
+        """No intervals → async_add_external_statistics is NOT called at all,
+        and _get_baseline_sums is also not called (no recorder round-trip)."""
+        coord = _make_coordinator(hass)
+        mock_baseline = AsyncMock(return_value=(0.0, 0.0))
+
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(coord, "_get_baseline_sums", new=mock_baseline),
+        ):
+            await coord._import_intervals([])
+
+        mock_add.assert_not_called()
+        mock_baseline.assert_not_called()
+
+    async def test_baseline_looked_up_at_earliest_fetched_hour(
         self, hass: HomeAssistant
     ) -> None:
-        """No intervals → async_add_external_statistics is called with empty lists."""
+        """The baseline cutoff must be the EARLIEST interval hour, not fetch_start midnight.
+
+        Regression guard for the phantom kWh spike bug: AGL's period= query is
+        interpreted in the contract's local timezone, so the first interval of a
+        day query lands at local midnight in UTC (e.g. 2026-04-27T14:00Z for an
+        AEST account). If the cutoff were fixed to fetch_start T00:00Z UTC it
+        would include ~10 h of about-to-be-overwritten old sums in the baseline
+        and then re-add those same hours' deltas — spiking the cumulative sum
+        every local-midnight UTC row.
+
+        Pass intervals OUT of chronological order; earliest hour is 14:00Z.
+        Assert _get_baseline_sums is called once with that exact cutoff.
+        """
         coord = _make_coordinator(hass)
+        earliest_hour = datetime(2026, 4, 28, 14, 0, tzinfo=UTC)
+        intervals = [
+            # Later hour first (out of order) to prove min() is used, not first-seen.
+            _make_interval(datetime(2026, 4, 28, 15, 0, tzinfo=UTC), kwh=0.3),
+            _make_interval(datetime(2026, 4, 28, 15, 30, tzinfo=UTC), kwh=0.2),
+            _make_interval(earliest_hour, kwh=0.5),
+            _make_interval(datetime(2026, 4, 28, 14, 30, tzinfo=UTC), kwh=0.4),
+        ]
+        mock_baseline = AsyncMock(return_value=(0.0, 0.0))
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                [],
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS),
+            patch.object(coord, "_get_baseline_sums", new=mock_baseline),
+        ):
+            await coord._import_intervals(intervals)
 
-        for c in mock_add.call_args_list:
-            assert c[0][2] == []
+        mock_baseline.assert_awaited_once()
+        # Third positional arg is before_dt / cutoff.
+        _, _, cutoff_arg = mock_baseline.call_args[0]
+        assert cutoff_arg == earliest_hour
 
 
 # ---------------------------------------------------------------------------
@@ -242,12 +301,15 @@ class TestImportIntervalsStatId:
             _make_interval(datetime(2026, 4, 28, 0, 0, tzinfo=UTC), kwh=0.2),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         cons_meta = mock_add.call_args_list[0][0][1]
         expected_id = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
@@ -264,12 +326,15 @@ class TestImportIntervalsStatId:
             _make_interval(datetime(2026, 4, 28, 0, 0, tzinfo=UTC), kwh=0.2),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         cons_meta = mock_add.call_args_list[0][0][1]
         assert cons_meta["unit_of_measurement"] == UnitOfEnergy.KILO_WATT_HOUR
@@ -290,12 +355,15 @@ class TestImportIntervalsAggregationFiltered:
             _make_interval(datetime(2026, 4, 28, 0, 30, tzinfo=UTC), kwh=0.3),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                initial_cons_sum=0.0,
-                initial_cost_sum=0.0,
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         cons_stats = mock_add.call_args_list[0][0][2]
         assert len(cons_stats) == 1
@@ -382,7 +450,7 @@ class TestFetchRange:
         end = today - timedelta(days=3)  # all days are before bill_start
 
         with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._fetch_range(start, end, bill_start, 0.0, 0.0)
+            await coord._fetch_range(start, end, bill_start)
 
         assert mock_client.async_get_usage_hourly_previous.call_count == 3
         mock_client.async_get_usage_hourly.assert_not_called()
@@ -401,7 +469,7 @@ class TestFetchRange:
         end = today - timedelta(days=1)
 
         with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._fetch_range(start, end, bill_start, 0.0, 0.0)
+            await coord._fetch_range(start, end, bill_start)
 
         assert mock_client.async_get_usage_hourly.call_count == 3
         mock_client.async_get_usage_hourly_previous.assert_not_called()
@@ -419,7 +487,7 @@ class TestFetchRange:
         end = today - timedelta(days=1)
 
         with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._fetch_range(start, end, None, 0.0, 0.0)
+            await coord._fetch_range(start, end, None)
 
         assert mock_client.async_get_usage_hourly.call_count == 2
         mock_client.async_get_usage_hourly_previous.assert_not_called()
@@ -444,7 +512,7 @@ class TestFetchRange:
                 "custom_components.haggle.coordinator.asyncio.sleep", new=AsyncMock()
             ),
         ):
-            await coord._fetch_range(start, end, None, 0.0, 0.0)  # must not raise
+            await coord._fetch_range(start, end, None)  # must not raise
 
         # All days attempted despite errors; no intervals → _import_intervals not called
         assert mock_client.async_get_usage_hourly.call_count == 3
@@ -477,7 +545,7 @@ class TestFetchRange:
                 "custom_components.haggle.coordinator.asyncio.sleep", new=AsyncMock()
             ),
         ):
-            await coord._fetch_range(start, end, None, 0.0, 0.0)
+            await coord._fetch_range(start, end, None)
 
         # Two attempts only: day 1 succeeded, day 2 halted the loop.
         assert mock_client.async_get_usage_hourly.call_count == 2
@@ -503,7 +571,7 @@ class TestFetchRange:
             patch.object(coord, "_import_intervals", new_callable=AsyncMock),
             patch("custom_components.haggle.coordinator.asyncio.sleep", new=sleep_mock),
         ):
-            await coord._fetch_range(start, end, None, 0.0, 0.0)
+            await coord._fetch_range(start, end, None)
 
         # 3 fetches, 2 inter-request sleeps (no sleep before first).
         assert mock_client.async_get_usage_hourly.call_count == 3
@@ -515,11 +583,28 @@ class TestFetchRange:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _stub_stored_tou_bands():
+    """Default _get_stored_tou_bands to return an empty set for every test.
+
+    _fetch_and_import calls _get_stored_tou_bands, which touches the recorder;
+    these unit tests don't set one up. Tests exercising ToU wiring patch
+    coord._get_stored_tou_bands explicitly, shadowing this class-level default.
+    """
+    with patch.object(
+        HaggleCoordinator,
+        "_get_stored_tou_bands",
+        new_callable=AsyncMock,
+        return_value=set(),
+    ):
+        yield
+
+
 class TestFetchAndImport:
     async def test_no_previous_stats_starts_from_backfill_days_ago(
         self, hass: HomeAssistant
     ) -> None:
-        """First install: fetch_start = today - BACKFILL_DAYS, baseline 0.0."""
+        """First install: fetch_start = today - BACKFILL_DAYS."""
         mock_client = AsyncMock()
         mock_client.async_get_usage_summary.return_value = _empty_summary()
         mock_client.async_get_plan.return_value = _empty_plan()
@@ -542,19 +627,11 @@ class TestFetchAndImport:
         assert mock_range.called
         actual_start = mock_range.call_args[0][0]
         assert actual_start == expected_start
-        # Baseline is 0 on first install — no prior data.
-        assert mock_range.call_args.kwargs["initial_cons_sum"] == 0.0
-        assert mock_range.call_args.kwargs["initial_cost_sum"] == 0.0
 
     async def test_big_gap_resumes_incrementally_without_rewindow(
         self, hass: HomeAssistant
     ) -> None:
-        """Gap larger than REWINDOW_DAYS → resume from last_stat_date+1, throttled.
-
-        Used when the integration was offline or a backfill is mid-flight.
-        baseline = last_cons_sum (the last stored cumulative), not a lookup —
-        the trailing rewindow doesn't apply.
-        """
+        """Gap larger than REWINDOW_DAYS → resume from last_stat_date+1, throttled."""
         mock_client = AsyncMock()
         mock_client.async_get_usage_summary.return_value = _empty_summary()
         mock_client.async_get_plan.return_value = _empty_plan()
@@ -572,11 +649,6 @@ class TestFetchAndImport:
                 new_callable=AsyncMock,
                 return_value=(100.0, last_date),
             ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-            ) as mock_baseline,
             patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
         ):
             await coord._fetch_and_import()
@@ -585,10 +657,6 @@ class TestFetchAndImport:
         # Throttle: fetch_end at most BACKFILL_CHUNK_DAYS - 1 past fetch_start.
         fetch_end = mock_range.call_args[0][1]
         assert (fetch_end - expected_start).days <= BACKFILL_CHUNK_DAYS - 1
-        # Baseline lookup must NOT be used in the catch-up path.
-        mock_baseline.assert_not_called()
-        # initial_cons_sum is the last stored cumulative.
-        assert mock_range.call_args.kwargs["initial_cons_sum"] == 100.0
 
     async def test_trailing_rewindow_when_within_window(
         self, hass: HomeAssistant
@@ -611,12 +679,6 @@ class TestFetchAndImport:
                 new_callable=AsyncMock,
                 return_value=(500.0, last_date),
             ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-                return_value=(450.0, 380.0),
-            ) as mock_baseline,
             patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
         ):
             await coord._fetch_and_import()
@@ -624,11 +686,6 @@ class TestFetchAndImport:
         # Rewindow re-fetches even though last_stat_date is "up to date".
         mock_range.assert_called_once()
         assert mock_range.call_args[0][0] == expected_start
-        # Baseline lookup must be called for the rewindow path.
-        mock_baseline.assert_called_once()
-        # initial_* come from the baseline lookup, NOT last_cons_sum=500.0.
-        assert mock_range.call_args.kwargs["initial_cons_sum"] == 450.0
-        assert mock_range.call_args.kwargs["initial_cost_sum"] == 380.0
 
     async def test_rewindow_clamped_to_backfill_floor(
         self, hass: HomeAssistant
@@ -653,12 +710,6 @@ class TestFetchAndImport:
                 new_callable=AsyncMock,
                 return_value=(500.0, last_date),
             ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-                return_value=(450.0, 380.0),
-            ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
         ):
             await coord._fetch_and_import()
@@ -682,12 +733,6 @@ class TestFetchAndImport:
                 "_get_last_stat",
                 new_callable=AsyncMock,
                 return_value=(200.0, yesterday),
-            ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-                return_value=(180.0, 150.0),
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
@@ -718,12 +763,6 @@ class TestFetchAndImport:
                 "_get_last_stat",
                 new_callable=AsyncMock,
                 return_value=(100.0, yesterday),
-            ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
@@ -765,12 +804,6 @@ class TestNumericGuards:
                 new_callable=AsyncMock,
                 return_value=(100.0, yesterday),
             ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
-            ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
             result = await coord._fetch_and_import()
@@ -806,12 +839,6 @@ class TestNumericGuards:
                 "_get_last_stat",
                 new_callable=AsyncMock,
                 return_value=(100.0, yesterday),
-            ),
-            patch.object(
-                coord,
-                "_get_baseline_sums",
-                new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
@@ -881,23 +908,6 @@ def _stat_ids(mock_add: MagicMock) -> list[str]:
     return [c[0][1]["statistic_id"] for c in mock_add.call_args_list]
 
 
-@pytest.fixture(autouse=True)
-def _stub_resolve_tou_state():
-    """Default the single ToU recorder entry point OFF for every test.
-
-    _fetch_and_import calls _resolve_tou_state, which touches the recorder;
-    these unit tests don't set one up. Tests exercising ToU wiring patch
-    coord._resolve_tou_state explicitly, shadowing this class-level default.
-    """
-    with patch.object(
-        HaggleCoordinator,
-        "_resolve_tou_state",
-        new_callable=AsyncMock,
-        return_value=(set(), {}),
-    ):
-        yield
-
-
 class TestImportIntervalsTou:
     async def test_tou_intervals_emit_aggregate_plus_per_tariff(
         self, hass: HomeAssistant
@@ -911,8 +921,20 @@ class TestImportIntervalsTou:
             _iv(datetime(2026, 4, 28, 2, 0, tzinfo=UTC), 0.2, 0.03, "normal"),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(intervals, 0.0, 0.0)
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+            patch.object(
+                coord,
+                "_get_tariff_baseline_sums",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         ids = _stat_ids(mock_add)
         assert mock_add.call_count == 10
@@ -931,8 +953,15 @@ class TestImportIntervalsTou:
             _iv(datetime(2026, 4, 28, 2, 0, tzinfo=UTC), 0.3, 0.10, "normal"),
         ]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(intervals, 0.0, 0.0)
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_intervals(intervals)
 
         assert mock_add.call_count == 2
         assert not coord._active_tou_bands
@@ -944,10 +973,20 @@ class TestImportIntervalsTou:
         coord = _make_coordinator(hass)
         intervals = [_iv(datetime(2026, 4, 28, 1, 0, tzinfo=UTC), 0.5, 0.16, "normal")]
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals, 0.0, 0.0, known_bands=frozenset({"peak"})
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+            patch.object(
+                coord,
+                "_get_tariff_baseline_sums",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            await coord._import_intervals(intervals, known_bands=frozenset({"peak"}))
 
         ids = _stat_ids(mock_add)
         assert mock_add.call_count == 4  # aggregate(2) + normal per-tariff(2)
@@ -956,20 +995,26 @@ class TestImportIntervalsTou:
     async def test_per_tariff_baseline_offset_applied(
         self, hass: HomeAssistant
     ) -> None:
-        """tariff_initial_sums offsets the per-tariff cumulative sum."""
+        """_get_tariff_baseline_sums offsets the per-tariff cumulative sum."""
         coord = _make_coordinator(hass)
         intervals = [_iv(datetime(2026, 4, 28, 7, 0, tzinfo=UTC), 1.0, 0.42, "peak")]
+        peak_cons_id, peak_cost_id = coord._tariff_stat_ids("peak")
 
-        with patch(_PATCH_ADD_STATS) as mock_add:
-            await coord._import_intervals(
-                intervals,
-                0.0,
-                0.0,
-                tariff_initial_sums={"peak": (10.0, 5.0)},
-                known_bands=frozenset({"peak"}),
-            )
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+            patch.object(
+                coord,
+                "_get_tariff_baseline_sums",
+                new=AsyncMock(return_value={peak_cons_id: 10.0, peak_cost_id: 5.0}),
+            ),
+        ):
+            await coord._import_intervals(intervals, known_bands=frozenset({"peak"}))
 
-        peak_cons_id = f"{DOMAIN}:{STAT_CONSUMPTION}_peak_{_CONTRACT}"
         for c in mock_add.call_args_list:
             if c[0][1]["statistic_id"] == peak_cons_id:
                 assert c[0][2][0]["sum"] == pytest.approx(11.0)
@@ -980,8 +1025,20 @@ class TestImportIntervalsTou:
     async def test_active_bands_updated_after_import(self, hass: HomeAssistant) -> None:
         coord = _make_coordinator(hass)
         intervals = [_iv(datetime(2026, 4, 28, 7, 0, tzinfo=UTC), 1.0, 0.42, "peak")]
-        with patch(_PATCH_ADD_STATS):
-            await coord._import_intervals(intervals, 0.0, 0.0)
+        with (
+            patch(_PATCH_ADD_STATS),
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+            patch.object(
+                coord,
+                "_get_tariff_baseline_sums",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            await coord._import_intervals(intervals)
         assert "peak" in coord._active_tou_bands
 
 
@@ -1027,8 +1084,20 @@ class TestTouRecorderHelpers:
     ) -> None:
         coord = _make_coordinator(hass)
         peak_cons_id, _ = coord._tariff_stat_ids("peak")
-        with patch(
-            _PATCH_GET_INSTANCE, _mock_get_instance({peak_cons_id: [{"sum": 1.0}]})
+        # Restore the real implementation on this instance (the autouse fixture
+        # patches the class-level method to return set(); these tests exercise
+        # the real recorder interaction via a _PATCH_GET_INSTANCE mock).
+        # _REAL_GET_STORED_TOU_BANDS was captured at module import time before
+        # any autouse fixture could replace the class attribute.
+        with (
+            patch.object(
+                coord,
+                "_get_stored_tou_bands",
+                new=_REAL_GET_STORED_TOU_BANDS.__get__(coord),
+            ),
+            patch(
+                _PATCH_GET_INSTANCE, _mock_get_instance({peak_cons_id: [{"sum": 1.0}]})
+            ),
         ):
             bands = await coord._get_stored_tou_bands()
         assert bands == {"peak"}
@@ -1037,7 +1106,14 @@ class TestTouRecorderHelpers:
         self, hass: HomeAssistant
     ) -> None:
         coord = _make_coordinator(hass)
-        with patch(_PATCH_GET_INSTANCE, _mock_get_instance({})):
+        with (
+            patch.object(
+                coord,
+                "_get_stored_tou_bands",
+                new=_REAL_GET_STORED_TOU_BANDS.__get__(coord),
+            ),
+            patch(_PATCH_GET_INSTANCE, _mock_get_instance({})),
+        ):
             assert await coord._get_stored_tou_bands() == set()
 
 
@@ -1078,15 +1154,9 @@ class TestFetchAndImportTou:
             ),
             patch.object(
                 coord,
-                "_get_baseline_sums",
+                "_get_stored_tou_bands",
                 new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
-            ),
-            patch.object(
-                coord,
-                "_resolve_tou_state",
-                new_callable=AsyncMock,
-                return_value=({"peak", "offpeak"}, {}),
+                return_value={"peak", "offpeak"},
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
@@ -1115,15 +1185,9 @@ class TestFetchAndImportTou:
             ),
             patch.object(
                 coord,
-                "_get_baseline_sums",
+                "_get_stored_tou_bands",
                 new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
-            ),
-            patch.object(
-                coord,
-                "_resolve_tou_state",
-                new_callable=AsyncMock,
-                return_value=(set(), {}),
+                return_value=set(),
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
         ):
@@ -1157,15 +1221,9 @@ class TestFetchAndImportTou:
             ),
             patch.object(
                 coord,
-                "_get_baseline_sums",
+                "_get_stored_tou_bands",
                 new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
-            ),
-            patch.object(
-                coord,
-                "_resolve_tou_state",
-                new_callable=AsyncMock,
-                return_value=({"peak"}, {}),
+                return_value={"peak"},
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
             patch.object(
@@ -1195,15 +1253,9 @@ class TestFetchAndImportTou:
             ),
             patch.object(
                 coord,
-                "_get_baseline_sums",
+                "_get_stored_tou_bands",
                 new_callable=AsyncMock,
-                return_value=(80.0, 60.0),
-            ),
-            patch.object(
-                coord,
-                "_resolve_tou_state",
-                new_callable=AsyncMock,
-                return_value=({"peak"}, {}),
+                return_value={"peak"},
             ),
             patch.object(coord, "_fetch_range", new_callable=AsyncMock),
             patch.object(


### PR DESCRIPTION
## Problem

The Energy dashboard showed a phantom kWh spike at every **local midnight**. Confirmed against the live recorder (`haggle:consumption_<contract>`): 8 hourly `sum` jumps of **10–27 kWh**, *all* landing at exactly `T14:00Z` (= 00:00 AEST), while the per-hour `state` stayed a normal ~1–2 kWh. The ToU `consumption_normal` series carried the same spikes.

```
2026-05-21 14:00Z  sum +26.96  (state 2.27)
2026-05-22 14:00Z  sum +23.60  (state 1.91)
...
2026-06-12 14:00Z  sum +13.05
```

## Root cause

The trailing-rewindow cumulative-sum baseline was looked up at `fetch_start` **UTC midnight**. But AGL's `period=YYYY-MM-DD` day query is interpreted in the contract's **local timezone**, so the first interval returned lands at `(fetch_start - 1)T14:00Z` for an AEST account. A cutoff at `fetch_start T00:00Z` folded ~10 h of about-to-be-overwritten rows into the baseline; the rebuilt chain then re-added those hours' deltas — a `+N kWh` jump in the `sum` column every local-midnight UTC row. The Energy dashboard plots hourly deltas as `sum[h] - sum[h-1]`, so the spike was visible there even though `state` was always correct.

v0.3.0 carried the bug in **both** the aggregate path (`_resolve_resume_point`) and the new per-tariff ToU path (`_resolve_tou_state`).

## Fix

Resolve the baseline **inside `_import_intervals`**, for the aggregate *and* every per-tariff series, using `min(hour_cons)` (the actual earliest fetched-interval hour) as the `statistics_during_period` cutoff. This is correct regardless of timezone or DST, since the cutoff is derived from the data AGL actually returned rather than a guessed UTC boundary.

- `_resolve_resume_point` → sync `_resolve_fetch_start` (returns only `fetch_start`).
- `_resolve_tou_state` removed; `_fetch_and_import` marks known bands directly.
- Bucketing extracted to `_bucket_hourly`.
- Net **−1 recorder round-trip per poll** (the cost-stat resume lookup is gone).

## Verification

- 128 tests pass; ruff, ruff-format, mypy, manifest, pre-commit all clean.
- New regression test `test_baseline_looked_up_at_earliest_fetched_hour` asserts the cutoff equals the earliest fetched hour (out-of-order input).
- Reviewed by `energy-domain-expert` (all 5 cumulative-sum cases — rewindow, big-gap, first-install, sparse ToU band, idempotency — confirmed correct) and `async-performance-reviewer` (no blocking I/O; round-trip count improved).

## Recovery note (in CHANGELOG)

Rows inside the current 7-day rewindow self-heal on the next poll. Older phantom rows outside the rewindow need a `haggle:*` stats wipe + 30-day backfill to clear. **Not done in this PR** — deploying the rebuild before this fix is live would just regenerate the spikes.

Related: #114 (per-tariff baseline hardening) — this makes the per-tariff baseline timezone-correct but does not close that issue's long-absent-band lookback concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)