### PR TITLE
docs: Energy dashboard user guide + HACS default-store install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,9 @@ tests/
 ├── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, ToU per-tariff series, numeric guards
 └── test_sensor.py                   # sensor descriptions + conditional ToU rate-sensor registration
 
+docs/
+└── energy-dashboard.md  # user guide — which haggle:* statistics to add per plan type, sensor glossary, troubleshooting (#137 footgun)
+
 scripts/
 ├── wt                   # bash worktree helper (new / list / rm)
 └── validate_manifest.py # used by the validate-manifest Claude hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Energy dashboard setup guide** (`docs/energy-dashboard.md`): which
+  `haggle:…` statistics to add per plan type (flat / ToU / solar), sensor
+  glossary, data-timing expectations, and troubleshooting — including the
+  "whole day as one bar on the wrong date" symptom caused by charting a
+  `sensor.…` entity instead of a statistic (#137, also observed on #126).
+- README refreshed: HACS default-store install (no more custom-repository
+  steps), current status (ToU in validation, solar in beta), new Energy
+  dashboard and Solar sections. `info.md` no longer tells users the
+  cumulative Consumption sensor "fits the Grid consumption slot" — that
+  instruction was the #137 footgun.
+
 ### Targets for next sprint
 
 - #141 — user-configured ToU windows: derive tariff bands locally from

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ dashboard.
 > **Australia only.** Requires an AGL Energy electricity account with a smart
 > meter (most Australian metropolitan installations).
 
-> **Status:** `v0.3.0`. The flat-rate consumption/cost path is stable and runs
-> live in the maintainer's Home Assistant. **Time-of-Use (ToU) support is
-> implemented but not yet verified against a real AGL ToU account** — see
-> [Time-of-Use (ToU)](#time-of-use-tou) below. See
+> **Status:** `v0.4.0-beta.2`. The flat-rate consumption/cost path is stable
+> and runs live in the maintainer's Home Assistant. **Time-of-Use** support is
+> in validation with real ToU customers
+> ([#126](https://github.com/NaanyaBiz/haggle/issues/126)), and **solar
+> feed-in** support is in beta validation
+> ([#128](https://github.com/NaanyaBiz/haggle/issues/128)) — enable
+> "Show beta versions" in HACS to try either. See
 > [`CHANGELOG.md`](./CHANGELOG.md) for milestone detail.
 
 ## Why
@@ -25,54 +28,71 @@ dashboard.
 AGL is one of Australia's largest electricity retailers. Their mobile app
 exposes half-hourly interval data for smart-meter accounts. `haggle` uses the
 same authenticated API endpoints that AGL's own mobile clients use, fetches
-your smart-meter intervals, and surfaces consumption and cost as proper HA
-energy sensors (`device_class=energy`, `state_class=total_increasing`).
+your smart-meter intervals, and feeds them into Home Assistant's long-term
+statistics so the Energy dashboard shows your usage on the hours it actually
+happened.
 
 ## Install
 
-> Not yet HACS-listed (PR queued). Install via HACS *Custom repository*.
+Haggle is in the [HACS](https://hacs.xyz/) default store:
 
-The fastest path is the badge above — click it on a machine with [My Home
-Assistant](https://my.home-assistant.io/) configured and HACS will open the
-"add repository" dialog pre-filled. Otherwise:
-
-1. HACS → *Integrations* → *Custom repositories* → add this repo URL → category **Integration**.
-2. Install **Haggle**, then restart Home Assistant.
-3. *Settings* → *Devices & Services* → *Add integration* → search **AGL Haggle**.
-4. A login URL is shown. Open it in your **real browser** (handles Akamai
+1. HACS → search **Haggle** → *Download*, then restart Home Assistant.
+   (Or click the badge above on a machine with
+   [My Home Assistant](https://my.home-assistant.io/) configured.)
+2. *Settings* → *Devices & Services* → *Add integration* → search **AGL Haggle**.
+3. A login URL is shown. Open it in your **real browser** (handles Akamai
    bot-protection and MFA transparently). Complete your AGL login.
-5. After login, AGL redirects to a "Not Found" page. Copy the full URL from
+4. After login, AGL redirects to a "Not Found" page. Copy the full URL from
    your browser's address bar and paste it into the HA dialog.
-6. If you have multiple electricity contracts, select the one to monitor.
+5. If you have multiple electricity contracts, select the one to monitor.
 
-The integration will backfill 30 days of history on first run, then poll
-once per day. AGL interval data lags 24–48 h.
+The integration will backfill 30 days of history on first run (throttled to
+7 days per daily poll), then poll once per day. AGL interval data lags
+24–48 h.
+
+## Energy dashboard
+
+**Add the `haggle:…` statistics as your dashboard sources — never the
+`sensor.…` entities.** The statistics carry your real half-hourly history;
+the sensor entities update once per day and would render a whole day as one
+bar on the wrong date.
+
+- **Flat rate:** add `haggle:consumption_<contract>` as *Grid consumption*.
+- **Time-of-Use:** add only the per-tariff series (peak / off-peak /
+  shoulder / anytime) — not the aggregate as well, or every kWh counts twice.
+- **Solar:** additionally add `haggle:generation_<contract>` as
+  *Return to grid*.
+
+Full setup guide, sensor glossary, data-timing expectations, and
+troubleshooting: **[docs/energy-dashboard.md](./docs/energy-dashboard.md)**.
 
 ## Time-of-Use (ToU)
 
-On a flat-rate contract, `haggle` writes one consumption series and one cost
-series — that is the path that runs live today.
-
 On a **Time-of-Use** contract — where AGL tags each 30-minute interval as
-`peak`, `off-peak`, or `shoulder` — `haggle` additionally writes a separate
-consumption + cost statistic per tariff band (peak / off-peak / shoulder /
-anytime), each selectable as its own Energy-dashboard source, plus a per-band
-unit-rate sensor. The split is driven entirely by AGL's per-interval tariff
-tags, so it does not depend on guessing your plan's rate structure.
+`peak`, `off-peak`, or `shoulder` — `haggle` writes a separate consumption +
+cost statistic per tariff band (peak / off-peak / shoulder / anytime), each
+selectable as its own Energy-dashboard source, plus per-band unit-rate
+sensors. The split is driven entirely by AGL's per-interval tariff tags.
 
-- **Energy dashboard:** a ToU contract should add **only the per-tariff
-  consumption sources** — *not* the aggregate "AGL Electricity Consumption"
-  source as well, or every kWh is counted twice. Flat-rate contracts add only
-  the aggregate.
+> ToU is in validation with real AGL ToU customers. The usage/cost split
+> follows AGL's documented per-interval tags; the per-band **rate sensors**
+> infer their band from free-text plan wording and may read `unavailable`
+> ([#90](https://github.com/NaanyaBiz/haggle/issues/90)). Locally-derived
+> tariff windows are planned
+> ([#141](https://github.com/NaanyaBiz/haggle/issues/141)).
 
-> ⚠️ **ToU is unverified.** The maintainer's live account is flat-rate, so ToU
-> has only ever been exercised against synthetic test data, never a real AGL ToU
-> contract. The usage/cost **split** is expected to be correct (it follows the
-> documented `consumption.type` tag), but the per-band **rate sensors** infer
-> their band from free-text plan wording and may read `unavailable`. If you run a
-> ToU plan, testing and feedback are very welcome — see issues
-> [#90](https://github.com/NaanyaBiz/haggle/issues/90) and
-> [#114](https://github.com/NaanyaBiz/haggle/issues/114).
+## Solar (feed-in)
+
+On contracts with rooftop solar, `haggle` also fetches your export data and
+writes `haggle:generation_<contract>` (exported kWh — an Energy-dashboard
+*Return to grid* source) and `haggle:generation_credit_<contract>` (feed-in
+credit). Sensors cover the current billing period (matching the AGL app's
+"Sold To Grid" tile), cumulative totals, and your feed-in rate.
+
+> Solar is in beta validation
+> ([#128](https://github.com/NaanyaBiz/haggle/issues/128)) — the field
+> mapping is confirmed against a real capture and the AGL app; install
+> `v0.4.0-beta.2` via HACS "Show beta versions" to try it.
 
 ## Develop
 

--- a/docs/energy-dashboard.md
+++ b/docs/energy-dashboard.md
@@ -39,7 +39,7 @@ not for the Energy dashboard:
 | **Unit rate / Supply charge** | Your plan's c/kWh (as AUD/kWh) and daily supply charge. |
 | **Unit rate (peak / off-peak / shoulder)** | Per-band rates — ToU contracts only. |
 | **Solar generation / Solar feed-in credit** | Cumulative exported kWh / credited AUD ever imported — solar contracts only. Like **Consumption**, these are running totals: do not compare them to the app's billing-period tile. |
-| **Solar sold this period / Solar feed-in credit this period** | Exported kWh / credited AUD in the current billing period — these are the numbers that match the AGL app's "Sold To Grid" tile. |
+| **Solar sold this period / Solar feed-in credit this period** | Exported kWh / credited AUD in the current billing period — these are the numbers that match the AGL app's "Sold To Grid" tile. Caveat: on **quarterly billing**, a period that started more than 30 days ago predates the backfill window, so these cover only the stored 30-day history and will read lower than the app until a new period starts. |
 | **Solar feed-in rate** | Your feed-in tariff in AUD/kWh. |
 
 ## Data timing — what "normal" looks like
@@ -73,6 +73,8 @@ Compare like with like: the *period* sensors match the app's billing-period
 tile; the Energy dashboard's daily "Return to grid" bars match the app's
 daily solar view. The cumulative **Solar generation** sensor is a running
 total over all imported history and will never match a billing-period figure.
+On quarterly billing the period sensors under-read once the billing period is
+older than the 30-day backfill window (see the glossary above).
 
 **Recent days are missing.**
 Expected — 24–48 h feed lag. If a day is still missing after 3 days, check

--- a/docs/energy-dashboard.md
+++ b/docs/energy-dashboard.md
@@ -1,0 +1,80 @@
+# Energy dashboard setup
+
+Haggle feeds your AGL smart-meter history into Home Assistant as **external
+statistics** — series named `haggle:…` that carry your real half-hourly usage,
+written to the hours the energy was actually used. These, not the sensor
+entities, are what belongs in the Energy dashboard.
+
+> **The one rule:** in the Energy dashboard, always pick a `haggle:…`
+> statistic (display names start with "AGL …"). Never pick a `sensor.…`
+> entity. The sensor entities update once per daily poll, so the dashboard
+> would attribute a whole day's energy to the poll hour — one big bar, on the
+> wrong day (see [Troubleshooting](#troubleshooting) below).
+
+## Which sources to add
+
+Find your exact statistic IDs under **Developer Tools → Statistics**
+(filter "haggle"). `<contract>` below is your AGL contract number.
+
+| Your plan | Grid consumption | Return to grid (solar) | Do **not** add |
+|---|---|---|---|
+| **Flat rate** | `haggle:consumption_<contract>` — "AGL Electricity Consumption (…)" | — | any `sensor.…` entity |
+| **Time-of-Use** | the per-tariff series only: `haggle:consumption_peak_…`, `…_offpeak_…`, `…_shoulder_…`, `…_normal_…` ("AGL Electricity Consumption Peak/Off-Peak/Shoulder/Anytime (…)") | — | the aggregate `haggle:consumption_<contract>` **as well** — the per-tariff series are a partition of it, so adding both counts every kWh twice |
+| **Solar** (either plan type) | as above for your plan type | `haggle:generation_<contract>` — "AGL Solar Generation (…)" | any `sensor.…` entity |
+
+Each consumption series has a matching cost series (`haggle:cost_…`,
+`haggle:generation_credit_…`) if you use the dashboard's cost tracking.
+
+## What the sensor entities are for
+
+The sensors are for at-a-glance values, dashboards cards, and automations —
+not for the Energy dashboard:
+
+| Sensor | What it shows |
+|---|---|
+| **Consumption** | Cumulative kWh ever imported by the integration. Mirrors the statistics total; moves once per daily poll. |
+| **Consumption this period** | kWh so far in the current AGL billing period (matches the app's "Usage So Far"). |
+| **Consumption cost** | AUD so far in the current billing period. |
+| **Bill projection** | AGL's own forecast for the current bill. |
+| **Unit rate / Supply charge** | Your plan's c/kWh (as AUD/kWh) and daily supply charge. |
+| **Unit rate (peak / off-peak / shoulder)** | Per-band rates — ToU contracts only. |
+| **Solar generation / Solar feed-in credit** | Cumulative exported kWh / credited AUD ever imported — solar contracts only. Like **Consumption**, these are running totals: do not compare them to the app's billing-period tile. |
+| **Solar sold this period / Solar feed-in credit this period** | Exported kWh / credited AUD in the current billing period — these are the numbers that match the AGL app's "Sold To Grid" tile. |
+| **Solar feed-in rate** | Your feed-in tariff in AUD/kWh. |
+
+## Data timing — what "normal" looks like
+
+- **AGL's feed lags 24–48 hours.** Today is always empty; yesterday often
+  arrives a day late. This is AGL/AEMO, not the integration.
+- **First install backfills 30 days**, throttled to 7 days per daily poll —
+  so the full month of history takes up to ~4–5 days to appear.
+- **Solar period sensors start as `unknown`** and stay that way until the
+  generation history has caught up (up to ~4 daily polls after
+  installing/upgrading). They deliberately never show a partial number.
+- Every poll re-fetches the trailing 7 days, so slots AGL fills in late are
+  corrected automatically.
+
+## Troubleshooting
+
+**A whole day shows as one big bar, on the wrong day.**
+The dashboard is charting a `sensor.…` entity instead of the `haggle:…`
+statistic. Remove the sensor from the dashboard's sources and add the
+statistic (see the table above). Past days re-render correctly immediately —
+the statistic already holds the hourly history. (Reported as
+[#137](https://github.com/NaanyaBiz/haggle/issues/137).)
+
+**My daily kWh is exactly double the AGL app.**
+Both the aggregate consumption series and the per-tariff series are added.
+They overlap by design — keep only the per-tariff series (ToU) or only the
+aggregate (flat rate).
+
+**Solar sensors don't match the AGL app.**
+Compare like with like: the *period* sensors match the app's billing-period
+tile; the Energy dashboard's daily "Return to grid" bars match the app's
+daily solar view. The cumulative **Solar generation** sensor is a running
+total over all imported history and will never match a billing-period figure.
+
+**Recent days are missing.**
+Expected — 24–48 h feed lag. If a day is still missing after 3 days, check
+`home-assistant.log` for `custom_components.haggle` warnings and open an
+issue.

--- a/info.md
+++ b/info.md
@@ -12,33 +12,44 @@ Assistant Energy dashboard using AGL's authenticated mobile API.
 
 ## Setup
 
-1. Install via HACS *Custom repositories* → add this repo URL → install **Haggle**.
-2. Restart Home Assistant.
-3. *Settings* → *Devices & Services* → *Add integration* → search **AGL Haggle**.
-4. A login URL is displayed. Open it in your **real browser** (not HA's built-in
+1. Install **Haggle** from HACS, then restart Home Assistant.
+2. *Settings* → *Devices & Services* → *Add integration* → search **AGL Haggle**.
+3. A login URL is displayed. Open it in your **real browser** (not HA's built-in
    browser) and complete your AGL login including any MFA prompt.
-5. After login AGL redirects to a "Not Found" page. Copy the full URL from your
+4. After login AGL redirects to a "Not Found" page. Copy the full URL from your
    browser's address bar and paste it back into the HA dialog.
-6. If you have multiple electricity contracts, select the one to monitor.
+5. If you have multiple electricity contracts, select the one to monitor.
 
 The integration polls once per day. AGL interval data lags 24–48 h, so
 recently-used electricity may not appear immediately.
 
+## Energy dashboard
+
+Add the **`haggle:…` statistics** as your dashboard sources — never the
+`sensor.…` entities (they update once per day and would chart a whole day as
+one bar on the wrong date):
+
+- **Flat rate:** `haggle:consumption_<contract>` as *Grid consumption*.
+- **Time-of-Use:** only the per-tariff series (peak / off-peak / shoulder /
+  anytime) — not the aggregate as well, or every kWh counts twice.
+- **Solar:** additionally `haggle:generation_<contract>` as *Return to grid*.
+
+Full guide:
+[docs/energy-dashboard.md](https://github.com/NaanyaBiz/haggle/blob/main/docs/energy-dashboard.md)
+
 ## Sensors
 
-- **Consumption** (`sensor.agl_consumption_*`) — cumulative kWh,
-  fits the Energy dashboard *Grid consumption* slot.
-- **Consumption this period** — kWh for the current bill period.
-- **Consumption cost** — AUD cost for the current bill period.
+- **Consumption** — cumulative kWh imported so far (at-a-glance total; not an
+  Energy-dashboard source).
+- **Consumption this period / Consumption cost** — kWh and AUD for the current
+  bill period.
 - **Bill projection** — AGL's estimated bill for the period.
-- **Unit rate** — your current c/kWh tariff.
-- **Supply charge** — daily supply charge in AUD.
+- **Unit rate / Supply charge** — your tariff and daily supply charge.
 
-On a **Time-of-Use** plan, Haggle also writes per-tariff consumption/cost
-statistics and peak / off-peak / shoulder rate sensors — add only the
-per-tariff consumption sources to the Energy dashboard (not the aggregate as
-well). ToU support is implemented but not yet validated against a real AGL ToU
-account; feedback from ToU customers is welcome.
+Time-of-Use contracts also get peak / off-peak / shoulder rate sensors.
+Solar contracts also get **Solar sold this period**, **Solar feed-in credit
+this period** (both matching the AGL app's "Sold To Grid" tile), cumulative
+generation/credit totals, and **Solar feed-in rate**.
 
 ## Provenance
 


### PR DESCRIPTION
## Summary

User documentation prompted by #137 (and the same symptom reported inside #126) plus the HACS default-store listing.

- **New `docs/energy-dashboard.md`** — the missing user guide: which `haggle:…` statistics to add per plan type (flat / ToU / solar), what NOT to add (sensor entities; aggregate+per-tariff double-count), sensor glossary, data-timing expectations (24–48 h lag, 30-day chunked backfill, solar period sensors `unknown` until caught up), and troubleshooting keyed to the symptoms users actually reported.
- **README** — HACS default-store install replaces the custom-repository instructions; status updated to v0.4.0-beta.2 (ToU in validation #126, solar in beta #128); new *Energy dashboard* and *Solar* sections; stale ToU wording refreshed.
- **info.md** — removed the actively harmful line telling users the cumulative Consumption sensor "fits the Energy dashboard Grid consumption slot" (that instruction is exactly the #137 footgun); added the statistics-not-sensors rule and solar sensors.
- CHANGELOG (Unreleased → Documentation) and AGENTS.md Repo Map updated per the docs checklist.

Docs-only; no code changes. The picker-footgun code fix (de-listing the cumulative sensors) is tracked separately in #147.

Refs #137, #147, #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147RbBtrNYqUX49P6DeU3cC