### PR TITLE
chore(release): v0.4.0-beta.2

### DIFF
--- a/custom_components/haggle/manifest.json
+++ b/custom_components/haggle/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.haggle"],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.4.0-beta.1"
+  "version": "0.4.0-beta.2"
 }


### PR DESCRIPTION
Release v0.4.0-beta.2 with solar validation improvements.

Bumps manifest version to 0.4.0-beta.2.