### PR TITLE
v0.3.2: dependency drain (HA 2026.6.3 floor) + #114 baseline fix + #91 decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:python"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -13,7 +13,7 @@ jobs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main@2026-01-26
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -13,5 +13,5 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658 # master@2026-04-07
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master@2026-04-07

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,17 @@ dashboard renders hourly deltas as `sum[h] - sum[h-1]`, so the spike was
 visible there). Using the earliest fetched hour is correct regardless of
 timezone or DST.
 
+The baseline lookup itself (`_baseline_sums_before`) is **two-stage**: a cheap
+batched window of `look_back_days` ending at the cutoff (2 days for the
+aggregate, `BACKFILL_DAYS` for per-tariff series), and — only for a series with
+NO rows in that window — a reach-back lookup from the start of recorded history.
+Both stages stay strictly *before* the cutoff, so neither ever reads a sum from
+inside the rewindow rows about to be rewritten (this is why `get_last_statistics`
+is wrong here). Without the reach-back, a ToU band absent for longer than the
+window and then reappearing inside the rewindow would reset its cumulative sum to
+0.0 — a downward step breaking that series' `TOTAL_INCREASING` monotonicity
+(#114, fixed v0.3.2).
+
 ### Previous Bill Period
 
 ```
@@ -479,6 +490,13 @@ The HA Energy dashboard requires:
   whose `config_entry_id` references the now-gone entry; reinstall causes
   `_2`-suffixed sensor IDs that linger as `unavailable` forever. See
   `__init__.py::async_remove_entry`.
+- **Don't clear the `haggle:*` external statistics in `async_remove_entry`.**
+  Those rows are the user's own historical energy/cost data; deleting them on
+  uninstall would silently and unrecoverably destroy years of Energy-dashboard
+  history. Orphaned statistics are harmless and the user can prune them via
+  Developer Tools → Statistics. Decided won't-implement on #91 (v0.3.2);
+  `async_remove_entry` documents the deliberate omission. Do not add
+  `async_clear_statistics` here without an explicit opt-in.
 - **Don't fire backfill requests in a tight loop.** AGL's BFF will 429
   if 7 sequential GETs land in <1 s. `_fetch_range` sleeps
   `BACKFILL_INTER_REQUEST_DELAY` between days and breaks out of the chunk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Targets for next sprint
 
 - #90 — validate the ToU plan rate-mapping heuristic against a real ToU capture.
-- #91 — clear external statistics on integration removal.
-- #114 — harden the per-tariff cumulative-sum baseline for long-absent bands.
+
+---
+
+## [0.3.2] — 2026-06-24
+
+### Fixed
+
+- **Per-tariff cumulative-sum baseline could reset to 0 for a long-absent band
+  (#114).** The trailing-rewindow baseline lookup searched only the
+  `BACKFILL_DAYS` (30-day) window before the fetch cutoff. A ToU band absent for
+  longer than that window but with older stored history resolved to a `0.0`
+  baseline; if the band then reappeared inside the 7-day rewindow, its cumulative
+  `sum` restarted from zero — a downward step that breaks the per-band
+  `TOTAL_INCREASING` monotonicity for that one series. Baseline resolution now
+  has a second, reach-back stage: any series with no rows in the normal window is
+  looked up again from the start of recorded history, still bounded strictly
+  *before* the fetch cutoff (never `get_last_statistics`, which would read a sum
+  from inside the rewindow rows about to be rewritten). The cheap windowed lookup
+  still resolves the normal and sparse-but-recent case in a single batched call;
+  the reach-back fires only for genuinely missing series. The same hardening now
+  also covers the aggregate baseline. Regression tests:
+  `test_baseline_reaches_back_when_band_absent_from_window`,
+  `test_baseline_no_reach_back_when_band_in_window`, and a per-hour partition
+  assertion `test_per_tariff_states_partition_aggregate`.
+
+### Changed
+
+- **Platform floor raised to Home Assistant 2026.6.3** (was 2026.5.1) and
+  **`aiohttp>=3.14.1`** (was 3.13.5); `hacs.json` minimum bumped to match, so
+  HACS refuses to install on older HA. Test harness pinned to
+  `pytest-homeassistant-custom-component>=0.13.339,<0.13.340` to track the new HA
+  patch, and dev-tooling floor `ruff>=0.15.17`.
+- **GitHub Actions rolled forward (all SHA-pinned)**: `actions/checkout` v6.0.3,
+  `astral-sh/setup-uv` v8.2.0, `codecov/codecov-action` v7.0.0,
+  `github/codeql-action` v4.36.2, and `home-assistant/actions/hassfest`.
+
+### Notes
+
+- **#91 (clear external statistics on uninstall) — resolved as won't-implement,
+  retain history.** Deleting the `haggle:*` recorder statistics on uninstall
+  would silently and unrecoverably destroy the user's historical Energy-dashboard
+  data. Orphaned statistics are harmless and the user can prune them on their own
+  terms via **Developer Tools → Statistics**. `async_remove_entry` now documents
+  the deliberate omission so it isn't "fixed" later.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Platform floor raised to Home Assistant 2026.6.3** (was 2026.5.1) and
-  **`aiohttp>=3.14.1`** (was 3.13.5); `hacs.json` minimum bumped to match, so
-  HACS refuses to install on older HA. Test harness pinned to
-  `pytest-homeassistant-custom-component>=0.13.339,<0.13.340` to track the new HA
-  patch, and dev-tooling floor `ruff>=0.15.17`.
+- **Platform floor raised to Home Assistant 2026.6.3** (was 2026.5.1);
+  `hacs.json` minimum bumped to match, so HACS refuses to install on older HA.
+  Test harness pinned to `pytest-homeassistant-custom-component>=0.13.339,<0.13.340`
+  (which pins `homeassistant==2026.6.3`), and dev-tooling floor `ruff>=0.15.17`.
+  `aiohttp` stays at `>=3.13.5`: HA pins `aiohttp==3.13.5` exactly, so the
+  dependabot `aiohttp>=3.14.1` bump (#106) is unsatisfiable until HA moves it
+  upstream — left open rather than merged.
 - **GitHub Actions rolled forward (all SHA-pinned)**: `actions/checkout` v6.0.3,
   `astral-sh/setup-uv` v8.2.0, `codecov/codecov-action` v7.0.0,
   `github/codeql-action` v4.36.2, and `home-assistant/actions/hassfest`.

--- a/custom_components/haggle/__init__.py
+++ b/custom_components/haggle/__init__.py
@@ -151,6 +151,15 @@ async def async_remove_entry(hass: HomeAssistant, entry: HaggleConfigEntry) -> N
     `config_entry_id` references the now-gone entry. On reinstall, HA
     sees an entity_id collision and renames the new sensors with a `_2`
     suffix; the orphans then linger forever as `unavailable`.
+
+    Deliberately does NOT clear the `haggle:*` external statistics from the
+    recorder (#91). Those rows are the user's own historical energy/cost data;
+    silently destroying years of Energy-dashboard history on an uninstall would
+    be surprising and unrecoverable. Orphaned statistics are harmless and the
+    user can prune them on their own terms via
+    Developer Tools → Statistics → "Fix issue" (orphaned statistics), so the
+    non-destructive default is the right one. Do not add async_clear_statistics
+    here without an explicit opt-in.
     """
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, entry.entry_id)

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -62,6 +62,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Lower bound for the reach-back baseline lookup (#114). Earlier than any
+# possible recorder row, so a series whose last stored hour predates the normal
+# look-back window is still found. Bounded ABOVE at the fetch cutoff by the
+# caller, so it never reads a sum from inside the rewindow being rewritten.
+_EARLIEST_HISTORY = datetime(1970, 1, 1, tzinfo=UTC)
+
 
 def _safe_float(raw: Any) -> float:
     """Coerce raw API value to a non-negative finite float, defaulting to 0.0."""
@@ -314,34 +320,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         """Return cumulative sums at the last hour strictly before before_dt.
 
         Used by the trailing-rewindow path so newly-imported rows resume from
-        the correct baseline. Looks back 2 days to tolerate sparse data.
-        Returns (0.0, 0.0) if no rows exist in the look-back window.
+        the correct baseline. Looks back 2 days to tolerate sparse data, with a
+        reach-back fallback for a series whose last row predates that window.
+        Returns (0.0, 0.0) if the series has no stored rows at all.
         """
-        from homeassistant.components.recorder.statistics import (
-            statistics_during_period,
+        sums = await self._baseline_sums_before(
+            {stat_id_cons, stat_id_cost}, before_dt, look_back_days=2
         )
-        from homeassistant.helpers.recorder import get_instance
-
-        look_back = before_dt - timedelta(days=2)
-        result = await get_instance(self.hass).async_add_executor_job(
-            statistics_during_period,
-            self.hass,
-            look_back,
-            before_dt,
-            {stat_id_cons, stat_id_cost},
-            "hour",
-            None,
-            {"sum"},
-        )
-
-        def _last_sum(stat_id: str) -> float:
-            rows = result.get(stat_id) or []
-            if not rows:
-                return 0.0
-            last = rows[-1].get("sum")
-            return float(last) if last is not None else 0.0
-
-        return _last_sum(stat_id_cons), _last_sum(stat_id_cost)
+        return sums[stat_id_cons], sums[stat_id_cost]
 
     async def _get_tariff_baseline_sums(
         self, stat_ids: set[str], before_dt: datetime
@@ -351,8 +337,33 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         Batched (one recorder call for all per-tariff series) so adding ToU
         doesn't multiply executor round-trips. Looks back BACKFILL_DAYS — wide
         enough that a sparse band (e.g. shoulder only on weekdays) still finds
-        its true last sum rather than resetting to 0.0. Series with no rows in
-        the window return 0.0.
+        its true last sum rather than resetting to 0.0.
+        """
+        return await self._baseline_sums_before(
+            set(stat_ids), before_dt, look_back_days=BACKFILL_DAYS
+        )
+
+    async def _baseline_sums_before(
+        self, stat_ids: set[str], before_dt: datetime, *, look_back_days: int
+    ) -> dict[str, float]:
+        """Return {stat_id: cumulative sum at the last hour strictly before before_dt}.
+
+        Resolution is two-stage. First a cheap bounded window of `look_back_days`
+        ending at before_dt — this covers the normal case and every
+        sparse-but-recent band in a single batched recorder call. Any series
+        with NO rows in that window is then resolved with a second lookup that
+        reaches back to the start of recorded history (still bounded above at
+        before_dt).
+
+        The reach-back stage exists for #114: a per-tariff band can be absent
+        for longer than the window (e.g. a shoulder band the plan stops using
+        for a month) and then reappear inside the trailing rewindow. Without it
+        the baseline falls to 0.0 and _emit_series restarts that series'
+        cumulative sum from zero — a downward step that breaks its
+        TOTAL_INCREASING monotonicity. The lookup stays strictly *before*
+        before_dt (never get_last_statistics) precisely so it cannot read a sum
+        from inside the rewindow rows about to be rewritten. A series with no
+        stored rows at all resolves to 0.0.
         """
         if not stat_ids:
             return {}
@@ -361,22 +372,33 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         from homeassistant.helpers.recorder import get_instance
 
-        look_back = before_dt - timedelta(days=BACKFILL_DAYS)
-        result = await get_instance(self.hass).async_add_executor_job(
-            statistics_during_period,
-            self.hass,
-            look_back,
-            before_dt,
-            set(stat_ids),
-            "hour",
-            None,
-            {"sum"},
-        )
-        out: dict[str, float] = {}
+        instance = get_instance(self.hass)
+
+        async def _last_sums(start_dt: datetime, ids: set[str]) -> dict[str, float]:
+            result = await instance.async_add_executor_job(
+                statistics_during_period,
+                self.hass,
+                start_dt,
+                before_dt,
+                set(ids),
+                "hour",
+                None,
+                {"sum"},
+            )
+            sums: dict[str, float] = {}
+            for stat_id in ids:
+                rows = result.get(stat_id) or []
+                last = rows[-1].get("sum") if rows else None
+                if last is not None:
+                    sums[stat_id] = float(last)
+            return sums
+
+        out = await _last_sums(before_dt - timedelta(days=look_back_days), stat_ids)
+        missing = {stat_id for stat_id in stat_ids if stat_id not in out}
+        if missing:
+            out.update(await _last_sums(_EARLIEST_HISTORY, missing))
         for stat_id in stat_ids:
-            rows = result.get(stat_id) or []
-            last = rows[-1].get("sum") if rows else None
-            out[stat_id] = float(last) if last is not None else 0.0
+            out.setdefault(stat_id, 0.0)
         return out
 
     async def _get_stored_tou_bands(self) -> set[str]:

--- a/custom_components/haggle/manifest.json
+++ b/custom_components/haggle/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.haggle"],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.6.3",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ dependencies = [
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
     "homeassistant>=2026.6.3",
-    "aiohttp>=3.14.1",
+    # HA pins aiohttp==3.13.5 exactly (still true on 2026.6.3/6.4), so this
+    # floor cannot move ahead of HA — the aiohttp>=3.14.1 bump (#106) is
+    # unsatisfiable until HA bumps it upstream.
+    "aiohttp>=3.13.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
-    "aiohttp>=3.13.5",
+    "homeassistant>=2026.6.3",
+    "aiohttp>=3.14.1",
 ]
 
 [project.optional-dependencies]
@@ -35,10 +35,10 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
-    # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
-    "ruff>=0.15.13",
+    # Pins a specific homeassistant patch — keep this aligned with the runtime
+    # floor above so transitive resolution stays consistent.
+    "pytest-homeassistant-custom-component>=0.13.339,<0.13.340",
+    "ruff>=0.15.17",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -945,6 +945,50 @@ class TestImportIntervalsTou:
             assert f"{DOMAIN}:{STAT_CONSUMPTION}_{band}_{_CONTRACT}" in ids
             assert f"{DOMAIN}:cost_{band}_{_CONTRACT}" in ids
 
+    async def test_per_tariff_states_partition_aggregate(
+        self, hass: HomeAssistant
+    ) -> None:
+        """#114: per-tariff consumption states sum back to the aggregate state,
+        hour by hour — so the per-band series are a true partition with no kWh
+        lost or double-counted (presence/count alone wouldn't catch a drop)."""
+        coord = _make_coordinator(hass)
+        intervals = [
+            # Two bands sharing the 07:00 UTC hour, plus a second hour, so the
+            # partition is checked per-hour and not merely in total.
+            _iv(datetime(2026, 4, 28, 7, 0, tzinfo=UTC), 1.0, 0.42, "peak"),
+            _iv(datetime(2026, 4, 28, 7, 30, tzinfo=UTC), 0.5, 0.20, "shoulder"),
+            _iv(datetime(2026, 4, 28, 8, 0, tzinfo=UTC), 0.4, 0.07, "offpeak"),
+            _iv(datetime(2026, 4, 28, 8, 30, tzinfo=UTC), 0.2, 0.03, "normal"),
+        ]
+
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord, "_get_baseline_sums", new=AsyncMock(return_value=(0.0, 0.0))
+            ),
+            patch.object(
+                coord, "_get_tariff_baseline_sums", new=AsyncMock(return_value={})
+            ),
+        ):
+            await coord._import_intervals(intervals)
+
+        # {statistic_id: {hour_start: state}} across every emitted series.
+        states: dict[str, dict[datetime, float]] = {}
+        for call in mock_add.call_args_list:
+            stat_id = call[0][1]["statistic_id"]
+            states[stat_id] = {s["start"]: s["state"] for s in call[0][2]}
+
+        agg = states[f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"]
+        bands = ("peak", "offpeak", "shoulder", "normal")
+        for hour, agg_state in agg.items():
+            band_total = sum(
+                states.get(f"{DOMAIN}:{STAT_CONSUMPTION}_{b}_{_CONTRACT}", {}).get(
+                    hour, 0.0
+                )
+                for b in bands
+            )
+            assert band_total == pytest.approx(agg_state)
+
     async def test_flat_rate_only_emits_aggregate(self, hass: HomeAssistant) -> None:
         """Only `normal` intervals and no known ToU bands → aggregate series only."""
         coord = _make_coordinator(hass)
@@ -1078,6 +1122,53 @@ class TestTouRecorderHelpers:
         with patch(_PATCH_GET_INSTANCE, _mock_get_instance({})):
             out = await coord._get_tariff_baseline_sums({cons_id}, datetime.now(UTC))
         assert out[cons_id] == 0.0
+
+    async def test_baseline_reaches_back_when_band_absent_from_window(
+        self, hass: HomeAssistant
+    ) -> None:
+        """#114: a band with no rows in the look-back window but older stored
+        history resumes from its true last sum — not 0.0 — so a band that goes
+        quiet for longer than the window then reappears inside the trailing
+        rewindow keeps its cumulative sum monotonic instead of stepping down.
+        """
+        from custom_components.haggle.coordinator import _EARLIEST_HISTORY
+
+        coord = _make_coordinator(hass)
+        cons_id, _ = coord._tariff_stat_ids("shoulder")
+        before = datetime(2026, 6, 1, tzinfo=UTC)
+
+        def _executor(_func: object, _hass: object, start_dt: datetime, *_rest: object):
+            # Narrow window → band absent; reach-back to history start → found.
+            if start_dt == _EARLIEST_HISTORY:
+                return {cons_id: [{"sum": 5.0}, {"sum": 42.0}]}
+            return {}
+
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(side_effect=_executor)
+        with patch(_PATCH_GET_INSTANCE, MagicMock(return_value=mock_instance)):
+            out = await coord._get_tariff_baseline_sums({cons_id}, before)
+
+        assert out[cons_id] == pytest.approx(42.0)
+        # Two recorder calls: the narrow window, then the reach-back fallback.
+        assert mock_instance.async_add_executor_job.await_count == 2
+
+    async def test_baseline_no_reach_back_when_band_in_window(
+        self, hass: HomeAssistant
+    ) -> None:
+        """#114: when the band has rows in the normal look-back window, the
+        extra reach-back lookup is skipped (a single recorder round-trip)."""
+        coord = _make_coordinator(hass)
+        cons_id, _ = coord._tariff_stat_ids("peak")
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(
+            return_value={cons_id: [{"sum": 9.0}]}
+        )
+        with patch(_PATCH_GET_INSTANCE, MagicMock(return_value=mock_instance)):
+            out = await coord._get_tariff_baseline_sums(
+                {cons_id}, datetime(2026, 6, 1, tzinfo=UTC)
+            )
+        assert out[cons_id] == pytest.approx(9.0)
+        assert mock_instance.async_add_executor_job.await_count == 1
 
     async def test_stored_tou_bands_detects_present_band(
         self, hass: HomeAssistant


### PR DESCRIPTION
## Summary

Cuts the work for **v0.3.2**: drains the open dependabot queue (including the deliberate platform-floor bump), fixes the #114 per-tariff baseline bug, and records the #91 decision. Prep only — **no tag is cut**; merge then run `/release 0.3.2`.

### Fixed — #114 (per-tariff baseline reset)
The trailing-rewindow baseline lookup searched only the `BACKFILL_DAYS` (30-day) window before the fetch cutoff. A ToU band absent longer than that window but with older stored history resolved to a `0.0` baseline; if it then reappeared inside the 7-day rewindow, its cumulative `sum` restarted from zero — a downward step breaking that series' `TOTAL_INCREASING` monotonicity.

`_baseline_sums_before` (now shared by the aggregate and per-tariff paths) gains a second **reach-back** stage: any series with no rows in the normal window is looked up again from the start of recorded history, still bounded strictly *before* the fetch cutoff so it never reads a sum from inside the rewindow rows about to be rewritten (this is why `get_last_statistics` is wrong here). The cheap windowed lookup still resolves the normal/sparse-but-recent case in one batched call; the reach-back only fires for genuinely missing series. The aggregate baseline now gets the same hardening.

New regression tests: `test_baseline_reaches_back_when_band_absent_from_window`, `test_baseline_no_reach_back_when_band_in_window`, and a per-hour partition assertion `test_per_tariff_states_partition_aggregate`.

### Changed — dependency drain (platform floor included, per maintainer decision)
- HA `>=2026.5.1 → >=2026.6.3` (#111); `hacs.json` minimum bumped to match.
- `pytest-homeassistant-custom-component >=0.13.339,<0.13.340` (#110, pins `homeassistant==2026.6.3`); `ruff >=0.15.17` (#112).
- Actions (all SHA-pinned): checkout v6.0.3 (#96), setup-uv v8.2.0 (#93), codecov v7.0.0 (#102), codeql v4.36.2 (#104), hassfest (#103).
- **`aiohttp` stays at `>=3.13.5` — NOT bumped.** HA pins `aiohttp==3.13.5` exactly (still true on 2026.6.3/6.4), so dependabot's `aiohttp>=3.14.1` (#106) is unsatisfiable and can't land until HA bumps it upstream. CI caught this on the first push; #106 is left **open/deferred**, not closed by this PR.

### Decided — #91 (retain history)
Clearing the `haggle:*` external statistics on uninstall would silently and unrecoverably destroy the user's Energy-dashboard history. Resolved as **won't-implement**: orphaned statistics are harmless and prunable via Developer Tools → Statistics. `async_remove_entry` and AGENTS.md now document the deliberate omission.

`#90` (validate ToU heuristic against a real ToU capture) is left open — it needs a real ToU account capture that isn't available.

## ⚠️ uv.lock not regenerated
The authoring environment only has Python `3.14.0rc2`; the project floor is `>=3.14.2`, so `uv lock` can't run here. **`uv.lock` must be relocked under Python ≥3.14.2 before release.** CI uses unpinned `uv sync`, so it re-resolves against the new floors and validates the bump regardless — but please run `uv lock` locally so the committed lock isn't stale.

## Local validation
- `ruff check` + `ruff format --check` (0.15.17): clean across `custom_components/` + `tests/`
- `scripts/validate_manifest.py`: OK
- JSON/YAML/TOML sanity: OK
- ⚠️ `mypy` and `pytest` not run locally (no Python ≥3.14.2) — relying on CI.

## Documentation checklist
- [x] CHANGELOG.md — dated `[0.3.2]` entry; `[Unreleased]` trimmed to #90
- [x] AGENTS.md — rewindow baseline section (reach-back) + "What NOT to Do" (#91)
- [x] manifest.json `version` → 0.3.2

Closes #114
Closes #91
Closes #93, #96, #102, #103, #104, #110, #111, #112

(#106 intentionally left open — blocked by HA's exact aiohttp pin.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)