### PR TITLE
chore(release): v0.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Targets for next sprint
+
+- #141 — user-configured ToU windows: derive tariff bands locally from
+  interval timestamps instead of trusting `consumption.type` (decision on
+  #126, 2026-07-03).
+- #90 — validate the ToU plan rate-mapping heuristic against a real ToU plan
+  capture (reduced priority: #141's manual rate entry demotes the heuristic
+  to a default-prefill role).
+
+---
+
+## [0.4.0-beta.1] — 2026-07-05
+
+> **Pre-release for community validation.** Solar generation support (#128)
+> has not yet been confirmed against a live solar contract, and the
+> `"pending"` interval filter (#126) awaits confirmation from an affected
+> ToU account. Install via HACS with "Show beta versions" enabled.
+
 ### Added
 
 - **Solar generation (feed-in) support** (#128). Contracts that report
@@ -50,15 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions rolled forward (all SHA-pinned)**:
   `actions/checkout` v7.0.0, `actions/setup-python` v6.3.0,
   `github/codeql-action` v4.36.3.
-
-### Targets for next sprint
-
-- #141 — user-configured ToU windows: derive tariff bands locally from
-  interval timestamps instead of trusting `consumption.type` (decision on
-  #126, 2026-07-03).
-- #90 — validate the ToU plan rate-mapping heuristic against a real ToU plan
-  capture (reduced priority: #141's manual rate entry demotes the heuristic
-  to a default-prefill role).
 
 ---
 

--- a/custom_components/haggle/manifest.json
+++ b/custom_components/haggle/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.haggle"],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.3.2"
+  "version": "0.4.0-beta.1"
 }


### PR DESCRIPTION
## Summary

- Release prep for **v0.4.0-beta.1**, a pre-release for community validation of solar generation support (#128, shipped in #142) and the `"pending"` interval filter (#126, shipped in #139).
- `manifest.json` version → `0.4.0-beta.1`; `CHANGELOG.md` Unreleased promoted to a dated `## [0.4.0-beta.1] — 2026-07-05` section with a pre-release note, and a fresh `## [Unreleased]` carrying the next-sprint targets (#141, #90). `hacs.json` unchanged (HA floor already 2026.7.0).
- After merge, the `v0.4.0-beta.1` tag will be pushed from main — `release.yml` then builds the GitHub Release and marks it as a pre-release (tag contains `-`).

## Test plan

- [x] `python scripts/validate_manifest.py custom_components/haggle/manifest.json` — OK
- [x] CHANGELOG section header matches the `^## \[0.4.0-beta.1\]` pattern release.yml's awk extraction expects
- [ ] Hassfest passes locally (or CI hassfest check is green)
- [ ] Manual test on a real HA instance (if touching config flow or sensors) — N/A, version/docs only

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [ ] The human maintainer has reviewed and understands every change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhmLAQ5AQr2tqFoy4DYzkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhmLAQ5AQr2tqFoy4DYzkk)_