### PR TITLE
chore(deps): dependency rollup 2026-06-23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:python"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -13,7 +13,7 @@ jobs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main@2026-01-26
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -13,5 +13,5 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658 # master@2026-04-07
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master@2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `homeassistant` floor from `>=2026.5.1` to `>=2026.6.3` (Dependabot #111); aligned `hacs.json` floor to match.
+- Bumped `aiohttp` floor from `>=3.13.5` to `>=3.14.1` (Dependabot #106).
+- Bumped `pytest-homeassistant-custom-component` pin from `>=0.13.330,<0.13.331` to `>=0.13.339,<0.13.340`; updated alignment comment (Dependabot #110).
+- Bumped `ruff` floor from `>=0.15.13` to `>=0.15.17` (Dependabot #112).
+- Bumped `actions/checkout` from `v6.0.2` to `v6.0.3` in all workflows (Dependabot #96).
+- Bumped `astral-sh/setup-uv` from `v8.1.0` to `v8.2.0` in `ci.yml` (Dependabot #93).
+- Bumped `codecov/codecov-action` from `v6.0.1` to `v7.0.0` in `ci.yml` (Dependabot #102).
+- Bumped `home-assistant/actions` SHA in `hassfest.yml` (Dependabot #103).
+- Bumped `github/codeql-action` from `v4.36.0` to `v4.36.2` in `codeql.yml` (Dependabot #104).
+
 ### Targets for next sprint
 
 - #90 — validate the ToU plan rate-mapping heuristic against a real ToU capture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped `homeassistant` floor from `>=2026.5.1` to `>=2026.6.3` (Dependabot #111); aligned `hacs.json` floor to match.
-- Bumped `aiohttp` floor from `>=3.13.5` to `>=3.14.1` (Dependabot #106).
 - Bumped `pytest-homeassistant-custom-component` pin from `>=0.13.330,<0.13.331` to `>=0.13.339,<0.13.340`; updated alignment comment (Dependabot #110).
 - Bumped `ruff` floor from `>=0.15.13` to `>=0.15.17` (Dependabot #112).
 - Bumped `actions/checkout` from `v6.0.2` to `v6.0.3` in all workflows (Dependabot #96).

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.6.3",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
-    "aiohttp>=3.13.5",
+    "homeassistant>=2026.6.3",
+    "aiohttp>=3.14.1",
 ]
 
 [project.optional-dependencies]
@@ -35,10 +35,10 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
+    # 0.13.339 pins homeassistant==2026.6.3 — keep test harness aligned with
     # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
-    "ruff>=0.15.13",
+    "pytest-homeassistant-custom-component>=0.13.339,<0.13.340",
+    "ruff>=0.15.17",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
     "homeassistant>=2026.6.3",
-    "aiohttp>=3.14.1",
+    "aiohttp>=3.13.5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Automated dependency rollup — bundles 8 open Dependabot PRs into one reviewable diff.

## pip dependency floors

| Package | Before | After | Dependabot PR |
|---|---|---|---|
| `homeassistant` | `>=2026.5.1` | `>=2026.6.3` | Closes #111 |
| `pytest-homeassistant-custom-component` | `>=0.13.330,<0.13.331` | `>=0.13.339,<0.13.340` | Closes #110 |
| `ruff` | `>=0.15.13` | `>=0.15.17` | Closes #112 |

`hacs.json` homeassistant floor lifted to match (`2026.5.1` → `2026.6.3`). Alignment comment in `pyproject.toml` updated to reflect the new `pytest-homeassistant-custom-component` pin.

**Excluded: `aiohttp` floor bump (#106)** — `homeassistant 2026.6.3` and `2026.6.4` both pin `aiohttp==3.13.5`, so raising our floor to `>=3.14.1` makes the dependency graph unsatisfiable. The `aiohttp` entry in `pyproject.toml` mirrors what HA provides at runtime and must not be bumped independently. PR #106 is left open for the next HA release that ships a newer aiohttp.

## GitHub Actions SHA pins

| Action | Before | After | Dependabot PR |
|---|---|---|---|
| `actions/checkout` | `v6.0.2` | `v6.0.3` | Closes #96 |
| `astral-sh/setup-uv` | `v8.1.0` | `v8.2.0` | Closes #93 |
| `codecov/codecov-action` | `v6.0.1` | `v7.0.0` | Closes #102 |
| `home-assistant/actions` | `868e6cb…` | `e91ad19…` | Closes #103 |
| `github/codeql-action` | `v4.36.0` | `v4.36.2` | Closes #104 |

All SHAs are pinned per project policy (no floating `@main`/`@vN` refs). `release.yml` is excluded per triage ground rules — the `actions/checkout` bump there is left for the maintainer.

## Notes

- Local pipeline could not be run (container provides Python 3.14.0rc2; project requires `>=3.14.2`). CI on GitHub validates with real 3.14.
- DO NOT MERGE until CI is green.