### PR TITLE
fix: filter "pending" consumption.type intervals (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser now filters `consumption.type = "pending"` intervals (#126).** AGL
+  returns `"pending"` (distinct from `"none"`) for 30-min and daily slots where
+  the AEMO meter read exists in their system but has not yet been delivered to the
+  BFF — confirmed via proxy trace. These slots carry non-zero `quantity`/`amount`
+  values that look real but are preliminary estimates; letting them through caused
+  phantom readings in the statistics that were never overwritten once the real AEMO
+  value arrived (unlike the zero-on-zero placeholder case). Both
+  `parse_interval_readings` and `parse_daily_readings` now skip `"pending"` the
+  same way they skip `"none"`.
+
 ### Targets for next sprint
 
 - #90 — validate the ToU plan rate-mapping heuristic against a real ToU capture.

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -90,19 +90,20 @@ def parse_overview(data: dict[str, Any]) -> list[Contract]:
 def parse_interval_readings(data: dict[str, Any]) -> list[IntervalReading]:
     """Parse /Hourly response into 30-min interval readings.
 
-    Filters out items with type='none' (future/unavailable slots) and
-    placeholder slots where kWh and cost are both zero (AGL returns these
-    for days where AEMO meter reads have not yet been delivered, even with
-    a non-``none`` type — they would otherwise create phantom flat rows in
-    the statistics table that the resume logic would never re-check).
+    Filters out items with type='none' or type='pending' (future/unavailable
+    slots) and placeholder slots where kWh and cost are both zero (AGL returns
+    these for days where AEMO meter reads have not yet been delivered, even with
+    a non-``none`` type — they would otherwise create phantom flat rows in the
+    statistics table that the resume logic would never re-check).
     dateTime is slot-start UTC; kwh from consumption.quantity (outer).
     """
+    _SKIP_TYPES = {"none", "pending"}
     readings: list[IntervalReading] = []
     for section in data.get("sections") or []:
         for item in section.get("items") or []:
             consumption = item.get("consumption") or {}
             rate_type: str = consumption.get("type", "none")
-            if rate_type == "none":
+            if rate_type in _SKIP_TYPES:
                 continue
             dt_str: str = item.get("dateTime", "")
             try:
@@ -137,7 +138,7 @@ def parse_daily_readings(data: dict[str, Any]) -> list[DailyReading]:
     for section in data.get("sections") or []:
         for item in section.get("items") or []:
             consumption = item.get("consumption") or {}
-            if consumption.get("type") == "none":
+            if consumption.get("type") in {"none", "pending"}:
                 continue
             dt_str: str = item.get("dateTime", "")
             try:

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -97,13 +97,13 @@ def parse_interval_readings(data: dict[str, Any]) -> list[IntervalReading]:
     statistics table that the resume logic would never re-check).
     dateTime is slot-start UTC; kwh from consumption.quantity (outer).
     """
-    _SKIP_TYPES = {"none", "pending"}
+    _skip_types = {"none", "pending"}
     readings: list[IntervalReading] = []
     for section in data.get("sections") or []:
         for item in section.get("items") or []:
             consumption = item.get("consumption") or {}
             rate_type: str = consumption.get("type", "none")
-            if rate_type in _SKIP_TYPES:
+            if rate_type in _skip_types:
                 continue
             dt_str: str = item.get("dateTime", "")
             try:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -225,6 +225,36 @@ class TestParseIntervalReadings:
         readings = parse_interval_readings(data)
         assert readings == []
 
+    def test_filters_pending_type(self) -> None:
+        """Intervals with type='pending' (AEMO data not yet available) must be dropped."""
+        data = {
+            "sections": [
+                {
+                    "items": [
+                        {
+                            "dateTime": "2026-07-01T00:00:00Z",
+                            "consumption": {
+                                "type": "pending",
+                                "quantity": 0.5,
+                                "amount": 0.1,
+                            },
+                        },
+                        {
+                            "dateTime": "2026-07-01T00:30:00Z",
+                            "consumption": {
+                                "type": "normal",
+                                "quantity": 0.3,
+                                "amount": 0.05,
+                            },
+                        },
+                    ]
+                }
+            ]
+        }
+        readings = parse_interval_readings(data)
+        assert len(readings) == 1
+        assert readings[0].rate_type == "normal"
+
 
 # ---------------------------------------------------------------------------
 # parse_overview
@@ -470,6 +500,36 @@ class TestParseDailyReadings:
         }
         readings = parse_daily_readings(data)
         assert readings == []
+
+    def test_daily_filters_pending_type(self) -> None:
+        """Daily slots with type='pending' must be dropped."""
+        data = {
+            "sections": [
+                {
+                    "items": [
+                        {
+                            "dateTime": "2026-07-01T00:00:00Z",
+                            "consumption": {
+                                "type": "pending",
+                                "quantity": 5.2,
+                                "amount": 1.75,
+                            },
+                        },
+                        {
+                            "dateTime": "2026-07-02T00:00:00Z",
+                            "consumption": {
+                                "type": "normal",
+                                "quantity": 4.8,
+                                "amount": 1.60,
+                            },
+                        },
+                    ]
+                }
+            ]
+        }
+        readings = parse_daily_readings(data)
+        assert len(readings) == 1
+        assert readings[0].day == date(2026, 7, 2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- AGL returns `consumption.type = "pending"` for 30-min and daily slots where the AEMO meter read exists in the BFF but has not yet been delivered — distinct from `"none"` (future/unavailable) and from the zero-on-zero placeholder case.
- Pending slots carry non-zero `quantity`/`amount` values that look real but are preliminary estimates. Letting them through created phantom statistics rows that were never overwritten once the real AEMO read arrived (unlike zero-on-zero placeholders which the resume logic revisits).
- Both `parse_interval_readings` and `parse_daily_readings` now skip `"pending"` via a `_skip_types = {"none", "pending"}` set.
- Regression tests added to `TestParseIntervalReadings` and `TestParseDailyReadings`.

Partially addresses #126 (the `"pending"` type filter only — deliberately does **not** close it; the remaining ToU-band work is tracked in #141).

## Changes

- `custom_components/haggle/agl/parser.py`: `_skip_types` set in `parse_interval_readings`; `{"none", "pending"}` set in `parse_daily_readings`; docstrings updated to document `"pending"`.
- `tests/test_parser.py`: `test_filters_pending_type` in `TestParseIntervalReadings`; `test_daily_filters_pending_type` in `TestParseDailyReadings`.
- `CHANGELOG.md`: `### Fixed` entry under `## [Unreleased]`.

## Test plan

- [x] `uv run pytest tests/test_parser.py -v` — both new tests pass, no regressions
- [x] `uv run ruff check custom_components/ tests/` — clean
- [x] `uv run mypy custom_components/haggle` — clean
- [x] CI green on all matrix legs

---
_Generated by [Claude Code](https://claude.ai/code/session_0182ED147eWpUVZVrendPeXZ)_