### PR TITLE
fix: solar validation round 2 — per-series backfill, period sensors, feed-in rate (#128)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ config/
 .env.*
 !.env.example
 security/
+.venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ custom_components/haggle/
 ├── manifest.json        # HACS/HA metadata; hassfest validates this
 ├── const.py             # all constants — DOMAIN, API hosts, config-entry keys, data keys
 ├── config_flow.py       # PKCE authorize URL → user pastes callback → exchange → select_contract
-├── coordinator.py       # HaggleCoordinator: 30-day backfill (throttled, 429-aware) + incremental statistics import (aggregate + per-tariff ToU series + solar generation/credit on hasSolar contracts)
-├── sensor.py            # 11 SensorEntityDescription entries (3 conditional ToU rate sensors, 2 conditional solar sensors); HaggleEnergySensor
+├── coordinator.py       # HaggleCoordinator: 30-day backfill (throttled, 429-aware, per-series ranges) + incremental statistics import (aggregate + per-tariff ToU series + solar generation/credit on hasSolar contracts) + bill-period solar totals
+├── sensor.py            # 14 SensorEntityDescription entries (3 conditional ToU rate sensors, 5 conditional solar sensors); HaggleEnergySensor
 ├── agl/
 │   ├── __init__.py
 │   ├── client.py        # AglAuth (JWT expiry + token rotation) + AglClient (HTTP methods)
@@ -68,7 +68,8 @@ tests/
 │   ├── plan_response.json           # /v2/plan/energy with gstInclusiveRates (flat rate)
 │   ├── tou_plan_response.json       # Time-of-Use plan — per-band gstInclusiveRates
 │   ├── tou_hourly_response.json     # mixed peak/offpeak/shoulder/normal intervals
-│   ├── solar_hourly_response.json   # ElectricitySolar response with consumption + feedIn blocks
+│   ├── solar_hourly_response.json   # REAL full-day ElectricitySolar capture (2026-07-01, app-reconciled)
+│   ├── solar_plan_response.json     # solar plan — feed-in rate in gstExclusiveRates
 │   ├── overview_solar_response.json # /v3/overview variant with hasSolar: true
 │   └── bill_period_response.json    # usage summary
 ├── test_init.py                     # setup/unload smoke tests
@@ -326,16 +327,22 @@ Confirmed working back to at least 2025-12-24 (single-day period params). Requir
 GET /mobile/bff/api/v2/usage/smart/ElectricitySolar/{contractNumber}/Current/Hourly?period=YYYY-MM-DD_YYYY-MM-DD&scaling=...
 ```
 
-Documented from a real capture provided on #128 (2026-07-03). Same envelope,
-headers, and `scaling` requirement as the `Electricity` endpoint — the path
-substitutes the `ElectricitySolar` segment, `resourceType` comes back as
-`electricity-solar`, and each item carries **both** a `consumption` block and a
-shape-identical **`feedIn`** block:
+Documented from real captures provided on #128 (2026-07-03, plus a full-day
+2026-07-01 capture with app reference figures). Same envelope, headers, and
+`scaling` requirement as the `Electricity` endpoint — the path substitutes the
+`ElectricitySolar` segment, `resourceType` comes back as `electricity-solar`,
+and each item carries **both** a `consumption` block and a shape-identical
+**`feedIn`** block:
 
-- **Exported kWh**: `feedIn.quantity` (outer) — same outer-vs-inner rule as
-  consumption; `feedIn.values.*` is the DPI/chart-scaled helper, do not read it.
+- **Exported kWh**: `feedIn.quantity` (outer) — **CONFIRMED 2026-07-06**
+  against the AGL app for the 2026-07-01 capture: `sum(outer feedIn.quantity)`
+  = 8.019 kWh vs the app's "Sold to Grid 8.02 kWh"; `sum(outer feedIn.amount)`
+  = $1.3629 vs the app's $1.36. The inner `feedIn.values.*` sums to 6.1448
+  (the usual DPI/chart-scaled undercount) — do not read it. Regression test:
+  `tests/test_parser.py::TestParseSolarIntervals::test_feedin_reconciles_with_agl_app_figures`.
 - **Feed-in credit**: `feedIn.amount` (outer) — AUD credited for the slot.
-- **`feedIn.type`**: same status vocabulary (`normal`/`none`/`pending`); filter
+- **`feedIn.type`**: same vocabulary as consumption INCLUDING ToU bands — the
+  2026-07-01 capture carries `normal` and `peak` typed feedIn slots. Filter
   `none`/`pending` as usual. Zero-on-zero feedIn slots are *real* at night
   (no sun) but are still safe to drop — a zero delta never moves the sum.
 - **Contract discovery**: `accounts[].contracts[].hasSolar` in `/v3/overview`
@@ -343,9 +350,22 @@ shape-identical **`feedIn`** block:
   solar contracts). A `Previous/Hourly` variant is assumed symmetric with the
   consumption endpoint (unconfirmed against a real capture — the fetch loop
   tolerates per-day errors either way).
-- The solar response's own `consumption` block is **ignored** — the aggregate
-  consumption series keeps reading the proven `Electricity` endpoint until the
-  solar-side consumption numbers have been reconciled against a real bill.
+- The solar response's own `consumption` block is **ignored** at runtime but
+  is now reconciled: its outer sums on the 2026-07-01 capture (6.072 kWh /
+  $2.2537) match the app's consumption figures (6.07 / $2.25), i.e. it
+  mirrors the `Electricity` endpoint. The aggregate consumption series still
+  reads the proven `Electricity` endpoint.
+- **Backfill is per-series** (beta.2): `_fetch_range` takes separate
+  consumption and solar `(start, end) | None` ranges, each resolved from that
+  series' own resume point. A contract that gains solar later (or upgrades
+  into solar support) backfills generation from the 30-day floor without
+  re-fetching consumption days; the app-matching bill-period sensors stay
+  `unknown` until the generation series reaches the trailing rewindow.
+- The beta.1 "numbers don't match" report (#128) was a **window artifact** —
+  a cumulative-since-backfill sensor compared against the app's
+  billing-period tile — not a field bug. When validating against the app,
+  compare the *period* sensors (or per-day Energy dashboard bars), never the
+  cumulative totals.
 
 ### Plan / Rates
 
@@ -355,6 +375,15 @@ GET /mobile/bff/api/v2/plan/energy/{contractNumber}
 
 Returns `gstInclusiveRates` list with `c/kWh` and `c/day` entries. Supply charge
 is a `c/day` entry with `title` containing "Supply charge".
+
+**Solar feed-in tariff lives in `gstExclusiveRates`**, not `gstInclusiveRates`
+(FiT is GST-free, so this is correct behaviour on AGL's side, not an
+inconsistency): a `kind:"detail"`, `type:"c/kWh"` row with `title` containing
+"feed-in"/"feed in" (confirmed from a real solar plan capture on #128;
+fixture: `tests/fixtures/solar_plan_response.json`). `parse_plan` scans both
+lists; a plan without a matching row leaves
+`PlanRates.feed_in_rate_cents_per_kwh = None` and the rate sensor reads
+`unavailable`.
 
 **Time-of-Use rate mapping (heuristic — needs real-capture validation)**: AGL
 does not return a machine `tariffType` field on plan rates. ToU bands are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0-beta.2] — 2026-07-06
+
+> **Pre-release for community validation** (#128 round 2). The beta.1 solar
+> field mapping is now **capture-validated**: on the tester's real 2026-07-01
+> capture the parser reproduces the AGL app's figures exactly (sold to grid
+> 8.019 kWh / $1.363 vs the app's 8.02 / $1.36; consumption 6.072 / $2.254 vs
+> 6.07 / $2.25). The mismatch reported against beta.1 was a *window* artifact
+> — a cumulative-since-backfill sensor compared against the app's
+> billing-period tile — not a data bug. Beta.2 adds bill-period sensors that
+> match the app tile directly.
+
+### Added
+
+- **Bill-period solar sensors** (#128): **Solar sold this period** (kWh) and
+  **Solar feed-in credit this period** (AUD) — computed from the generation
+  statistics since the current bill period start, so they line up with the
+  AGL app's "Sold To Grid" tile. They read `unknown` until the generation
+  series has backfilled to the trailing rewindow (a mid-backfill partial
+  could never match the app). Note: on quarterly billing the 30-day backfill
+  window is shorter than the bill period, so these sensors cover the stored
+  history only.
+- **Solar feed-in rate sensor** (#128): AGL reports the feed-in tariff under
+  `gstExclusiveRates` (FiT is GST-free) — the parser previously only read
+  `gstInclusiveRates`, so the rate never surfaced. New **Solar feed-in rate**
+  sensor (AUD/kWh) registers on solar contracts when the plan carries a
+  feed-in rate.
+
+### Fixed
+
+- **Generation series now backfills independently of consumption** (#128).
+  Previously the fetch window was resolved from the consumption series'
+  resume point alone, so an install that *upgraded* into solar support only
+  ever received the trailing 7-day rewindow of export history — the older
+  ~23 days of the 30-day backfill never arrived. Each series now resolves its
+  own chunked fetch range from its own resume point; disjoint ranges skip the
+  other series' days (no extra load on AGL's BFF).
+- `tests/fixtures/solar_hourly_response.json` replaced with the tester's real
+  full-day capture (48 slots, 11 non-zero export slots, mixed
+  `normal`/`peak` feedIn types); reconciliation totals are locked in as
+  regression tests.
+
+---
+
 ## [0.4.0-beta.1] — 2026-07-05
 
 > **Pre-release for community validation.** Solar generation support (#128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ~23 days of the 30-day backfill never arrived. Each series now resolves its
   own chunked fetch range from its own resume point; disjoint ranges skip the
   other series' days (no extra load on AGL's BFF).
+- **Zero-export days no longer stall the solar backfill.** A successfully
+  fetched day whose feed-in intervals are all zero (cloudy day, or a solar
+  system newer than the 30-day backfill floor) now writes a single
+  zero-delta marker row so the generation resume point advances; previously
+  a full chunk of such days was refetched forever and the period sensors
+  never unlocked. Found by Codex review on the beta.2 PR.
 - `tests/fixtures/solar_hourly_response.json` replaced with the tester's real
   full-day capture (48 slots, 11 non-zero export slots, mixed
   `normal`/`peak` feedIn types); reconciliation totals are locked in as

--- a/custom_components/haggle/agl/models.py
+++ b/custom_components/haggle/agl/models.py
@@ -71,3 +71,6 @@ class PlanRates:
     supply_charge_cents_per_day: float = 0.0
     # Time-of-Use unit rates, tariff type → c/kWh; empty for flat-rate plans.
     tou_unit_rates: dict[str, float] = field(default_factory=dict)
+    # Solar feed-in tariff, c/kWh. Lives in gstExclusiveRates (FiT is GST-free),
+    # not gstInclusiveRates. None when the plan has no feed-in rate.
+    feed_in_rate_cents_per_kwh: float | None = None

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -243,9 +243,24 @@ def parse_plan(data: dict[str, Any]) -> PlanRates:
             }
         )
 
+    # Solar feed-in tariff lives in gstExclusiveRates (FiT is GST-free, so
+    # AGL correctly reports it there — confirmed from a real solar plan
+    # capture on #128). Matched by title so an unrelated GST-exclusive row
+    # can never masquerade as the feed-in rate; unmatched plans stay None
+    # (sensor reads `unavailable`, never a misleading 0.0).
+    feed_in_rate: float | None = None
+    for rate in data.get("gstExclusiveRates") or []:
+        if rate.get("kind") != "detail" or rate.get("type") != "c/kWh":
+            continue
+        title = rate.get("title") or ""
+        if "feed-in" in title.lower() or "feed in" in title.lower():
+            feed_in_rate = _safe_float(rate.get("price"))
+            break
+
     return PlanRates(
         product_name=product_name,
         unit_rates=unit_rates,
         supply_charge_cents_per_day=supply_charge,
         tou_unit_rates=tou_unit_rates,
+        feed_in_rate_cents_per_kwh=feed_in_rate,
     )

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -150,3 +150,7 @@ DATA_UNIT_RATE_SHOULDER: Final = "unit_rate_shoulder_aud_per_kwh"
 # Solar feed-in cumulatives — only populated/registered on hasSolar contracts.
 DATA_GENERATION_KWH: Final = "latest_generation_kwh"  # TOTAL_INCREASING sensor
 DATA_GENERATION_CREDIT: Final = "latest_generation_credit_aud"  # cumulative AUD
+# Bill-period solar totals (match the app's "Sold To Grid" tile) + feed-in rate.
+DATA_GENERATION_PERIOD: Final = "generation_period_kwh"  # kWh exported this period
+DATA_GENERATION_PERIOD_CREDIT: Final = "generation_period_credit_aud"  # AUD credited
+DATA_FEED_IN_RATE: Final = "feed_in_rate_aud_per_kwh"  # AUD/kWh

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -34,6 +34,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
+from homeassistant.util import dt as dt_util
 
 from .agl.client import AGLAuthError, AGLError, AGLRateLimitError
 from .const import (
@@ -105,6 +106,14 @@ class HaggleData:
     has_solar: bool = False
     latest_generation_kwh: float = 0.0
     latest_generation_credit_aud: float = 0.0
+    # Bill-period solar totals (match the AGL app's "Sold To Grid" tile).
+    # None until the generation series has backfilled to the current rewindow
+    # — publishing a mid-backfill partial would show numbers that can't match
+    # the app (the exact confusion reported on #128 for beta.1).
+    generation_period_kwh: float | None = None
+    generation_period_credit_aud: float | None = None
+    # Solar feed-in tariff (AUD/kWh) from the plan's gstExclusiveRates.
+    feed_in_rate_aud_per_kwh: float | None = None
 
 
 class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
@@ -183,28 +192,41 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # in lockstep, and every cumulative-sum baseline is now looked up inside
         # _import_intervals (against the earliest fetched-interval hour), so the
         # cost stat's last row is no longer needed here.
-        last_cons_sum, last_stat_date = await self._get_last_stat(stat_id_cons)
+        last_cons_sum, last_cons_date = await self._get_last_stat(stat_id_cons)
 
         # AGL `dateTime` slots are UTC; using `date.today()` (OS local time)
         # would skew the fetch range by a day around midnight in non-UTC zones.
         today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
 
-        fetch_start = self._resolve_fetch_start(today, last_stat_date)
-        fetch_end = min(
-            yesterday, fetch_start + timedelta(days=BACKFILL_CHUNK_DAYS - 1)
-        )
-
         # Seed the sensor with the most-recent known cumulative; _fetch_range
         # bumps it forward when the import produces new rows.
         self._latest_cumulative_kwh = last_cons_sum or 0.0
 
+        # Each series resolves its own fetch range from its own resume point,
+        # chunk-capped independently. A single consumption-derived range would
+        # starve a generation series added by upgrade: consumption is caught up,
+        # so the range never reaches further back than the trailing rewindow and
+        # the older BACKFILL_DAYS of solar history would never arrive.
+        cons_range = self._chunked_range(
+            self._resolve_fetch_start(today, last_cons_date), yesterday
+        )
+
+        # Pre-fetch generation resume state. last_gen_date also gates the
+        # bill-period totals below: reading it BEFORE the fetch guarantees the
+        # rows behind the bill_start baseline were committed in an earlier
+        # cycle, not queued in the recorder by this one.
+        last_gen_date: date | None = None
+        solar_range: tuple[date, date] | None = None
         if self._has_solar:
             stat_id_gen, stat_id_credit = self._generation_stat_ids()
-            last_gen_sum, _ = await self._get_last_stat(stat_id_gen)
+            last_gen_sum, last_gen_date = await self._get_last_stat(stat_id_gen)
             last_credit_sum, _ = await self._get_last_stat(stat_id_credit)
             self._latest_generation_kwh = last_gen_sum or 0.0
             self._latest_generation_credit = last_credit_sum or 0.0
+            solar_range = self._chunked_range(
+                self._resolve_fetch_start(today, last_gen_date), yesterday
+            )
 
         # Mark which ToU bands already have stored statistics so the per-tariff
         # series are emitted only for a contract that has been seen using ToU
@@ -212,13 +234,12 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # per-tariff baseline sums themselves are resolved in _import_intervals.
         self._active_tou_bands |= await self._get_stored_tou_bands()
 
-        if fetch_start <= yesterday:
+        if cons_range or solar_range:
             await self._fetch_range(
-                fetch_start,
-                fetch_end,
+                cons_range,
+                solar_range,
                 bill_start,
                 known_bands=frozenset(self._active_tou_bands),
-                include_solar=self._has_solar,
             )
 
         # Extract rates from plan.
@@ -238,6 +259,21 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         def _tou_rate(tariff: str) -> float | None:
             cents = plan.tou_unit_rates.get(tariff)
             return cents / 100.0 if cents is not None else None
+
+        feed_in_cents = plan.feed_in_rate_cents_per_kwh
+        feed_in_rate_aud = feed_in_cents / 100.0 if feed_in_cents is not None else None
+
+        # Bill-period solar totals — after the fetch so this cycle's rows are
+        # included in the in-memory latest sums.
+        generation_period_kwh: float | None = None
+        generation_period_credit: float | None = None
+        if self._has_solar:
+            (
+                generation_period_kwh,
+                generation_period_credit,
+            ) = await self._get_generation_period_totals(
+                bill_start, last_gen_date, today
+            )
 
         # A new ToU band (or solar newly detected) appearing after first
         # refresh means sensors need to be added; schedule a loop-safe reload.
@@ -267,6 +303,9 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             has_solar=self._has_solar,
             latest_generation_kwh=self._latest_generation_kwh,
             latest_generation_credit_aud=self._latest_generation_credit,
+            generation_period_kwh=generation_period_kwh,
+            generation_period_credit_aud=generation_period_credit,
+            feed_in_rate_aud_per_kwh=feed_in_rate_aud,
         )
 
     async def _refresh_has_solar(self) -> None:
@@ -341,6 +380,17 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         if last_stat_date < today - timedelta(days=REWINDOW_DAYS):
             return last_stat_date + timedelta(days=1)
         return max(today - timedelta(days=REWINDOW_DAYS), backfill_floor)
+
+    @staticmethod
+    def _chunked_range(start: date, yesterday: date) -> tuple[date, date] | None:
+        """Cap a series' fetch start to one BACKFILL_CHUNK_DAYS chunk.
+
+        Returns None when the series has nothing to fetch (start past
+        yesterday — AGL never has data for today).
+        """
+        if start > yesterday:
+            return None
+        return start, min(yesterday, start + timedelta(days=BACKFILL_CHUNK_DAYS - 1))
 
     async def _get_last_stat(self, stat_id: str) -> tuple[float | None, date | None]:
         """Return (last_sum, last_date) for stat_id, or (None, None) if no rows."""
@@ -483,71 +533,111 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         return {band for stat_id, band in id_to_band.items() if result.get(stat_id)}
 
+    async def _get_generation_period_totals(
+        self,
+        bill_start: date,
+        last_gen_date: date | None,
+        today: date,
+    ) -> tuple[float | None, float | None]:
+        """Return (kWh, AUD) exported since bill_start, or (None, None).
+
+        Matches the AGL app's billing-period "Sold To Grid" tile: latest
+        cumulative sum minus the stored sum at local midnight of bill_start.
+
+        Gated on the PRE-FETCH generation resume point: values publish only
+        once the series was already caught up to the trailing rewindow at the
+        start of this cycle. Mid-backfill partials are suppressed (None →
+        sensor `unknown`) because they cannot match the app — the exact
+        confusion behind the beta.1 report on #128. Using the pre-fetch date
+        also sidesteps the recorder's async write queue: every row behind the
+        bill_start baseline was committed by an earlier cycle, never queued by
+        this one. The latest sums are the in-memory values returned
+        synchronously by _emit_series, so they are exact either way.
+
+        Known limitation (not gated): a billing period longer than
+        BACKFILL_DAYS — quarterly bills — starts before the backfill floor,
+        so the baseline resolves to 0.0 and the totals cover only the stored
+        history. Gating on it would leave quarterly-billed users permanently
+        unavailable.
+
+        Half-hour timezones (e.g. ACST, local midnight = 14:30Z): the hourly
+        row strictly before the cutoff contains the day's first 30-min slot,
+        so at most one midnight slot folds into the baseline — solar export at
+        local midnight is zero, so no correction is needed.
+        """
+        if last_gen_date is None or last_gen_date < today - timedelta(
+            days=REWINDOW_DAYS
+        ):
+            return None, None
+        stat_id_gen, stat_id_credit = self._generation_stat_ids()
+        cutoff = dt_util.start_of_local_day(bill_start)
+        base_gen, base_credit = await self._get_baseline_sums(
+            stat_id_gen, stat_id_credit, cutoff
+        )
+        kwh = max(0.0, self._latest_generation_kwh - base_gen)
+        credit = max(0.0, self._latest_generation_credit - base_credit)
+        return kwh, credit
+
     async def _fetch_range(
         self,
-        start: date,
-        end: date,
+        cons_range: tuple[date, date] | None,
+        solar_range: tuple[date, date] | None,
         bill_start: date | None,
         *,
         known_bands: frozenset[str] = frozenset(),
-        include_solar: bool = False,
     ) -> None:
-        """Fetch [start..end] with smart endpoint selection, then import.
+        """Fetch per-series day ranges with smart endpoint selection, then import.
 
-        Sleeps between per-day requests so a chunk-of-7 first-install backfill
-        doesn't hammer AGL's BFF in under a second. On rate-limit the loop
-        stops early — the next 24h poll cycle will resume from the last
-        successfully imported date.
+        Each series carries its own (start, end) so a generation series that is
+        behind (e.g. solar support added by upgrade while consumption is caught
+        up) backfills from its own resume point without re-fetching consumption
+        days — and vice versa. A day outside both ranges is skipped without a
+        request. Worst case (fully disjoint chunks) is 7 + 7 requests, the same
+        peak load as a steady-state solar cycle (7 days x 2 requests).
 
-        With include_solar, each day additionally fetches the ElectricitySolar
-        feed-in intervals (a second, delay-separated request per day). The
-        consumption series keeps reading the proven Electricity endpoint — the
-        solar endpoint's own consumption block is ignored until it has been
+        Sleeps between requests so a chunk-of-7 first-install backfill doesn't
+        hammer AGL's BFF in under a second. AGL rate limits are account-wide,
+        so an AGLRateLimitError from either endpoint halts the whole chunk —
+        each series resumes from its own last imported date next cycle.
+
+        The consumption series keeps reading the proven Electricity endpoint —
+        the solar endpoint's own consumption block is ignored until it has been
         reconciled against a real bill.
         """
+        ranges = [r for r in (cons_range, solar_range) if r is not None]
+        if not ranges:
+            return
         all_intervals: list[IntervalReading] = []
         solar_intervals: list[IntervalReading] = []
-        current = start
+        current = min(r[0] for r in ranges)
+        loop_end = max(r[1] for r in ranges)
         first = True
-        while current <= end:
-            if not first:
-                await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
-            first = False
+        rate_limited = False
+        while current <= loop_end and not rate_limited:
+            fetch_cons = cons_range is not None and (
+                cons_range[0] <= current <= cons_range[1]
+            )
+            fetch_solar = solar_range is not None and (
+                solar_range[0] <= current <= solar_range[1]
+            )
             previous = bill_start is not None and current < bill_start
-            try:
-                if previous:
-                    readings = await self.client.async_get_usage_hourly_previous(
-                        self.contract_number, current
-                    )
-                else:
-                    readings = await self.client.async_get_usage_hourly(
-                        self.contract_number, current
-                    )
-                all_intervals.extend(readings)
-            except AGLRateLimitError as err:
-                _LOGGER.warning(
-                    "AGL rate-limited at %s; halting backfill chunk: %s", current, err
-                )
-                break
-            except AGLError as err:
-                _LOGGER.debug("Fetch skip %s: %s", current, err)
-            if include_solar:
-                await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
-                try:
-                    solar_intervals.extend(
-                        await self.client.async_get_solar_hourly(
-                            self.contract_number, current, previous=previous
-                        )
-                    )
-                except AGLRateLimitError as err:
-                    _LOGGER.warning(
-                        "AGL rate-limited at %s (solar); halting backfill chunk: %s",
-                        current,
-                        err,
-                    )
+            if fetch_cons:
+                if not first:
+                    await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
+                first = False
+                readings = await self._fetch_day_consumption(current, previous)
+                if readings is None:  # rate-limited
                     break
-                except AGLError as err:
-                    _LOGGER.debug("Solar fetch skip %s: %s", current, err)
+                all_intervals.extend(readings)
+            if fetch_solar:
+                if not first:
+                    await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
+                first = False
+                solar_readings = await self._fetch_day_solar(current, previous)
+                if solar_readings is None:  # rate-limited
+                    rate_limited = True
+                else:
+                    solar_intervals.extend(solar_readings)
             current += timedelta(days=1)
 
         if all_intervals:
@@ -559,6 +649,46 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave the cumulative seeds as the caller set them — the
         # most recent stored cumulative remains the sensor value.
+
+    async def _fetch_day_consumption(
+        self, day: date, previous: bool
+    ) -> list[IntervalReading] | None:
+        """Fetch one day of consumption intervals.
+
+        Returns [] on a skippable AGLError (logged, the loop continues) and
+        None on AGLRateLimitError so the caller halts the chunk.
+        """
+        try:
+            if previous:
+                return await self.client.async_get_usage_hourly_previous(
+                    self.contract_number, day
+                )
+            return await self.client.async_get_usage_hourly(self.contract_number, day)
+        except AGLRateLimitError as err:
+            _LOGGER.warning(
+                "AGL rate-limited at %s; halting backfill chunk: %s", day, err
+            )
+            return None
+        except AGLError as err:
+            _LOGGER.debug("Fetch skip %s: %s", day, err)
+            return []
+
+    async def _fetch_day_solar(
+        self, day: date, previous: bool
+    ) -> list[IntervalReading] | None:
+        """Fetch one day of solar feed-in intervals (same contract as above)."""
+        try:
+            return await self.client.async_get_solar_hourly(
+                self.contract_number, day, previous=previous
+            )
+        except AGLRateLimitError as err:
+            _LOGGER.warning(
+                "AGL rate-limited at %s (solar); halting backfill chunk: %s", day, err
+            )
+            return None
+        except AGLError as err:
+            _LOGGER.debug("Solar fetch skip %s: %s", day, err)
+            return []
 
     @staticmethod
     def _bucket_hourly(

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -648,8 +648,11 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 else:
                     if solar_readings is not None:
                         solar_intervals.extend(solar_readings)
-                        # Only a *successful* fetch marks the day as covered —
-                        # an errored day must stay unmarked so it is retried.
+                        # Only a *successful* fetch marks the day as covered.
+                        # An errored day stays unmarked; it is retried until a
+                        # LATER day in the chunk writes rows (same
+                        # skip-and-continue semantics as consumption — see
+                        # _fetch_day_solar docstring for the tradeoff).
                         fetched_solar_days.append(current)
             current += timedelta(days=1)
 
@@ -696,7 +699,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         """Fetch one day of solar feed-in intervals (same contract as above).
 
         Returns None on a skippable AGLError so the caller does NOT count the
-        day as fetched (no zero-marker row → the day is retried next cycle).
+        day as fetched (no zero-marker row). The day is retried while the
+        resume point still trails it; once a LATER day in the chunk imports
+        rows, resume moves past the gap and — outside the trailing rewindow —
+        it is not revisited. Deliberate tradeoff, same skip-and-continue
+        semantics as the consumption backfill (#34): halting at the first
+        errored day would let a permanently-500ing old day (AGL does this on
+        very old dates) stall the backfill and the period sensors forever,
+        which is worse than a rare one-day historical hole.
         AGLRateLimitError propagates so the caller halts the whole chunk.
         """
         try:

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -57,6 +57,8 @@ from .const import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -609,6 +611,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             return
         all_intervals: list[IntervalReading] = []
         solar_intervals: list[IntervalReading] = []
+        fetched_solar_days: list[date] = []
         current = min(r[0] for r in ranges)
         loop_end = max(r[1] for r in ranges)
         first = True
@@ -633,19 +636,33 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 if not first:
                     await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
                 first = False
-                solar_readings = await self._fetch_day_solar(current, previous)
-                if solar_readings is None:  # rate-limited
+                try:
+                    solar_readings = await self._fetch_day_solar(current, previous)
+                except AGLRateLimitError as err:
+                    _LOGGER.warning(
+                        "AGL rate-limited at %s (solar); halting backfill chunk: %s",
+                        current,
+                        err,
+                    )
                     rate_limited = True
                 else:
-                    solar_intervals.extend(solar_readings)
+                    if solar_readings is not None:
+                        solar_intervals.extend(solar_readings)
+                        # Only a *successful* fetch marks the day as covered —
+                        # an errored day must stay unmarked so it is retried.
+                        fetched_solar_days.append(current)
             current += timedelta(days=1)
 
         if all_intervals:
             await self._import_intervals(all_intervals, known_bands=known_bands)
         # Partial solar batches import too — idempotent, and the trailing
         # rewindow re-fetches the last REWINDOW_DAYS so short gaps self-heal.
-        if solar_intervals:
-            await self._import_generation(solar_intervals)
+        # fetched_solar_days matters even with zero intervals: an all-zero
+        # export day must still advance the generation resume point.
+        if solar_intervals or fetched_solar_days:
+            await self._import_generation(
+                solar_intervals, fetched_days=fetched_solar_days
+            )
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave the cumulative seeds as the caller set them — the
         # most recent stored cumulative remains the sensor value.
@@ -676,19 +693,21 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     async def _fetch_day_solar(
         self, day: date, previous: bool
     ) -> list[IntervalReading] | None:
-        """Fetch one day of solar feed-in intervals (same contract as above)."""
+        """Fetch one day of solar feed-in intervals (same contract as above).
+
+        Returns None on a skippable AGLError so the caller does NOT count the
+        day as fetched (no zero-marker row → the day is retried next cycle).
+        AGLRateLimitError propagates so the caller halts the whole chunk.
+        """
         try:
             return await self.client.async_get_solar_hourly(
                 self.contract_number, day, previous=previous
             )
-        except AGLRateLimitError as err:
-            _LOGGER.warning(
-                "AGL rate-limited at %s (solar); halting backfill chunk: %s", day, err
-            )
-            return None
+        except AGLRateLimitError:
+            raise
         except AGLError as err:
             _LOGGER.debug("Solar fetch skip %s: %s", day, err)
-            return []
+            return None
 
     @staticmethod
     def _bucket_hourly(
@@ -879,7 +898,12 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         return running
 
-    async def _import_generation(self, intervals: list[IntervalReading]) -> None:
+    async def _import_generation(
+        self,
+        intervals: list[IntervalReading],
+        *,
+        fetched_days: Iterable[date] = (),
+    ) -> None:
         """Aggregate solar feed-in intervals to hourly and push to statistics.
 
         Writes haggle:generation_<contract> (exported kWh, unit_class="energy"
@@ -887,6 +911,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         haggle:generation_credit_<contract> (AUD feed-in credit). Uses the same
         earliest-fetched-hour baseline cutoff as the consumption import — see
         _import_intervals for why a fetch_start-derived UTC midnight is wrong.
+
+        A successfully fetched day whose intervals all filtered out (zero
+        export: cloudy day, or a solar system newer than the backfill floor)
+        still gets ONE zero-delta marker row at the hour of local midnight so
+        the generation resume point advances. Without it the backfill would
+        refetch the same all-zero chunk forever and the bill-period sensors
+        would never unlock (Codex review, PR #144). An AEMO-lag placeholder
+        day marked this way self-heals: the trailing rewindow re-fetches the
+        last REWINDOW_DAYS and the idempotent import overwrites the marker
+        (data lag is 24-48 h, well inside the window).
         """
         from homeassistant.const import UnitOfEnergy
 
@@ -896,6 +930,19 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             h = r.dt.replace(minute=0, second=0, microsecond=0)
             hour_kwh[h] = hour_kwh.get(h, 0.0) + r.kwh
             hour_credit[h] = hour_credit.get(h, 0.0) + r.cost_aud
+
+        for day in fetched_days:
+            day_start = dt_util.start_of_local_day(day)
+            day_end = day_start + timedelta(days=1)
+            if any(day_start <= h < day_end for h in hour_kwh):
+                continue
+            # Floor to the hour: half-hour zones (ACST) have local midnight at
+            # :30 past a UTC hour, and statistics rows start on the hour.
+            marker = dt_util.as_utc(day_start).replace(
+                minute=0, second=0, microsecond=0
+            )
+            hour_kwh.setdefault(marker, 0.0)
+            hour_credit.setdefault(marker, 0.0)
 
         if not hour_kwh:
             return

--- a/custom_components/haggle/sensor.py
+++ b/custom_components/haggle/sensor.py
@@ -32,8 +32,11 @@ from .const import (
     DATA_CONSUMPTION_COST,
     DATA_CONSUMPTION_KWH,
     DATA_CONSUMPTION_PERIOD,
+    DATA_FEED_IN_RATE,
     DATA_GENERATION_CREDIT,
     DATA_GENERATION_KWH,
+    DATA_GENERATION_PERIOD,
+    DATA_GENERATION_PERIOD_CREDIT,
     DATA_SUPPLY_CHARGE,
     DATA_UNIT_RATE,
     DATA_UNIT_RATE_OFFPEAK,
@@ -137,6 +140,36 @@ SOLAR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement="AUD",
         suggested_display_precision=2,
+    ),
+    # --- Bill-period solar totals (mirror the consumption period sensors) ---
+    # TOTAL without last_reset: HA treats a decrease as a reset, which is
+    # exactly the bill-rollover behaviour. `unknown` until the generation
+    # series has backfilled to the trailing rewindow — a mid-backfill partial
+    # could never match the AGL app's "Sold To Grid" tile (#128).
+    SensorEntityDescription(
+        key=DATA_GENERATION_PERIOD,
+        translation_key="generation_period",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+    ),
+    SensorEntityDescription(
+        key=DATA_GENERATION_PERIOD_CREDIT,
+        translation_key="generation_period_credit",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement="AUD",
+        suggested_display_precision=2,
+    ),
+    # Feed-in tariff is a unit price, not a cumulative amount: MEASUREMENT +
+    # AUD/kWh, NO device_class (same rule as the other rate sensors).
+    SensorEntityDescription(
+        key=DATA_FEED_IN_RATE,
+        translation_key="feed_in_rate",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="AUD/kWh",
+        suggested_display_precision=4,
     ),
 )
 

--- a/custom_components/haggle/strings.json
+++ b/custom_components/haggle/strings.json
@@ -59,6 +59,15 @@
       },
       "generation_credit": {
         "name": "Solar feed-in credit"
+      },
+      "generation_period": {
+        "name": "Solar sold this period"
+      },
+      "generation_period_credit": {
+        "name": "Solar feed-in credit this period"
+      },
+      "feed_in_rate": {
+        "name": "Solar feed-in rate"
       }
     }
   }

--- a/custom_components/haggle/translations/en.json
+++ b/custom_components/haggle/translations/en.json
@@ -59,6 +59,15 @@
       },
       "generation_credit": {
         "name": "Solar feed-in credit"
+      },
+      "generation_period": {
+        "name": "Solar sold this period"
+      },
+      "generation_period_credit": {
+        "name": "Solar feed-in credit this period"
+      },
+      "feed_in_rate": {
+        "name": "Solar feed-in rate"
       }
     }
   }

--- a/tests/fixtures/solar_hourly_response.json
+++ b/tests/fixtures/solar_hourly_response.json
@@ -4,111 +4,1014 @@
   "timeZone": "Australia/Sydney",
   "sections": [
     {
-      "startDate": "2026-06-29",
+      "startDate": "2026-07-01",
       "items": [
         {
-          "dateTime": "2026-06-29T00:00:00Z",
+          "dateTime": "2026-07-01T13:30:00Z",
           "consumption": {
-            "values": {"amount": 0.09, "quantity": 0.09},
-            "amount": 0.052,
-            "quantity": 0.141,
+            "values": {
+              "amount": 0.1138,
+              "quantity": 0.0521
+            },
+            "amount": 0.025238,
+            "quantity": 0.068,
             "type": "normal"
           },
           "feedIn": {
-            "values": {"amount": 0.31, "quantity": 0.31},
-            "amount": 0.0165,
-            "quantity": 0.502,
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
             "type": "normal"
           }
         },
         {
-          "dateTime": "2026-06-29T02:00:00Z",
+          "dateTime": "2026-07-01T13:00:00Z",
           "consumption": {
-            "values": {"amount": 0.07, "quantity": 0.07},
-            "amount": 0.041,
-            "quantity": 0.112,
+            "values": {
+              "amount": 0.1305,
+              "quantity": 0.0598
+            },
+            "amount": 0.02895,
+            "quantity": 0.078,
             "type": "normal"
           },
           "feedIn": {
-            "values": {"amount": 0.79, "quantity": 0.79},
-            "amount": 0.0421,
-            "quantity": 1.276,
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
             "type": "normal"
           }
         },
         {
-          "dateTime": "2026-06-29T02:30:00Z",
+          "dateTime": "2026-07-01T12:30:00Z",
           "consumption": {
-            "values": {"amount": 0.08, "quantity": 0.08},
-            "amount": 0.046,
-            "quantity": 0.124,
+            "values": {
+              "amount": 0.1155,
+              "quantity": 0.0529
+            },
+            "amount": 0.02561,
+            "quantity": 0.069,
             "type": "normal"
           },
           "feedIn": {
-            "values": {"amount": 0.72, "quantity": 0.72},
-            "amount": 0.0385,
-            "quantity": 1.168,
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
             "type": "normal"
           }
         },
         {
-          "dateTime": "2026-06-29T13:00:00Z",
+          "dateTime": "2026-07-01T12:00:00Z",
           "consumption": {
-            "values": {"amount": 0.0491, "quantity": 0.049},
-            "amount": 0.024871,
+            "values": {
+              "amount": 0.1255,
+              "quantity": 0.0575
+            },
+            "amount": 0.027837,
+            "quantity": 0.075,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T11:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1924,
+              "quantity": 0.0881
+            },
+            "amount": 0.042682,
+            "quantity": 0.115,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T11:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1573,
+              "quantity": 0.072
+            },
+            "amount": 0.03489,
+            "quantity": 0.094,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T10:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2326,
+              "quantity": 0.1065
+            },
+            "amount": 0.05159,
+            "quantity": 0.139,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T10:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2895,
+              "quantity": 0.1326
+            },
+            "amount": 0.064209,
+            "quantity": 0.173,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T09:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.5003,
+              "quantity": 0.2291
+            },
+            "amount": 0.110977,
+            "quantity": 0.299,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T09:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.4284,
+              "quantity": 0.1962
+            },
+            "amount": 0.095016,
+            "quantity": 0.256,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T08:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.5221,
+              "quantity": 0.2391
+            },
+            "amount": 0.115801,
+            "quantity": 0.312,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T08:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2527,
+              "quantity": 0.1157
+            },
+            "amount": 0.056045,
+            "quantity": 0.151,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T07:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.6961,
+              "quantity": 0.3188
+            },
+            "amount": 0.1544,
+            "quantity": 0.416,
+            "type": "peak"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T07:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.8752,
+              "quantity": 0.4008
+            },
+            "amount": 0.194115,
+            "quantity": 0.523,
+            "type": "peak"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T06:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.3397,
+              "quantity": 0.1556
+            },
+            "amount": 0.075346,
+            "quantity": 0.203,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T06:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1556,
+              "quantity": 0.0713
+            },
+            "amount": 0.034518,
+            "quantity": 0.093,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T05:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1205,
+              "quantity": 0.0552
+            },
+            "amount": 0.026723,
+            "quantity": 0.072,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T05:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0753,
+              "quantity": 0.0345
+            },
+            "amount": 0.016702,
+            "quantity": 0.045,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T04:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.092,
+              "quantity": 0.0421
+            },
+            "amount": 0.020414,
+            "quantity": 0.055,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T04:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.087,
+              "quantity": 0.0398
+            },
+            "amount": 0.019301,
+            "quantity": 0.052,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0146,
+              "quantity": 0.0146
+            },
+            "amount": 0.00323,
+            "quantity": 0.019,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T03:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0284,
+              "quantity": 0.013
+            },
+            "amount": 0.00631,
+            "quantity": 0.017,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.1425,
+              "quantity": 0.1425
+            },
+            "amount": 0.031612,
+            "quantity": 0.186,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T03:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.39,
+              "quantity": 0.39
+            },
+            "amount": 0.08651,
+            "quantity": 0.509,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T02:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.7617,
+              "quantity": 0.7617
+            },
+            "amount": 0.168942,
+            "quantity": 0.994,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T02:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0067,
+              "quantity": 0.0031
+            },
+            "amount": 0.001485,
+            "quantity": 0.004,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.7617,
+              "quantity": 0.7617
+            },
+            "amount": 0.168942,
+            "quantity": 0.994,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T01:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.8866,
+              "quantity": 0.8866
+            },
+            "amount": 0.196646,
+            "quantity": 1.157,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T01:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 1.0,
+              "quantity": 1.0
+            },
+            "amount": 0.2218,
+            "quantity": 1.305,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T00:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.8866,
+              "quantity": 0.8866
+            },
+            "amount": 0.196646,
+            "quantity": 1.157,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2026-07-01T00:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.7318,
+              "quantity": 0.7318
+            },
+            "amount": 0.162314,
+            "quantity": 0.955,
+            "type": "peak"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T23:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.5218,
+              "quantity": 0.5218
+            },
+            "amount": 0.115744,
+            "quantity": 0.681,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T23:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.0485,
+              "quantity": 0.0222
+            },
+            "amount": 0.010765,
+            "quantity": 0.029,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0475,
+              "quantity": 0.0475
+            },
+            "amount": 0.010538,
+            "quantity": 0.062,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T22:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1707,
+              "quantity": 0.0782
+            },
+            "amount": 0.037858,
+            "quantity": 0.102,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T22:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.6041,
+              "quantity": 0.2766
+            },
+            "amount": 0.133987,
+            "quantity": 0.361,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T21:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.8099,
+              "quantity": 0.3709
+            },
+            "amount": 0.179639,
+            "quantity": 0.484,
+            "type": "peak"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T21:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2811,
+              "quantity": 0.1287
+            },
+            "amount": 0.062355,
+            "quantity": 0.168,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T20:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2209,
+              "quantity": 0.1011
+            },
+            "amount": 0.048992,
+            "quantity": 0.132,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T20:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1707,
+              "quantity": 0.0782
+            },
+            "amount": 0.037858,
+            "quantity": 0.102,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T19:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.159,
+              "quantity": 0.0728
+            },
+            "amount": 0.035259,
+            "quantity": 0.095,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T19:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.241,
+              "quantity": 0.1103
+            },
+            "amount": 0.053447,
+            "quantity": 0.144,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T18:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2912,
+              "quantity": 0.1333
+            },
+            "amount": 0.064581,
+            "quantity": 0.174,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T18:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.2912,
+              "quantity": 0.1333
+            },
+            "amount": 0.064581,
+            "quantity": 0.174,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T17:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.3079,
+              "quantity": 0.141
+            },
+            "amount": 0.068292,
+            "quantity": 0.184,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T17:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.328,
+              "quantity": 0.1502
+            },
+            "amount": 0.072747,
+            "quantity": 0.196,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T16:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1272,
+              "quantity": 0.0582
+            },
+            "amount": 0.028208,
+            "quantity": 0.076,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T16:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1138,
+              "quantity": 0.0521
+            },
+            "amount": 0.025238,
+            "quantity": 0.068,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T15:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1205,
+              "quantity": 0.0552
+            },
+            "amount": 0.026723,
+            "quantity": 0.072,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T15:00:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1054,
+              "quantity": 0.0483
+            },
+            "amount": 0.023384,
+            "quantity": 0.063,
+            "type": "normal"
+          },
+          "feedIn": {
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
+            "amount": 0.0,
+            "quantity": 0.0,
+            "type": "normal"
+          }
+        },
+        {
+          "dateTime": "2026-06-30T14:30:00Z",
+          "consumption": {
+            "values": {
+              "amount": 0.1121,
+              "quantity": 0.0513
+            },
+            "amount": 0.024867,
             "quantity": 0.067,
             "type": "normal"
           },
           "feedIn": {
-            "values": {"amount": 0.0, "quantity": 0.0},
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
             "amount": 0.0,
             "quantity": 0.0,
             "type": "normal"
           }
         },
         {
-          "dateTime": "2026-06-29T13:30:00Z",
+          "dateTime": "2026-06-30T14:00:00Z",
           "consumption": {
-            "values": {"amount": 0.0483, "quantity": 0.0483},
-            "amount": 0.024499,
-            "quantity": 0.066,
+            "values": {
+              "amount": 0.1205,
+              "quantity": 0.0552
+            },
+            "amount": 0.026723,
+            "quantity": 0.072,
             "type": "normal"
           },
           "feedIn": {
-            "values": {"amount": 0.0, "quantity": 0.0},
+            "values": {
+              "amount": 0.0,
+              "quantity": 0.0
+            },
             "amount": 0.0,
             "quantity": 0.0,
             "type": "normal"
-          }
-        },
-        {
-          "dateTime": "2026-06-29T14:00:00Z",
-          "consumption": {
-            "values": {"amount": 0.0, "quantity": 0.0},
-            "amount": 0.0,
-            "quantity": 0.0,
-            "type": "pending"
-          },
-          "feedIn": {
-            "values": {"amount": 0.0, "quantity": 0.0},
-            "amount": 0.0,
-            "quantity": 0.0,
-            "type": "pending"
-          }
-        },
-        {
-          "dateTime": "2026-06-29T14:30:00Z",
-          "consumption": {
-            "values": {"amount": 0.0, "quantity": 0.0},
-            "amount": 0.0,
-            "quantity": 0.0,
-            "type": "none"
-          },
-          "feedIn": {
-            "values": {"amount": 0.0, "quantity": 0.0},
-            "amount": 0.0,
-            "quantity": 0.0,
-            "type": "none"
           }
         }
       ],

--- a/tests/fixtures/solar_plan_response.json
+++ b/tests/fixtures/solar_plan_response.json
@@ -1,0 +1,45 @@
+{
+  "contractNumber": "9999999999",
+  "fuelType": "Electricity",
+  "productCode": "AGLMKTRE0000000",
+  "productName": "Bright",
+  "billFrequency": "Quarterly",
+  "greenEnergy": "None",
+  "pricingOption": {
+    "value": "YB",
+    "text": "Variable"
+  },
+  "bonuses": [],
+  "gstInclusiveRates": [
+    {
+      "validTo": "2026-07-31",
+      "timeBasis": "91",
+      "type": "c/kWh",
+      "price": 30,
+      "kind": "detail",
+      "title": "General Usage"
+    },
+    {
+      "validTo": "2026-07-31",
+      "timeBasis": "1",
+      "type": "c/day",
+      "price": 140,
+      "kind": "detail",
+      "title": "Supply charge"
+    }
+  ],
+  "gstExclusiveRates": [
+    {
+      "validTo": "2026-07-31",
+      "type": "c/kWh",
+      "price": 1.2,
+      "kind": "detail",
+      "title": "Solar feed-in"
+    }
+  ],
+  "footnotes": [],
+  "changePlan": {
+    "authenticated": true,
+    "url": "https://www.agl.com.au/apps/confirm/?app-config="
+  }
+}

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -1408,6 +1408,95 @@ class TestSolarGeneration:
             await coord._import_generation([])
         assert mock_add.call_count == 0
 
+    async def test_zero_export_day_writes_resume_marker(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A fetched all-zero day gets one zero-delta row so resume advances.
+
+        Codex review on PR #144: without a marker, a cloudy zero-export week
+        (a full chunk) or a solar system newer than the backfill floor would
+        refetch the same days forever and never unlock the period sensors.
+        """
+        coord = _make_coordinator(hass)
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(10.0, 1.0)),
+            ),
+        ):
+            await coord._import_generation([], fetched_days=[date(2026, 6, 29)])
+
+        assert mock_add.call_count == 2
+        gen_stats = mock_add.call_args_list[0][0][2]
+        assert len(gen_stats) == 1
+        assert gen_stats[0]["state"] == 0.0
+        # Zero delta: the cumulative sum stays on the baseline.
+        assert gen_stats[0]["sum"] == pytest.approx(10.0)
+        # Marker lands inside the local day (floored to the hour).
+        from homeassistant.util import dt as dt_util
+
+        marker = gen_stats[0]["start"]
+        expected = dt_util.as_utc(
+            dt_util.start_of_local_day(date(2026, 6, 29))
+        ).replace(minute=0, second=0, microsecond=0)
+        assert marker == expected
+
+    async def test_no_marker_when_day_has_real_intervals(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A day with surviving intervals must not get an extra zero row."""
+        from homeassistant.util import dt as dt_util
+
+        day = date(2026, 6, 29)
+        slot = dt_util.as_utc(dt_util.start_of_local_day(day)) + timedelta(hours=3)
+        coord = _make_coordinator(hass)
+        with (
+            patch(_PATCH_ADD_STATS) as mock_add,
+            patch.object(
+                coord,
+                "_get_baseline_sums",
+                new=AsyncMock(return_value=(0.0, 0.0)),
+            ),
+        ):
+            await coord._import_generation(
+                [_make_interval(slot, kwh=1.0)], fetched_days=[day]
+            )
+
+        gen_stats = mock_add.call_args_list[0][0][2]
+        assert len(gen_stats) == 1  # the real hour only, no marker row
+
+    async def test_fetch_range_marks_zero_days_but_not_errored_days(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Successful-but-empty solar days count as fetched; errored days don't."""
+        from custom_components.haggle.agl.client import AGLError
+
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.return_value = []
+        mock_client.async_get_solar_hourly.side_effect = [
+            [],  # day 1: success, zero export → marked
+            AGLError("HTTP 500"),  # day 2: errored → NOT marked, retried later
+            [],  # day 3: success → marked
+        ]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        day_range = (date(2026, 6, 27), date(2026, 6, 29))
+        with (
+            patch.object(
+                coord, "_import_generation", new_callable=AsyncMock
+            ) as mock_gen,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await coord._fetch_range(day_range, day_range, None)
+
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args.kwargs["fetched_days"] == [
+            date(2026, 6, 27),
+            date(2026, 6, 29),
+        ]
+
     async def test_fetch_range_solar_range_fetches_solar_endpoint(
         self, hass: HomeAssistant
     ) -> None:
@@ -1420,7 +1509,10 @@ class TestSolarGeneration:
 
         bill_start = date(2026, 6, 29)
         day_range = (date(2026, 6, 28), date(2026, 6, 29))
-        with patch("asyncio.sleep", new=AsyncMock()):
+        with (
+            patch.object(coord, "_import_generation", new_callable=AsyncMock),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
             await coord._fetch_range(day_range, day_range, bill_start)
 
         calls = mock_client.async_get_solar_hourly.call_args_list
@@ -1459,7 +1551,10 @@ class TestSolarGeneration:
 
         cons_range = (date(2026, 6, 27), date(2026, 6, 29))
         solar_range = (date(2026, 6, 1), date(2026, 6, 3))
-        with patch("asyncio.sleep", new=AsyncMock()):
+        with (
+            patch.object(coord, "_import_generation", new_callable=AsyncMock),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
             await coord._fetch_range(cons_range, solar_range, None)
 
         cons_days = [c[0][1] for c in mock_client.async_get_usage_hourly.call_args_list]

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -450,7 +450,7 @@ class TestFetchRange:
         end = today - timedelta(days=3)  # all days are before bill_start
 
         with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._fetch_range(start, end, bill_start)
+            await coord._fetch_range((start, end), None, bill_start)
 
         assert mock_client.async_get_usage_hourly_previous.call_count == 3
         mock_client.async_get_usage_hourly.assert_not_called()
@@ -469,7 +469,7 @@ class TestFetchRange:
         end = today - timedelta(days=1)
 
         with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._fetch_range(start, end, bill_start)
+            await coord._fetch_range((start, end), None, bill_start)
 
         assert mock_client.async_get_usage_hourly.call_count == 3
         mock_client.async_get_usage_hourly_previous.assert_not_called()
@@ -487,7 +487,7 @@ class TestFetchRange:
         end = today - timedelta(days=1)
 
         with patch.object(coord, "_import_intervals", new_callable=AsyncMock):
-            await coord._fetch_range(start, end, None)
+            await coord._fetch_range((start, end), None, None)
 
         assert mock_client.async_get_usage_hourly.call_count == 2
         mock_client.async_get_usage_hourly_previous.assert_not_called()
@@ -512,7 +512,7 @@ class TestFetchRange:
                 "custom_components.haggle.coordinator.asyncio.sleep", new=AsyncMock()
             ),
         ):
-            await coord._fetch_range(start, end, None)  # must not raise
+            await coord._fetch_range((start, end), None, None)  # must not raise
 
         # All days attempted despite errors; no intervals → _import_intervals not called
         assert mock_client.async_get_usage_hourly.call_count == 3
@@ -545,7 +545,7 @@ class TestFetchRange:
                 "custom_components.haggle.coordinator.asyncio.sleep", new=AsyncMock()
             ),
         ):
-            await coord._fetch_range(start, end, None)
+            await coord._fetch_range((start, end), None, None)
 
         # Two attempts only: day 1 succeeded, day 2 halted the loop.
         assert mock_client.async_get_usage_hourly.call_count == 2
@@ -571,7 +571,7 @@ class TestFetchRange:
             patch.object(coord, "_import_intervals", new_callable=AsyncMock),
             patch("custom_components.haggle.coordinator.asyncio.sleep", new=sleep_mock),
         ):
-            await coord._fetch_range(start, end, None)
+            await coord._fetch_range((start, end), None, None)
 
         # 3 fetches, 2 inter-request sleeps (no sleep before first).
         assert mock_client.async_get_usage_hourly.call_count == 3
@@ -625,7 +625,7 @@ class TestFetchAndImport:
             await coord._fetch_and_import()
 
         assert mock_range.called
-        actual_start = mock_range.call_args[0][0]
+        actual_start = mock_range.call_args[0][0][0]
         assert actual_start == expected_start
 
     async def test_big_gap_resumes_incrementally_without_rewindow(
@@ -653,9 +653,9 @@ class TestFetchAndImport:
         ):
             await coord._fetch_and_import()
 
-        assert mock_range.call_args[0][0] == expected_start
+        assert mock_range.call_args[0][0][0] == expected_start
         # Throttle: fetch_end at most BACKFILL_CHUNK_DAYS - 1 past fetch_start.
-        fetch_end = mock_range.call_args[0][1]
+        fetch_end = mock_range.call_args[0][0][1]
         assert (fetch_end - expected_start).days <= BACKFILL_CHUNK_DAYS - 1
 
     async def test_trailing_rewindow_when_within_window(
@@ -685,7 +685,7 @@ class TestFetchAndImport:
 
         # Rewindow re-fetches even though last_stat_date is "up to date".
         mock_range.assert_called_once()
-        assert mock_range.call_args[0][0] == expected_start
+        assert mock_range.call_args[0][0][0] == expected_start
 
     async def test_rewindow_clamped_to_backfill_floor(
         self, hass: HomeAssistant
@@ -714,7 +714,7 @@ class TestFetchAndImport:
         ):
             await coord._fetch_and_import()
 
-        assert mock_range.call_args[0][0] >= backfill_floor
+        assert mock_range.call_args[0][0][0] >= backfill_floor
 
     async def test_returns_haggle_data_instance(self, hass: HomeAssistant) -> None:
         from custom_components.haggle.coordinator import HaggleData
@@ -891,7 +891,7 @@ class TestUTCDateBoundary:
 
         # The UTC `today` is 2026-05-02; backfill starts BACKFILL_DAYS earlier.
         expected_start = date(2026, 5, 2) - timedelta(days=BACKFILL_DAYS)
-        assert mock_range.call_args[0][0] == expected_start
+        assert mock_range.call_args[0][0][0] == expected_start
 
 
 # ---------------------------------------------------------------------------
@@ -1408,10 +1408,10 @@ class TestSolarGeneration:
             await coord._import_generation([])
         assert mock_add.call_count == 0
 
-    async def test_fetch_range_include_solar_fetches_solar_endpoint(
+    async def test_fetch_range_solar_range_fetches_solar_endpoint(
         self, hass: HomeAssistant
     ) -> None:
-        """include_solar=True adds one solar fetch per day with the right variant."""
+        """A solar_range adds one solar fetch per day with the right variant."""
         mock_client = AsyncMock()
         mock_client.async_get_usage_hourly.return_value = []
         mock_client.async_get_usage_hourly_previous.return_value = []
@@ -1419,13 +1419,9 @@ class TestSolarGeneration:
         coord = _make_coordinator(hass, client=mock_client)
 
         bill_start = date(2026, 6, 29)
+        day_range = (date(2026, 6, 28), date(2026, 6, 29))
         with patch("asyncio.sleep", new=AsyncMock()):
-            await coord._fetch_range(
-                date(2026, 6, 28),
-                date(2026, 6, 29),
-                bill_start,
-                include_solar=True,
-            )
+            await coord._fetch_range(day_range, day_range, bill_start)
 
         calls = mock_client.async_get_solar_hourly.call_args_list
         assert len(calls) == 2
@@ -1443,9 +1439,79 @@ class TestSolarGeneration:
         coord = _make_coordinator(hass, client=mock_client)
 
         with patch("asyncio.sleep", new=AsyncMock()):
-            await coord._fetch_range(date(2026, 6, 29), date(2026, 6, 29), None)
+            await coord._fetch_range((date(2026, 6, 29), date(2026, 6, 29)), None, None)
 
         assert mock_client.async_get_solar_hourly.call_count == 0
+
+    async def test_fetch_range_disjoint_ranges_skip_other_series(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Each series only fetches days inside its own range.
+
+        The upgrade shape: consumption is caught up (trailing rewindow) while
+        the new generation series backfills from 30 days back. Consumption
+        must not re-fetch the solar backlog days, and vice versa.
+        """
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.return_value = []
+        mock_client.async_get_solar_hourly.return_value = []
+        coord = _make_coordinator(hass, client=mock_client)
+
+        cons_range = (date(2026, 6, 27), date(2026, 6, 29))
+        solar_range = (date(2026, 6, 1), date(2026, 6, 3))
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await coord._fetch_range(cons_range, solar_range, None)
+
+        cons_days = [c[0][1] for c in mock_client.async_get_usage_hourly.call_args_list]
+        solar_days = [
+            c[0][1] for c in mock_client.async_get_solar_hourly.call_args_list
+        ]
+        assert cons_days == [
+            date(2026, 6, 27),
+            date(2026, 6, 28),
+            date(2026, 6, 29),
+        ]
+        assert solar_days == [date(2026, 6, 1), date(2026, 6, 2), date(2026, 6, 3)]
+
+    async def test_fetch_range_solar_rate_limit_still_imports_partial(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A 429 on the solar endpoint halts the chunk but imports both batches.
+
+        The consumption batch and the partial solar batch are idempotent, so
+        importing them preserves each series' own resume point for next cycle.
+        """
+        from custom_components.haggle.agl.client import AGLRateLimitError
+
+        reading = _make_interval(datetime(2026, 6, 29, 2, 0, tzinfo=UTC), kwh=1.0)
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_hourly.return_value = [reading]
+        mock_client.async_get_solar_hourly.side_effect = [
+            [reading],  # day 1 ok
+            AGLRateLimitError("HTTP 429"),  # day 2 — halt
+            [reading],  # day 3 — must not be attempted
+        ]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        day_range = (date(2026, 6, 28), date(2026, 6, 30))
+        with (
+            patch.object(
+                coord, "_import_intervals", new_callable=AsyncMock
+            ) as mock_imp,
+            patch.object(
+                coord, "_import_generation", new_callable=AsyncMock
+            ) as mock_gen,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await coord._fetch_range(day_range, day_range, None)
+
+        # Solar halted on day 2; day 3 fetched for neither series.
+        assert mock_client.async_get_solar_hourly.call_count == 2
+        assert mock_client.async_get_usage_hourly.call_count == 2
+        # Both partial batches still imported.
+        mock_imp.assert_called_once()
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args[0][0] == [reading]
 
     async def test_refresh_has_solar_sets_flag_from_overview(
         self, hass: HomeAssistant
@@ -1497,3 +1563,228 @@ class TestSolarGeneration:
         coord._has_solar = True
         await coord._refresh_has_solar()
         assert coord._has_solar is True
+
+
+# ---------------------------------------------------------------------------
+# Per-series backfill ranges (#128 beta.2) — solar catches up independently
+# ---------------------------------------------------------------------------
+
+
+def _solar_contract() -> object:
+    from custom_components.haggle.agl.models import Contract
+
+    return Contract(
+        contract_number=_CONTRACT,
+        account_number="1234567890",
+        address="",
+        fuel_type="electricityContract",
+        status="active",
+        has_solar=True,
+    )
+
+
+class TestPerSeriesBackfill:
+    async def test_upgrader_solar_backfills_from_floor_while_consumption_rewindows(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Upgrade shape: consumption caught up, generation series empty.
+
+        The generation series must start its own 30-day backfill instead of
+        inheriting consumption's trailing rewindow (which would silently cap
+        solar history at REWINDOW_DAYS forever).
+        """
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        mock_client.async_get_overview.return_value = [_solar_contract()]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)  # consumption caught up
+            return (None, None)  # generation/credit series empty
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        cons_range, solar_range = mock_range.call_args[0][0:2]
+        assert cons_range == (today - timedelta(days=REWINDOW_DAYS), yesterday)
+        backfill_floor = today - timedelta(days=BACKFILL_DAYS)
+        assert solar_range == (
+            backfill_floor,
+            backfill_floor + timedelta(days=BACKFILL_CHUNK_DAYS - 1),
+        )
+
+    async def test_fresh_solar_install_ranges_coincide(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Both series empty → both ranges are the same first backfill chunk."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        mock_client.async_get_overview.return_value = [_solar_contract()]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        cons_range, solar_range = mock_range.call_args[0][0:2]
+        assert cons_range == solar_range
+
+    async def test_non_solar_contract_passes_no_solar_range(
+        self, hass: HomeAssistant
+    ) -> None:
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        coord = _make_coordinator(hass, client=mock_client)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        assert mock_range.call_args[0][1] is None
+
+
+# ---------------------------------------------------------------------------
+# Bill-period solar totals (#128 beta.2) — match the app's "Sold To Grid" tile
+# ---------------------------------------------------------------------------
+
+
+class TestGenerationPeriodTotals:
+    async def test_returns_none_when_no_generation_stats(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        today = datetime.now(UTC).date()
+        result = await coord._get_generation_period_totals(
+            today - timedelta(days=10), None, today
+        )
+        assert result == (None, None)
+
+    async def test_returns_none_while_backfill_behind_rewindow(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Mid-backfill partials never publish — they can't match the app."""
+        coord = _make_coordinator(hass)
+        today = datetime.now(UTC).date()
+        stale = today - timedelta(days=REWINDOW_DAYS + 1)
+        result = await coord._get_generation_period_totals(
+            today - timedelta(days=10), stale, today
+        )
+        assert result == (None, None)
+
+    async def test_caught_up_returns_latest_minus_bill_start_baseline(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Period totals = in-memory latest sums - sums at bill_start midnight."""
+        from homeassistant.util import dt as dt_util
+
+        coord = _make_coordinator(hass)
+        coord._latest_generation_kwh = 18.019
+        coord._latest_generation_credit = 2.3629
+        today = datetime.now(UTC).date()
+        bill_start = today - timedelta(days=12)
+
+        with patch.object(
+            coord,
+            "_get_baseline_sums",
+            new=AsyncMock(return_value=(10.0, 1.0)),
+        ) as mock_base:
+            kwh, credit = await coord._get_generation_period_totals(
+                bill_start, today - timedelta(days=1), today
+            )
+
+        assert kwh == pytest.approx(8.019)
+        assert credit == pytest.approx(1.3629)
+        cutoff = mock_base.call_args[0][2]
+        assert cutoff == dt_util.start_of_local_day(bill_start)
+
+    async def test_clamps_negative_diff_to_zero(self, hass: HomeAssistant) -> None:
+        coord = _make_coordinator(hass)
+        coord._latest_generation_kwh = 5.0
+        coord._latest_generation_credit = 0.5
+        today = datetime.now(UTC).date()
+
+        with patch.object(
+            coord,
+            "_get_baseline_sums",
+            new=AsyncMock(return_value=(6.0, 1.0)),
+        ):
+            kwh, credit = await coord._get_generation_period_totals(
+                today - timedelta(days=3), today - timedelta(days=1), today
+            )
+
+        assert kwh == 0.0
+        assert credit == 0.0
+
+    async def test_fetch_and_import_wires_period_totals_and_feed_in_rate(
+        self, hass: HomeAssistant
+    ) -> None:
+        """HaggleData carries the period totals and the AUD/kWh feed-in rate."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        plan = _empty_plan()
+        plan.feed_in_rate_cents_per_kwh = 1.2
+        mock_client.async_get_plan.return_value = plan
+        mock_client.async_get_overview.return_value = [_solar_contract()]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+        ):
+            data = await coord._fetch_and_import()
+
+        assert data.feed_in_rate_aud_per_kwh == pytest.approx(0.012)
+        # Generation series empty → gated to None, not a partial number.
+        assert data.generation_period_kwh is None
+        assert data.generation_period_credit_aud is None
+
+    async def test_feed_in_rate_none_without_plan_rate(
+        self, hass: HomeAssistant
+    ) -> None:
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        coord = _make_coordinator(hass, client=mock_client)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock),
+        ):
+            data = await coord._fetch_and_import()
+
+        assert data.feed_in_rate_aud_per_kwh is None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -606,6 +606,46 @@ class TestParsePlanTou:
         assert plan.tou_unit_rates == {"peak": pytest.approx(40.0)}
 
 
+class TestParsePlanFeedInRate:
+    """Solar feed-in tariff lives in gstExclusiveRates (#128, FiT is GST-free)."""
+
+    def test_solar_plan_feed_in_rate_parsed(self) -> None:
+        plan = parse_plan(load_fixture("solar_plan_response.json"))
+        assert plan.feed_in_rate_cents_per_kwh == pytest.approx(1.2)
+        # The gstInclusiveRates side is unaffected.
+        assert plan.supply_charge_cents_per_day == pytest.approx(140.0)
+
+    def test_flat_plan_without_feed_in_is_none(self) -> None:
+        plan = parse_plan(load_fixture("plan_response.json"))
+        assert plan.feed_in_rate_cents_per_kwh is None
+
+    def test_unrelated_gst_exclusive_rows_ignored(self) -> None:
+        """Only a c/kWh detail row titled feed-in can set the rate."""
+        data = {
+            "gstExclusiveRates": [
+                {
+                    "kind": "detail",
+                    "type": "c/day",
+                    "price": 90.0,
+                    "title": "Membership",
+                },
+                {"kind": "header", "title": "Solar feed-in"},
+                {"kind": "detail", "type": "c/kWh", "price": 5.0, "title": "Demand"},
+            ]
+        }
+        plan = parse_plan(data)
+        assert plan.feed_in_rate_cents_per_kwh is None
+
+    def test_feed_in_title_variants_match(self) -> None:
+        for title in ("Solar feed-in", "Solar Feed In tariff", "FEED-IN credit"):
+            data = {
+                "gstExclusiveRates": [
+                    {"kind": "detail", "type": "c/kWh", "price": 3.3, "title": title}
+                ]
+            }
+            assert parse_plan(data).feed_in_rate_cents_per_kwh == pytest.approx(3.3)
+
+
 class TestParseIntervalReadingsTou:
     def test_mixed_tou_intervals_preserve_rate_type(self) -> None:
         readings = parse_interval_readings(load_fixture("tou_hourly_response.json"))
@@ -620,39 +660,95 @@ class TestParseIntervalReadingsTou:
 class TestParseSolarIntervals:
     """feedIn extraction from the ElectricitySolar /Hourly response (#128).
 
-    Fixture shape is a real anonymised capture (Ausgrid NSW, 2026-06-29);
-    the daytime non-zero feedIn values are extrapolated onto that shape —
-    the capture's real slots were night-time zeros.
+    Fixture is a REAL anonymised capture (full local day 2026-07-01, AEST)
+    provided on #128, reconciled against the AGL app for that same day:
+    "Sold to Grid: 8.02 kWh ($1.36)", "Consumption: 6.07 kWh ($2.25)".
+    These totals are the ground truth that validated reading the OUTER
+    feedIn.quantity/amount — do not change them without a new capture.
     """
 
-    def test_feedin_outer_quantity_and_amount(self) -> None:
+    def test_feedin_reconciles_with_agl_app_figures(self) -> None:
         data = load_fixture("solar_hourly_response.json")
         readings = parse_interval_readings(data, source_field="feedIn")
-        # 3 daytime export slots survive; the two night zero-on-zero feedIn
-        # slots and the pending/none placeholders are dropped.
-        assert len(readings) == 3
-        kwhs = {r.kwh for r in readings}
-        assert kwhs == {0.502, 1.276, 1.168}
-        # Inner values.quantity (DPI/chart-scaled) must not leak through.
-        assert kwhs.isdisjoint({0.31, 0.79, 0.72})
-        credits = {r.cost_aud for r in readings}
-        assert credits == {0.0165, 0.0421, 0.0385}
+        # 11 daytime export slots survive; 37 night zero-on-zero slots drop.
+        assert len(readings) == 11
+        assert sum(r.kwh for r in readings) == pytest.approx(8.019)
+        assert sum(r.cost_aud for r in readings) == pytest.approx(1.362924)
 
-    def test_consumption_side_of_solar_response_parses_with_default(self) -> None:
-        data = load_fixture("solar_hourly_response.json")
-        readings = parse_interval_readings(data)
-        # All five real consumption slots survive (pending/none dropped).
-        assert len(readings) == 5
-        assert {r.kwh for r in readings} == {0.141, 0.112, 0.124, 0.067, 0.066}
+    def test_uses_outer_feedin_quantity_not_inner_values(self) -> None:
+        """Inner values.* is the DPI/chart-scaled helper — it undercounts.
 
-    def test_feedin_filters_pending_and_none(self) -> None:
+        On the 2026-07-01 capture the inner series sums to 6.1448 kWh vs the
+        app-confirmed 8.02; reading it would repeat the v0.1.0 consumption
+        undercount bug on the export side.
+        """
         data = load_fixture("solar_hourly_response.json")
         readings = parse_interval_readings(data, source_field="feedIn")
+        total = sum(r.kwh for r in readings)
+        assert total != pytest.approx(6.1448)
+        # Spot-check one slot: 01:00Z outer 1.305 kWh, inner 1.0.
         from datetime import UTC, datetime
 
-        dts = {r.dt for r in readings}
-        assert datetime(2026, 6, 29, 14, 0, tzinfo=UTC) not in dts  # pending
-        assert datetime(2026, 6, 29, 14, 30, tzinfo=UTC) not in dts  # none
+        slot = {r.dt: r for r in readings}[datetime(2026, 7, 1, 1, 0, tzinfo=UTC)]
+        assert slot.kwh == pytest.approx(1.305)
+        assert slot.cost_aud == pytest.approx(0.2218)
+
+    def test_feedin_carries_tou_rate_types(self) -> None:
+        """Real solar responses type feedIn slots too (normal + peak seen)."""
+        data = load_fixture("solar_hourly_response.json")
+        all_types = {
+            item["feedIn"]["type"]
+            for section in data["sections"]
+            for item in section["items"]
+        }
+        assert all_types == {"normal", "peak"}
+
+    def test_consumption_side_of_solar_response_parses_with_default(self) -> None:
+        """The solar response's consumption block matches the app figures.
+
+        The coordinator ignores this block (the Electricity endpoint stays the
+        consumption source of truth) but the reconciliation is documented:
+        6.072 kWh / $2.2537 vs the app's 6.07 / $2.25 for 2026-07-01.
+        """
+        data = load_fixture("solar_hourly_response.json")
+        readings = parse_interval_readings(data)
+        assert len(readings) == 41
+        assert sum(r.kwh for r in readings) == pytest.approx(6.072)
+        assert sum(r.cost_aud for r in readings) == pytest.approx(2.253663)
+
+    def test_feedin_filters_pending_and_none(self) -> None:
+        """Synthetic payload — the real capture has no pending/none slots."""
+        data = {
+            "sections": [
+                {
+                    "items": [
+                        {
+                            "dateTime": "2026-07-01T04:00:00Z",
+                            "feedIn": {
+                                "amount": 0.1,
+                                "quantity": 0.5,
+                                "type": "pending",
+                            },
+                        },
+                        {
+                            "dateTime": "2026-07-01T04:30:00Z",
+                            "feedIn": {"amount": 0.1, "quantity": 0.5, "type": "none"},
+                        },
+                        {
+                            "dateTime": "2026-07-01T05:00:00Z",
+                            "feedIn": {
+                                "amount": 0.1,
+                                "quantity": 0.5,
+                                "type": "normal",
+                            },
+                        },
+                    ]
+                }
+            ]
+        }
+        readings = parse_interval_readings(data, source_field="feedIn")
+        assert len(readings) == 1
+        assert readings[0].rate_type == "normal"
 
 
 class TestParseOverviewSolar:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -151,24 +151,83 @@ class TestSolarRegistration:
         self, hass: HomeAssistant
     ) -> None:
         from custom_components.haggle.const import (
+            DATA_FEED_IN_RATE,
             DATA_GENERATION_CREDIT,
             DATA_GENERATION_KWH,
+            DATA_GENERATION_PERIOD,
+            DATA_GENERATION_PERIOD_CREDIT,
         )
 
         keys = await _setup_keys(hass, _data(frozenset(), has_solar=True))
         assert DATA_GENERATION_KWH in keys
         assert DATA_GENERATION_CREDIT in keys
+        assert DATA_GENERATION_PERIOD in keys
+        assert DATA_GENERATION_PERIOD_CREDIT in keys
+        assert DATA_FEED_IN_RATE in keys
         assert set(keys) >= _BASE_KEYS
 
     async def test_non_solar_contract_has_no_generation_sensors(
         self, hass: HomeAssistant
     ) -> None:
         from custom_components.haggle.const import (
+            DATA_FEED_IN_RATE,
             DATA_GENERATION_CREDIT,
             DATA_GENERATION_KWH,
+            DATA_GENERATION_PERIOD,
+            DATA_GENERATION_PERIOD_CREDIT,
         )
 
         keys = await _setup_keys(hass, _data(frozenset()))
         assert DATA_GENERATION_KWH not in keys
         assert DATA_GENERATION_CREDIT not in keys
+        assert DATA_GENERATION_PERIOD not in keys
+        assert DATA_GENERATION_PERIOD_CREDIT not in keys
+        assert DATA_FEED_IN_RATE not in keys
         assert set(keys) == _BASE_KEYS
+
+
+class TestSolarDescriptions:
+    def test_period_sensors_mirror_consumption_period_pattern(self) -> None:
+        """Bill-period totals reset at rollover: TOTAL, never TOTAL_INCREASING."""
+        from homeassistant.components.sensor import (
+            SensorDeviceClass,
+            SensorStateClass,
+        )
+
+        from custom_components.haggle.const import (
+            DATA_GENERATION_PERIOD,
+            DATA_GENERATION_PERIOD_CREDIT,
+        )
+        from custom_components.haggle.sensor import SOLAR_DESCRIPTIONS
+
+        by_key = {d.key: d for d in SOLAR_DESCRIPTIONS}
+        period = by_key[DATA_GENERATION_PERIOD]
+        assert period.state_class is SensorStateClass.TOTAL
+        assert period.device_class is SensorDeviceClass.ENERGY
+        credit = by_key[DATA_GENERATION_PERIOD_CREDIT]
+        assert credit.state_class is SensorStateClass.TOTAL
+        assert credit.device_class is SensorDeviceClass.MONETARY
+
+    def test_feed_in_rate_is_a_unit_price_not_monetary(self) -> None:
+        """Unit prices: MEASUREMENT + AUD/kWh, no device_class (repo rule)."""
+        from homeassistant.components.sensor import SensorStateClass
+
+        from custom_components.haggle.const import DATA_FEED_IN_RATE
+        from custom_components.haggle.sensor import SOLAR_DESCRIPTIONS
+
+        desc = {d.key: d for d in SOLAR_DESCRIPTIONS}[DATA_FEED_IN_RATE]
+        assert desc.device_class is None
+        assert desc.state_class is SensorStateClass.MEASUREMENT
+        assert desc.native_unit_of_measurement == "AUD/kWh"
+
+    async def test_period_sensor_unknown_until_backfill_caught_up(
+        self, hass: HomeAssistant
+    ) -> None:
+        """generation_period_kwh None → sensor unavailable, never a partial."""
+        from custom_components.haggle.const import DATA_GENERATION_PERIOD
+        from custom_components.haggle.sensor import SOLAR_DESCRIPTIONS
+
+        entry = _make_entry_with_coordinator(hass, _data(frozenset(), has_solar=True))
+        desc = {d.key: d for d in SOLAR_DESCRIPTIONS}[DATA_GENERATION_PERIOD]
+        sensor = HaggleEnergySensor(entry.runtime_data.coordinator, entry, desc)
+        assert sensor.native_value is None


### PR DESCRIPTION
## Summary

Round-2 fixes for the #128 solar beta, built from the tester's real full-day 2026-07-01 `ElectricitySolar` capture.

**Key finding first: the beta.1 field mapping was CORRECT.** On the new capture, `sum(outer feedIn.quantity/amount)` = **8.019 kWh / $1.3629** vs the AGL app's **8.02 kWh / $1.36**, and the response's consumption block sums to **6.072 / $2.2537** vs the app's **6.07 / $2.25**. The mismatch reported against beta.1 was a *window artifact* — the cumulative Solar generation sensor (mid-backfill) compared against the app's billing-period tile — not a data bug. The issue thread's outer-field-is-wrong hypothesis is disproven and the mapping is now locked in by regression tests.

## Changes

- **Per-series backfill** — `_fetch_range` now takes separate consumption/solar `(start, end)` ranges, each resolved from its own resume point with its own chunk cap. Fixes upgraders whose generation series could never backfill past the 7-day rewindow. Disjoint ranges skip the other series' days (no extra BFF load: worst case 7+7 requests = steady-state solar load).
- **Bill-period solar sensors** — *Solar sold this period* (kWh) and *Solar feed-in credit this period* (AUD), computed as latest generation sum − sum at `bill_start` local midnight. Gated `unknown` until the generation series is caught up to the rewindow (pre-fetch resume point, so recorder write-queue timing can't race the baseline). These match the app tile the tester compared against.
- **Solar feed-in rate sensor** — the FiT lives in `gstExclusiveRates` (GST-free), which `parse_plan` never read. New `PlanRates.feed_in_rate_cents_per_kwh` + *Solar feed-in rate* sensor (MEASUREMENT, AUD/kWh, no device_class per repo rule).
- **Fixtures/tests** — `solar_hourly_response.json` replaced with the real capture (48 slots, mixed normal/peak feedIn types); new `solar_plan_response.json`; reconciliation totals locked as regression tests; per-series backfill + period-gate + rate-limit-partial-import coordinator tests; 168 tests green.
- **Docs** — CHANGELOG 0.4.0-beta.2 entry; AGENTS.md solar section marked confirmed with the reconciliation numbers, `gstExclusiveRates` fact, per-series backfill note.

## Documentation checklist

- [x] CHANGELOG.md
- [x] AGENTS.md Repo Map (solar_plan fixture, sensor count, coordinator description)
- [x] AGENTS.md AGL API facts (feedIn outer confirmed, gstExclusiveRates, feedIn ToU types)
- [x] Memory files (solar-feedin-validation)

Part of #128 (release gate for stable 0.4.0 — leaving the issue open for tester re-validation of beta.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147RbBtrNYqUX49P6DeU3cC