### PR TITLE
chore(deps): dependency rollup 2026-06-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=custom_components/haggle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.python-version == '3.14'
         with:
           files: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:python"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -13,7 +13,7 @@ jobs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main@2026-01-26
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -13,5 +13,5 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658 # master@2026-04-07
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master@2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dependency rollup 2026-06-26: `pytest` floor `>=8.0` → `>=9.1.1` (#120);
+  `homeassistant` runtime floor `>=2026.5.1` → `>=2026.6.3` (#111);
+  `pytest-homeassistant-custom-component` pin `0.13.330` → `0.13.339`
+  (HA 2026.6.3 test harness, #110); `ruff` `>=0.15.13` → `>=0.15.19` (#112,
+  #122); `hacs.json` minimum lifted to match. GitHub Actions SHA pins:
+  `actions/checkout` v6.0.3 (#96), `astral-sh/setup-uv` v8.2.0 (#93),
+  `codecov/codecov-action` v7.0.0 (#102), `home-assistant/actions/hassfest`
+  SHA updated (#103), `github/codeql-action` v4.36.2 (#104).
+
 ### Targets for next sprint
 
 - #90 — validate the ToU plan rate-mapping heuristic against a real ToU capture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Dependency rollup 2026-06-26: `pytest` floor `>=8.0` → `>=9.1.1` (#120);
-  `homeassistant` runtime floor `>=2026.5.1` → `>=2026.6.3` (#111);
-  `pytest-homeassistant-custom-component` pin `0.13.330` → `0.13.339`
-  (HA 2026.6.3 test harness, #110); `ruff` `>=0.15.13` → `>=0.15.19` (#112,
-  #122); `hacs.json` minimum lifted to match. GitHub Actions SHA pins:
-  `actions/checkout` v6.0.3 (#96), `astral-sh/setup-uv` v8.2.0 (#93),
-  `codecov/codecov-action` v7.0.0 (#102), `home-assistant/actions/hassfest`
-  SHA updated (#103), `github/codeql-action` v4.36.2 (#104).
+- Dependency rollup 2026-06-26: `homeassistant` runtime floor `>=2026.5.1` →
+  `>=2026.6.3` (#111); `pytest-homeassistant-custom-component` pin `0.13.330`
+  → `0.13.339` (HA 2026.6.3 test harness, #110); `ruff` `>=0.15.13` →
+  `>=0.15.19` (#112, #122); `hacs.json` minimum lifted to match. GitHub
+  Actions SHA pins: `actions/checkout` v6.0.3 (#96), `astral-sh/setup-uv`
+  v8.2.0 (#93), `codecov/codecov-action` v7.0.0 (#102),
+  `home-assistant/actions/hassfest` SHA updated (#103), `github/codeql-action`
+  v4.36.2 (#104). `pytest` floor left at `>=8.0` — PHCC 0.13.339 pins
+  `pytest==9.0.3` which is incompatible with `>=9.1.1`; #120 deferred.
 
 ### Targets for next sprint
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "AGL Haggle",
   "country": "AU",
-  "homeassistant": "2026.5.1",
+  "homeassistant": "2026.6.3",
   "render_readme": true,
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,19 +26,22 @@ dependencies = [
     # HA 2026.4 closed the 13 CVEs v0.1.0 inherited (SCA-M01..M05, SCA-L01..L08,
     # SCA-H02) via aiohttp==3.13.5 + cryptography>=46.0.6 + orjson>=3.11.6;
     # 2026.5.0 keeps those at-or-above. HA 2026.4+ also requires Python 3.14.2.
-    "homeassistant>=2026.5.1",
+    "homeassistant>=2026.6.3",
+    # HA pins aiohttp==3.13.5 exactly (still true on 2026.6.3/6.4), so this
+    # floor cannot move ahead of HA — the aiohttp>=3.14.1 bump (#106) is
+    # unsatisfiable until HA bumps it upstream.
     "aiohttp>=3.13.5",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.1.1",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
-    # 0.13.330 pins homeassistant==2026.5.1 — keep test harness aligned with
-    # the runtime floor above so transitive resolution stays consistent.
-    "pytest-homeassistant-custom-component>=0.13.330,<0.13.331",
-    "ruff>=0.15.13",
+    # Pins a specific homeassistant patch — keep this aligned with the runtime
+    # floor above so transitive resolution stays consistent.
+    "pytest-homeassistant-custom-component>=0.13.339,<0.13.340",
+    "ruff>=0.15.19",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=9.1.1",
+    "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.1.0",
     # Pins a specific homeassistant patch — keep this aligned with the runtime


### PR DESCRIPTION
## Summary

Bundles all safe Dependabot PRs open as of 2026-06-26 into a single rollup.

### Included Dependabot PRs (closed by this PR)

| PR | Change |
|---|---|
| #96 | `actions/checkout` v6.0.2 → v6.0.3 |
| #93 | `astral-sh/setup-uv` v8.1.0 → v8.2.0 |
| #102 | `codecov/codecov-action` v6.0.1 → v7.0.0 |
| #103 | `home-assistant/actions/hassfest` SHA updated |
| #104 | `github/codeql-action` v4.36.0 → v4.36.2 |
| #110 | `pytest-homeassistant-custom-component` 0.13.330 → 0.13.339 (HA 2026.6.3 harness) |
| #111 | `homeassistant` runtime floor >=2026.5.1 → >=2026.6.3 |
| #112 | `ruff` floor >=0.15.13 → >=0.15.15 |
| #122 | `ruff` floor → >=0.15.19 (supersedes #112) |

Also lifts `hacs.json` minimum to `2026.6.3` to match the PHCC pin (AGENTS.md invariant: PHCC pin, `hacs.json` minimum, and `homeassistant` runtime floor must stay in step).

Closes #93, #96, #102, #103, #104, #110, #111, #112, #122

### Excluded Dependabot PRs (need human decision)

| PR | Why excluded |
|---|---|
| #106 | `aiohttp >=3.14.1` — HA pins `aiohttp==3.13.5` exactly; unsatisfiable until HA bumps it |
| #120 | `pytest >=9.1.1` — PHCC 0.13.339 pins `pytest==9.0.3` exactly; `>=9.1.1` makes `uv sync` fail (confirmed by CI). Defer until PHCC bumps its pytest pin |
| #121 | `homeassistant >=2026.6.4` — unsatisfiable alongside PHCC 0.13.339 (pins homeassistant==2026.6.3); would need PHCC 0.13.341 |
| #123 | `pytest-homeassistant-custom-component >=0.13.341` — pins HA 2026.7.0b1 (beta); lifting `hacs.json` to a beta version blocks HACS stable users |

### Relationship to PR #119

PR #119 (`v0.3.2: dependency drain + #114 baseline fix + #91 decision`) covers the same dependency bumps as this rollup **plus** code fixes for #114 and #91. Both PRs touch the same files (`pyproject.toml`, `hacs.json`, `CHANGELOG.md`, workflow YAMLs). If #119 is merged first, this branch will need a rebase before it can merge (and will become a pure dep-only cleanup). If this PR lands first, #119 will need a rebase. Recommend merging #119 first if the code fixes are ready — it subsumes this work.

## Test plan

- [ ] CI (ruff, mypy, pytest on Python 3.14) green
- [ ] HACS validation green
- [ ] Hassfest green
- [ ] Confirm `hacs.json` minimum matches `pytest-homeassistant-custom-component` pin (both 2026.6.3)

**Note:** Local pipeline could not be run — container provides Python 3.11.15; project requires >=3.14.2. GitHub CI validates with the real Python 3.14 environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)