### PR TITLE
fix: heal leading hole in solar generation statistics (#128)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,15 +371,21 @@ and each item carries **both** a `consumption` block and a shape-identical
   detects it (`_generation_needs_heal`: earliest stored row well past the floor)
   and re-imports the FULL `floor..yesterday` window in one contiguous batch so
   `_emit_series` rebuilds the whole cumulative chain from a correct baseline (a
-  partial fill would step the sum down — #114 class). Completion is **persisted**
-  in `entry.data[CONF_SOLAR_HEAL_STATE]`, not inferred: it stays
-  `SOLAR_HEAL_PENDING` (`_fetch_range` returns `False` on a 429, so the heal
-  retries next cycle) until a sweep reaches yesterday cleanly, then
-  `SOLAR_HEAL_DONE` and **never re-arms** (so an unfetchable permanent leading
-  gap isn't re-swept every poll). Bill-period solar totals are suppressed for
-  the heal cycle (the rewritten pre-`bill_start` rows are still queued, so a
-  live baseline read would transiently over-count). Written like the rotated
-  refresh token — no reload listener fires.
+  partial fill would step the sum down — #114 class). Progress is **persisted**
+  in `entry.data[CONF_SOLAR_HEAL]` as a record `{state, floor, attempts}`, not
+  inferred. The `floor` is **frozen** when the heal starts and re-read from the
+  pending record each retry, so a `today`-recomputed floor can't slide forward
+  and drop the oldest day (Codex P2). `_fetch_range` returns `False` if a 429
+  halted it **or any solar day was skipped** by a transient AGL error
+  (`_fetch_solar_day_into` → `"skip"`), so the heal stays `SOLAR_HEAL_PENDING`
+  and retries the frozen window rather than declaring done with a hole (Codex
+  P1). After `MAX_SOLAR_HEAL_ATTEMPTS` incomplete sweeps it gives up to
+  `SOLAR_HEAL_DONE` so a permanently-erroring old day can't wedge the heal or
+  re-sweep every poll (Codex P3; matches `_fetch_day_solar`'s accepted rare-hole
+  tradeoff). Once `SOLAR_HEAL_DONE` it **never re-arms**. Bill-period solar
+  totals are suppressed for a heal cycle (the rewritten pre-`bill_start` rows are
+  still queued, so a live baseline read would transiently over-count). Written
+  like the rotated refresh token — no reload listener fires.
 - The beta.1 "numbers don't match" report (#128) was a **window artifact** —
   a cumulative-since-backfill sensor compared against the app's
   billing-period tile — not a field bug. When validating against the app,
@@ -607,11 +613,20 @@ The HA Energy dashboard requires:
   neither proxy flags (permanent undercount), and a *legitimately* unfetchable
   leading gap (pre-solar days that HTTP-error rather than return empty) keeps the
   leading-hole check true forever → a 30-day fetch burst every poll. Track
-  completion explicitly in `entry.data` (`SOLAR_HEAL_PENDING`→`SOLAR_HEAL_DONE`,
-  driven by whether `_fetch_range` reached the end without a 429) and suppress
-  bill-period totals during the heal cycle (the rewritten pre-`bill_start` rows
-  are still queued in the recorder, so a live baseline read over-counts). These
-  three were Codex P1/P3/P2 on PR #150.
+  completion explicitly in `entry.data` and suppress bill-period totals during
+  the heal cycle (the rewritten pre-`bill_start` rows are still queued in the
+  recorder, so a live baseline read over-counts). Two more edge cases surfaced
+  on the second Codex pass, both from the completion signal being too coarse:
+  (a) recomputing the heal `floor` from `today` each retry slides it forward, so
+  a 429-interrupted heal drops its oldest day — **freeze the floor** in the
+  persisted record and re-read it on retry; (b) a day skipped by a transient
+  non-429 AGL error (`_fetch_day_solar` → `None`) still let the sweep report
+  "complete" — count **any** skipped solar day as incomplete so the heal
+  retries, but **bound the retries** (`MAX_SOLAR_HEAL_ATTEMPTS`) so a
+  permanently-erroring old date gives up gracefully instead of wedging pending
+  forever. The persisted heal is therefore a record `{state, floor, attempts}`,
+  not a bare state string. First pass: Codex P1/P2/P3; second pass: the
+  floor-slide and skipped-day P2s — all on PR #150.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,9 +373,12 @@ and each item carries **both** a `consumption` block and a shape-identical
   `_emit_series` rebuilds the whole cumulative chain from a correct baseline (a
   partial fill would step the sum down — #114 class). Progress is **persisted**
   in `entry.data[CONF_SOLAR_HEAL]` as a record `{state, floor, attempts}`, not
-  inferred. The `floor` is **frozen** when the heal starts and re-read from the
-  pending record each retry, so a `today`-recomputed floor can't slide forward
-  and drop the oldest day (Codex P2). `_fetch_range` returns `False` if a 429
+  inferred. The `floor` is **frozen** when the heal starts — the pending record
+  is written BEFORE the multi-second fetch (in `_plan_solar_fetch`, via
+  `_write_solar_heal`) so an HA restart mid-heal resumes the same window rather
+  than recomputing the floor from a later `today` — and re-read from the pending
+  record each retry, so it can't slide forward and drop the oldest day (Codex
+  P2, passes 2 and 3). `_fetch_range` returns `False` if a 429
   halted it **or any solar day was skipped** by a transient AGL error
   (`_fetch_solar_day_into` → `"skip"`), so the heal stays `SOLAR_HEAL_PENDING`
   and retries the frozen window rather than declaring done with a hole (Codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,22 @@ and each item carries **both** a `consumption` block and a shape-identical
   into solar support) backfills generation from the 30-day floor without
   re-fetching consumption days; the app-matching bill-period sensors stay
   `unknown` until the generation series reaches the trailing rewindow.
+- **Leading-hole heal** (beta.3, #128): beta.1 seeded the generation series
+  from the *consumption* resume point, so a caught-up beta.1 upgrader got only
+  the trailing `REWINDOW_DAYS` of solar — a permanent hole before that, which
+  the per-series resume (keyed off the *last* row) never revisits. `_plan_solar_fetch`
+  detects it (`_generation_needs_heal`: earliest stored row well past the floor)
+  and re-imports the FULL `floor..yesterday` window in one contiguous batch so
+  `_emit_series` rebuilds the whole cumulative chain from a correct baseline (a
+  partial fill would step the sum down — #114 class). Completion is **persisted**
+  in `entry.data[CONF_SOLAR_HEAL_STATE]`, not inferred: it stays
+  `SOLAR_HEAL_PENDING` (`_fetch_range` returns `False` on a 429, so the heal
+  retries next cycle) until a sweep reaches yesterday cleanly, then
+  `SOLAR_HEAL_DONE` and **never re-arms** (so an unfetchable permanent leading
+  gap isn't re-swept every poll). Bill-period solar totals are suppressed for
+  the heal cycle (the rewritten pre-`bill_start` rows are still queued, so a
+  live baseline read would transiently over-count). Written like the rotated
+  refresh token — no reload listener fires.
 - The beta.1 "numbers don't match" report (#128) was a **window artifact** —
   a cumulative-since-backfill sensor compared against the app's
   billing-period tile — not a field bug. When validating against the app,
@@ -580,6 +596,19 @@ The HA Energy dashboard requires:
   Fixed v0.3.0 → confirmed against the live recorder: 8 phantom spikes at
   `T14:00Z` (AEST local midnight) of 10–27 kWh each, including in the ToU
   `consumption_normal` series.
+- **Don't track heal (or any multi-cycle repair) completion by inferring it
+  from the statistics themselves.** The solar leading-hole heal first shipped
+  "stateless" — re-detecting a leading hole / downward sum-step each cycle. Both
+  proxies leak: a 429 that halts a heal after its markers reach the floor but
+  before the real days complete leaves a monotonic-but-incomplete chain that
+  neither proxy flags (permanent undercount), and a *legitimately* unfetchable
+  leading gap (pre-solar days that HTTP-error rather than return empty) keeps the
+  leading-hole check true forever → a 30-day fetch burst every poll. Track
+  completion explicitly in `entry.data` (`SOLAR_HEAL_PENDING`→`SOLAR_HEAL_DONE`,
+  driven by whether `_fetch_range` reached the end without a 429) and suppress
+  bill-period totals during the heal cycle (the rewritten pre-`bill_start` rows
+  are still queued in the recorder, so a live baseline read over-counts). These
+  three were Codex P1/P3/P2 on PR #150.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now detects a leading hole (earliest stored row well after the backfill floor)
   and re-imports the full window in one contiguous batch via the existing hourly
   endpoint, so the cumulative chain is recomputed from a correct baseline. The
-  heal is a one-time repair whose completion is recorded in the config entry
-  (`solar_heal_state`): it stays *pending* — retrying — until a sweep reaches
-  yesterday without a rate-limit, then *done* and never re-runs, so an
-  interrupted heal always finishes and an unfetchable permanent leading gap
-  isn't re-swept every poll. Bill-period solar totals are suppressed for the
-  one heal cycle (avoiding a transient over-read while the rewritten rows are
-  still queued). Fresh installs and flat/ToU/non-solar contracts are unaffected.
+  heal is a one-time repair whose progress is recorded in the config entry
+  (`solar_heal` = `{state, floor, attempts}`): the backfill floor is **frozen**
+  when the heal starts so a rate-limited retry re-fetches the same window
+  instead of sliding forward and dropping its oldest day; it stays *pending* —
+  retrying — while any day was skipped (429 or a transient AGL error), up to a
+  few attempts, then *done* and never re-runs, so an interrupted heal finishes
+  and a permanently-erroring old day can't wedge it or re-sweep every poll.
+  Bill-period solar totals are suppressed for a heal cycle (avoiding a transient
+  over-read while the rewritten rows are still queued). Fresh installs and
+  flat/ToU/non-solar contracts are unaffected.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revisits them, permanently stranding (for the reporter) 24–27 June (~27 kWh)
   and making *Solar sold this period* undercount the AGL app. The coordinator
   now detects a leading hole (earliest stored row well after the backfill floor)
-  or a downward cumulative-sum step (an interrupted heal) and re-imports the
-  full window in one contiguous batch via the existing hourly endpoint, so the
-  cumulative chain is recomputed from a correct baseline. Stateless and
-  429-safe: an interrupted heal leaves a sum step the next cycle re-detects and
-  finishes. Fresh installs and flat/ToU/non-solar contracts are unaffected.
+  and re-imports the full window in one contiguous batch via the existing hourly
+  endpoint, so the cumulative chain is recomputed from a correct baseline. The
+  heal is a one-time repair whose completion is recorded in the config entry
+  (`solar_heal_state`): it stays *pending* — retrying — until a sweep reaches
+  yesterday without a rate-limit, then *done* and never re-runs, so an
+  interrupted heal always finishes and an unfetchable permanent leading gap
+  isn't re-swept every poll. Bill-period solar totals are suppressed for the
+  one heal cycle (avoiding a transient over-read while the rewritten rows are
+  still queued). Fresh installs and flat/ToU/non-solar contracts are unaffected.
 
 ### Targets for next sprint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Solar generation: heal a **leading hole** in the generation statistics for
+  contracts upgraded from beta.1 (#128). Beta.1 seeded the generation series
+  from the *consumption* resume point, so on a caught-up install solar imported
+  only the trailing `REWINDOW_DAYS` and the older billing-period days were never
+  fetched — `_resolve_fetch_start` keys off the series' last row and never
+  revisits them, permanently stranding (for the reporter) 24–27 June (~27 kWh)
+  and making *Solar sold this period* undercount the AGL app. The coordinator
+  now detects a leading hole (earliest stored row well after the backfill floor)
+  or a downward cumulative-sum step (an interrupted heal) and re-imports the
+  full window in one contiguous batch via the existing hourly endpoint, so the
+  cumulative chain is recomputed from a correct baseline. Stateless and
+  429-safe: an interrupted heal leaves a sum step the next cycle re-detects and
+  finishes. Fresh installs and flat/ToU/non-solar contracts are unaffected.
+
 ### Targets for next sprint
 
 - #141 — user-configured ToU windows: derive tariff bands locally from

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -135,6 +135,13 @@ CONF_ACCOUNT_NUMBER: Final = "account_number"
 # = no pin yet (older entries pre-PR4 / capture failed at install time).
 CONF_PINNED_SPKI_AUTH: Final = "pinned_spki_auth"  # secure.agl.com.au
 CONF_PINNED_SPKI_BFF: Final = "pinned_spki_bff"  # api.platform.agl.com.au
+# One-time solar generation leading-hole heal (#128). Absent = never attempted;
+# "pending" = a full-window re-import is in progress (retried until it completes
+# without a 429); "done" = the one-time heal has run and must never re-arm (so an
+# unfetchable permanent leading gap is not re-swept every poll).
+CONF_SOLAR_HEAL_STATE: Final = "solar_heal_state"
+SOLAR_HEAL_PENDING: Final = "pending"
+SOLAR_HEAL_DONE: Final = "done"
 
 # Coordinator data attribute names — must match HaggleData field names exactly.
 DATA_CONSUMPTION_KWH: Final = "latest_cumulative_kwh"  # TOTAL_INCREASING sensor

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -135,13 +135,21 @@ CONF_ACCOUNT_NUMBER: Final = "account_number"
 # = no pin yet (older entries pre-PR4 / capture failed at install time).
 CONF_PINNED_SPKI_AUTH: Final = "pinned_spki_auth"  # secure.agl.com.au
 CONF_PINNED_SPKI_BFF: Final = "pinned_spki_bff"  # api.platform.agl.com.au
-# One-time solar generation leading-hole heal (#128). Absent = never attempted;
-# "pending" = a full-window re-import is in progress (retried until it completes
-# without a 429); "done" = the one-time heal has run and must never re-arm (so an
-# unfetchable permanent leading gap is not re-swept every poll).
-CONF_SOLAR_HEAL_STATE: Final = "solar_heal_state"
+# One-time solar generation leading-hole heal (#128). Stored as a record:
+#   {"state": "pending"|"done", "floor": "YYYY-MM-DD", "attempts": int}
+# Absent = never attempted. "pending" = a full-window re-import is in progress;
+# the `floor` is frozen when the heal starts so a 429-interrupted retry re-fetches
+# the SAME window instead of sliding forward and dropping its oldest day (Codex
+# P2 on #150). "done" = the heal has run and must never re-arm (so an unfetchable
+# permanent leading gap is not re-swept every poll). A sweep that leaves any day
+# skipped (429 or transient AGL 5xx) stays pending and retries, up to
+# MAX_SOLAR_HEAL_ATTEMPTS sweeps, then gives up to "done" so a permanently-erroring
+# old day can't wedge the heal forever (matches _fetch_day_solar's accepted
+# rare-hole tradeoff).
+CONF_SOLAR_HEAL: Final = "solar_heal"
 SOLAR_HEAL_PENDING: Final = "pending"
 SOLAR_HEAL_DONE: Final = "done"
+MAX_SOLAR_HEAL_ATTEMPTS: Final = 3
 
 # Coordinator data attribute names — must match HaggleData field names exactly.
 DATA_CONSUMPTION_KWH: Final = "latest_cumulative_kwh"  # TOTAL_INCREASING sensor

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -226,9 +226,28 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             last_credit_sum, _ = await self._get_last_stat(stat_id_credit)
             self._latest_generation_kwh = last_gen_sum or 0.0
             self._latest_generation_credit = last_credit_sum or 0.0
-            solar_range = self._chunked_range(
-                self._resolve_fetch_start(today, last_gen_date), yesterday
-            )
+            backfill_floor = today - timedelta(days=BACKFILL_DAYS)
+            if last_gen_date is not None and await self._generation_needs_heal(
+                stat_id_gen, backfill_floor, today
+            ):
+                # One-time leading-hole heal (#128). A generation series seeded
+                # only from the trailing rewindow — beta.1 shared the consumption
+                # resume point, so on a caught-up install solar got just the last
+                # REWINDOW_DAYS — has real rows from ~today-7 and nothing for the
+                # older billing-period days. _resolve_fetch_start keys off the
+                # LAST row, so those stranded days are never revisited. Re-import
+                # the FULL window in one contiguous batch (uncapped by
+                # _chunked_range on purpose) so _import_generation recomputes the
+                # whole cumulative chain from a correct baseline. A partial fill
+                # would leave the later rows on their old baseline and step the
+                # sum downward (#114 class); the 0.5s inter-request delay paces
+                # the burst and a 429 just halts, leaving a step the next cycle's
+                # heal check re-detects and finishes.
+                solar_range = (backfill_floor, yesterday)
+            else:
+                solar_range = self._chunked_range(
+                    self._resolve_fetch_start(today, last_gen_date), yesterday
+                )
 
         # Mark which ToU bands already have stored statistics so the per-tariff
         # series are emitted only for a contract that has been seen using ToU
@@ -507,6 +526,73 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         for stat_id in stat_ids:
             out.setdefault(stat_id, 0.0)
         return out
+
+    async def _generation_needs_heal(
+        self, stat_id_gen: str, floor: date, today: date
+    ) -> bool:
+        """True if the generation series must be re-imported from the floor.
+
+        Two stateless triggers, both re-derived from the recorder each cycle so
+        no heal-progress flag has to be persisted:
+
+        1. LEADING HOLE — the earliest stored generation hour sits well after
+           the backfill floor. A series backfilled from the floor carries a row
+           (a real read, or a zero-export marker) at every day since the floor,
+           so its first row is at/near the floor. A series seeded only from the
+           trailing rewindow (the beta.1 upgrade artifact, #128) starts ~today-7
+           with nothing before it; _resolve_fetch_start keys off the LAST row
+           and never revisits those older days, stranding them permanently.
+
+        2. BROKEN CHAIN — a downward step in the cumulative sum. A heal
+           interrupted mid-way (AGL 429) re-imports a contiguous prefix but
+           leaves the later rows on their old baseline, stepping the sum down at
+           the frontier. Re-detecting that step re-triggers the heal next cycle
+           so it completes — this is what makes the uncapped re-import 429-safe.
+
+        A series with no rows in the window (fresh install) never heals; normal
+        backfill from the floor handles it.
+        """
+        from homeassistant.components.recorder.statistics import (
+            statistics_during_period,
+        )
+        from homeassistant.helpers.recorder import get_instance
+
+        floor_dt = dt_util.as_utc(dt_util.start_of_local_day(floor))
+        now = datetime.now(UTC)
+        result = await get_instance(self.hass).async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            floor_dt,
+            now,
+            {stat_id_gen},
+            "hour",
+            None,
+            {"start", "sum"},
+        )
+        rows = result.get(stat_id_gen) or []
+        if not rows:
+            return False
+
+        # Leading hole: earliest stored hour is more than a day past the floor.
+        # One day of slack absorbs the local-midnight-vs-UTC offset (a local day
+        # begins on the previous UTC date in a positive-offset zone).
+        first_start = rows[0].get("start")
+        if first_start is not None:
+            first_date = datetime.fromtimestamp(float(first_start), tz=UTC).date()
+            if first_date > floor + timedelta(days=1):
+                return True
+
+        # Broken chain: any downward step in the cumulative sum.
+        prev: float | None = None
+        for row in rows:
+            raw = row.get("sum")
+            if raw is None:
+                continue
+            s = float(raw)
+            if prev is not None and s < prev - 1e-6:
+                return True
+            prev = s
+        return False
 
     async def _get_stored_tou_bands(self) -> set[str]:
         """Return the ToU bands (peak/offpeak/shoulder) that already have stats.

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -41,8 +41,9 @@ from .const import (
     BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
     BACKFILL_INTER_REQUEST_DELAY,
-    CONF_SOLAR_HEAL_STATE,
+    CONF_SOLAR_HEAL,
     DOMAIN,
+    MAX_SOLAR_HEAL_ATTEMPTS,
     REWINDOW_DAYS,
     SCAN_INTERVAL_HOURLY,
     SOLAR_HEAL_DONE,
@@ -223,14 +224,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # cycle, not queued in the recorder by this one.
         last_gen_date: date | None = None
         solar_range: tuple[date, date] | None = None
-        solar_healing = False
+        heal_ctx: tuple[date, int] | None = None
         if self._has_solar:
             stat_id_gen, stat_id_credit = self._generation_stat_ids()
             last_gen_sum, last_gen_date = await self._get_last_stat(stat_id_gen)
             last_credit_sum, _ = await self._get_last_stat(stat_id_credit)
             self._latest_generation_kwh = last_gen_sum or 0.0
             self._latest_generation_credit = last_credit_sum or 0.0
-            solar_range, solar_healing = await self._plan_solar_fetch(
+            solar_range, heal_ctx = await self._plan_solar_fetch(
                 stat_id_gen, last_gen_date, today, yesterday
             )
 
@@ -249,8 +250,8 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 known_bands=frozenset(self._active_tou_bands),
             )
 
-        if solar_healing:
-            self._persist_solar_heal(fetch_complete)
+        if heal_ctx is not None:
+            self._persist_solar_heal(heal_ctx, fetch_complete)
 
         # Extract rates from plan.
         unit_rate_aud: float | None = None
@@ -281,7 +282,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # — a one-cycle over-read. The next non-heal cycle reports correctly.
         generation_period_kwh: float | None = None
         generation_period_credit: float | None = None
-        if self._has_solar and not solar_healing:
+        if self._has_solar and heal_ctx is None:
             (
                 generation_period_kwh,
                 generation_period_credit,
@@ -526,55 +527,73 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         last_gen_date: date | None,
         today: date,
         yesterday: date,
-    ) -> tuple[tuple[date, date] | None, bool]:
-        """Return (solar_range, healing) for this cycle.
+    ) -> tuple[tuple[date, date] | None, tuple[date, int] | None]:
+        """Return (solar_range, heal_ctx) for this cycle.
 
-        Normal cycles use the chunked trailing rewindow. A one-time leading-hole
-        heal (#128) instead re-imports the FULL floor..yesterday window in one
-        contiguous batch: a generation series seeded only from the trailing
-        rewindow (beta.1 shared the consumption resume point, so on a caught-up
-        install solar got just the last REWINDOW_DAYS) has real rows from
-        ~today-7 and nothing for the older billing-period days, which
-        _resolve_fetch_start — keyed off the LAST row — never revisits. A
-        contiguous re-import lets _import_generation recompute the whole
-        cumulative chain from a correct baseline; a partial fill would leave
-        later rows on their old baseline and step the sum down (#114 class).
+        `heal_ctx` is None on a normal cycle (chunked trailing rewindow), or
+        `(floor, attempts)` when a one-time leading-hole heal (#128) is active.
+        A generation series seeded only from the trailing rewindow (beta.1 shared
+        the consumption resume point, so on a caught-up install solar got just the
+        last REWINDOW_DAYS) has real rows from ~today-7 and nothing for the older
+        billing-period days, which _resolve_fetch_start — keyed off the LAST row
+        — never revisits. The heal re-imports the FULL floor..yesterday window in
+        one contiguous batch so _import_generation rebuilds the whole cumulative
+        chain from a correct baseline (a partial fill would step the sum down —
+        #114 class).
 
-        Completion is tracked in entry.data, not inferred: the heal stays
-        SOLAR_HEAL_PENDING until _fetch_range reaches yesterday without a 429,
-        then SOLAR_HEAL_DONE and never re-arms. That keeps an interrupted heal
-        retrying (a partial fill the stateless check missed — Codex P1) and
-        stops an unfetchable permanent leading gap from re-sweeping every poll
-        (Codex P3).
+        Completion is tracked in entry.data, not inferred (Codex P1/P2/P3). The
+        `floor` is FROZEN when the heal starts and re-read from the pending record
+        on every retry, so a 429-interrupted heal re-fetches the same window
+        instead of sliding forward and dropping its oldest day. The heal stays
+        pending — retrying — until a sweep completes with no skipped day, then
+        goes done and never re-arms.
         """
-        backfill_floor = today - timedelta(days=BACKFILL_DAYS)
-        heal_state = self.config_entry.data.get(CONF_SOLAR_HEAL_STATE)
-        if (
-            heal_state != SOLAR_HEAL_DONE
-            and last_gen_date is not None
-            and (
-                heal_state == SOLAR_HEAL_PENDING
-                or await self._generation_needs_heal(stat_id_gen, backfill_floor, today)
-            )
-        ):
-            return (backfill_floor, yesterday), True
+        heal = self.config_entry.data.get(CONF_SOLAR_HEAL) or {}
+        state = heal.get("state")
+        if state != SOLAR_HEAL_DONE and last_gen_date is not None:
+            if state == SOLAR_HEAL_PENDING:
+                floor = date.fromisoformat(heal["floor"])  # frozen at heal start
+                return (floor, yesterday), (floor, int(heal.get("attempts", 0)))
+            floor = today - timedelta(days=BACKFILL_DAYS)
+            if await self._generation_needs_heal(stat_id_gen, floor, today):
+                return (floor, yesterday), (floor, 0)
         normal = self._chunked_range(
             self._resolve_fetch_start(today, last_gen_date), yesterday
         )
-        return normal, False
+        return normal, None
 
-    def _persist_solar_heal(self, fetch_complete: bool) -> None:
-        """Record heal progress in entry.data (Codex P1/P3 on #150).
+    def _persist_solar_heal(self, heal_ctx: tuple[date, int], complete: bool) -> None:
+        """Record heal progress in entry.data (Codex P1/P2/P3 on #150).
 
-        A full-window re-import that reached yesterday without a 429 is complete
-        and never re-runs; an interrupted one stays pending and retries next
-        cycle. Written like the rotated refresh token — no reload listener fires.
+        A sweep that reached yesterday with no skipped day (429 or transient AGL
+        5xx) is complete → done, never re-runs. Otherwise it stays pending —
+        keeping the FROZEN floor so the retry re-fetches the same window — and
+        bumps the attempt count; after MAX_SOLAR_HEAL_ATTEMPTS sweeps it gives up
+        to done so a permanently-erroring old day can't wedge the heal forever
+        (matching _fetch_day_solar's accepted rare-hole tradeoff). Written like
+        the rotated refresh token — no reload listener fires.
         """
-        new_state = SOLAR_HEAL_DONE if fetch_complete else SOLAR_HEAL_PENDING
-        if self.config_entry.data.get(CONF_SOLAR_HEAL_STATE) != new_state:
+        floor, attempts = heal_ctx
+        new: dict[str, object]
+        if complete:
+            new = {"state": SOLAR_HEAL_DONE}
+        elif attempts + 1 >= MAX_SOLAR_HEAL_ATTEMPTS:
+            _LOGGER.warning(
+                "Solar heal gave up after %d attempts; some pre-rewindow days may "
+                "remain unfetched (persistent AGL error on old solar dates)",
+                attempts + 1,
+            )
+            new = {"state": SOLAR_HEAL_DONE}
+        else:
+            new = {
+                "state": SOLAR_HEAL_PENDING,
+                "floor": floor.isoformat(),
+                "attempts": attempts + 1,
+            }
+        if self.config_entry.data.get(CONF_SOLAR_HEAL) != new:
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
-                data={**self.config_entry.data, CONF_SOLAR_HEAL_STATE: new_state},
+                data={**self.config_entry.data, CONF_SOLAR_HEAL: new},
             )
 
     async def _generation_needs_heal(
@@ -726,9 +745,12 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     ) -> bool:
         """Fetch per-series day ranges with smart endpoint selection, then import.
 
-        Returns True if the sweep reached the end of the range, False if an AGL
-        429 halted it early — the caller keeps a solar heal SOLAR_HEAL_PENDING
-        until a run returns True.
+        Returns True only if the sweep reached the end of the range AND every
+        solar-range day was fetched cleanly — False if an AGL 429 halted it early
+        or any solar day was skipped by a transient AGL error (`_fetch_day_solar`
+        → None). The caller keeps a solar heal pending until a run returns True,
+        so a skipped old day is retried rather than silently left as a permanent
+        hole (Codex P1/P2 on #150).
 
         Each series carries its own (start, end) so a generation series that is
         behind (e.g. solar support added by upgrade while consumption is caught
@@ -756,6 +778,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         loop_end = max(r[1] for r in ranges)
         first = True
         rate_limited = False
+        solar_skipped = False
         while current <= loop_end and not rate_limited:
             fetch_cons = cons_range is not None and (
                 cons_range[0] <= current <= cons_range[1]
@@ -777,24 +800,17 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 if not first:
                     await asyncio.sleep(BACKFILL_INTER_REQUEST_DELAY)
                 first = False
-                try:
-                    solar_readings = await self._fetch_day_solar(current, previous)
-                except AGLRateLimitError as err:
-                    _LOGGER.warning(
-                        "AGL rate-limited at %s (solar); halting backfill chunk: %s",
-                        current,
-                        err,
-                    )
+                status = await self._fetch_solar_day_into(
+                    current, previous, solar_intervals, fetched_solar_days
+                )
+                if status == "ratelimit":
                     rate_limited = True
-                else:
-                    if solar_readings is not None:
-                        solar_intervals.extend(solar_readings)
-                        # Only a *successful* fetch marks the day as covered.
-                        # An errored day stays unmarked; it is retried until a
-                        # LATER day in the chunk writes rows (same
-                        # skip-and-continue semantics as consumption — see
-                        # _fetch_day_solar docstring for the tradeoff).
-                        fetched_solar_days.append(current)
+                elif status == "skip":
+                    # Transient AGL error on this solar day: unmarked, and the
+                    # sweep is flagged incomplete so a heal retries it rather than
+                    # declaring done with a hole. On normal cycles the return is
+                    # ignored and the trailing rewindow re-fetches it next cycle.
+                    solar_skipped = True
             current += timedelta(days=1)
 
         if all_intervals:
@@ -810,7 +826,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave the cumulative seeds as the caller set them — the
         # most recent stored cumulative remains the sensor value.
-        return not rate_limited
+        return not rate_limited and not solar_skipped
 
     async def _fetch_day_consumption(
         self, day: date, previous: bool
@@ -860,6 +876,35 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         except AGLError as err:
             _LOGGER.debug("Solar fetch skip %s: %s", day, err)
             return None
+
+    async def _fetch_solar_day_into(
+        self,
+        day: date,
+        previous: bool,
+        solar_intervals: list[IntervalReading],
+        fetched_solar_days: list[date],
+    ) -> str:
+        """Fetch one solar day into the accumulators; classify the outcome.
+
+        Returns "ok" (day fetched, marked covered), "skip" (transient AGL error
+        — unmarked, sweep is incomplete), or "ratelimit" (429 — caller halts the
+        chunk). Only a *successful* fetch appends to `fetched_solar_days`, so a
+        skipped day is retried while a heal is pending.
+        """
+        try:
+            readings = await self._fetch_day_solar(day, previous)
+        except AGLRateLimitError as err:
+            _LOGGER.warning(
+                "AGL rate-limited at %s (solar); halting backfill chunk: %s",
+                day,
+                err,
+            )
+            return "ratelimit"
+        if readings is None:
+            return "skip"
+        solar_intervals.extend(readings)
+        fetched_solar_days.append(day)
+        return "ok"
 
     @staticmethod
     def _bucket_hourly(

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -41,9 +41,12 @@ from .const import (
     BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
     BACKFILL_INTER_REQUEST_DELAY,
+    CONF_SOLAR_HEAL_STATE,
     DOMAIN,
     REWINDOW_DAYS,
     SCAN_INTERVAL_HOURLY,
+    SOLAR_HEAL_DONE,
+    SOLAR_HEAL_PENDING,
     STAT_CONSUMPTION,
     STAT_COST,
     STAT_GENERATION,
@@ -220,34 +223,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # cycle, not queued in the recorder by this one.
         last_gen_date: date | None = None
         solar_range: tuple[date, date] | None = None
+        solar_healing = False
         if self._has_solar:
             stat_id_gen, stat_id_credit = self._generation_stat_ids()
             last_gen_sum, last_gen_date = await self._get_last_stat(stat_id_gen)
             last_credit_sum, _ = await self._get_last_stat(stat_id_credit)
             self._latest_generation_kwh = last_gen_sum or 0.0
             self._latest_generation_credit = last_credit_sum or 0.0
-            backfill_floor = today - timedelta(days=BACKFILL_DAYS)
-            if last_gen_date is not None and await self._generation_needs_heal(
-                stat_id_gen, backfill_floor, today
-            ):
-                # One-time leading-hole heal (#128). A generation series seeded
-                # only from the trailing rewindow — beta.1 shared the consumption
-                # resume point, so on a caught-up install solar got just the last
-                # REWINDOW_DAYS — has real rows from ~today-7 and nothing for the
-                # older billing-period days. _resolve_fetch_start keys off the
-                # LAST row, so those stranded days are never revisited. Re-import
-                # the FULL window in one contiguous batch (uncapped by
-                # _chunked_range on purpose) so _import_generation recomputes the
-                # whole cumulative chain from a correct baseline. A partial fill
-                # would leave the later rows on their old baseline and step the
-                # sum downward (#114 class); the 0.5s inter-request delay paces
-                # the burst and a 429 just halts, leaving a step the next cycle's
-                # heal check re-detects and finishes.
-                solar_range = (backfill_floor, yesterday)
-            else:
-                solar_range = self._chunked_range(
-                    self._resolve_fetch_start(today, last_gen_date), yesterday
-                )
+            solar_range, solar_healing = await self._plan_solar_fetch(
+                stat_id_gen, last_gen_date, today, yesterday
+            )
 
         # Mark which ToU bands already have stored statistics so the per-tariff
         # series are emitted only for a contract that has been seen using ToU
@@ -255,13 +240,17 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # per-tariff baseline sums themselves are resolved in _import_intervals.
         self._active_tou_bands |= await self._get_stored_tou_bands()
 
+        fetch_complete = True
         if cons_range or solar_range:
-            await self._fetch_range(
+            fetch_complete = await self._fetch_range(
                 cons_range,
                 solar_range,
                 bill_start,
                 known_bands=frozenset(self._active_tou_bands),
             )
+
+        if solar_healing:
+            self._persist_solar_heal(fetch_complete)
 
         # Extract rates from plan.
         unit_rate_aud: float | None = None
@@ -285,10 +274,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         feed_in_rate_aud = feed_in_cents / 100.0 if feed_in_cents is not None else None
 
         # Bill-period solar totals — after the fetch so this cycle's rows are
-        # included in the in-memory latest sums.
+        # included in the in-memory latest sums. Suppressed (→ sensor `unknown`)
+        # during a heal cycle (Codex P2): the heal rewrites rows behind
+        # bill_start this cycle, so the baseline query could still read the old
+        # queued sum while _latest_generation_kwh already holds the rebuilt total
+        # — a one-cycle over-read. The next non-heal cycle reports correctly.
         generation_period_kwh: float | None = None
         generation_period_credit: float | None = None
-        if self._has_solar:
+        if self._has_solar and not solar_healing:
             (
                 generation_period_kwh,
                 generation_period_credit,
@@ -527,6 +520,63 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             out.setdefault(stat_id, 0.0)
         return out
 
+    async def _plan_solar_fetch(
+        self,
+        stat_id_gen: str,
+        last_gen_date: date | None,
+        today: date,
+        yesterday: date,
+    ) -> tuple[tuple[date, date] | None, bool]:
+        """Return (solar_range, healing) for this cycle.
+
+        Normal cycles use the chunked trailing rewindow. A one-time leading-hole
+        heal (#128) instead re-imports the FULL floor..yesterday window in one
+        contiguous batch: a generation series seeded only from the trailing
+        rewindow (beta.1 shared the consumption resume point, so on a caught-up
+        install solar got just the last REWINDOW_DAYS) has real rows from
+        ~today-7 and nothing for the older billing-period days, which
+        _resolve_fetch_start — keyed off the LAST row — never revisits. A
+        contiguous re-import lets _import_generation recompute the whole
+        cumulative chain from a correct baseline; a partial fill would leave
+        later rows on their old baseline and step the sum down (#114 class).
+
+        Completion is tracked in entry.data, not inferred: the heal stays
+        SOLAR_HEAL_PENDING until _fetch_range reaches yesterday without a 429,
+        then SOLAR_HEAL_DONE and never re-arms. That keeps an interrupted heal
+        retrying (a partial fill the stateless check missed — Codex P1) and
+        stops an unfetchable permanent leading gap from re-sweeping every poll
+        (Codex P3).
+        """
+        backfill_floor = today - timedelta(days=BACKFILL_DAYS)
+        heal_state = self.config_entry.data.get(CONF_SOLAR_HEAL_STATE)
+        if (
+            heal_state != SOLAR_HEAL_DONE
+            and last_gen_date is not None
+            and (
+                heal_state == SOLAR_HEAL_PENDING
+                or await self._generation_needs_heal(stat_id_gen, backfill_floor, today)
+            )
+        ):
+            return (backfill_floor, yesterday), True
+        normal = self._chunked_range(
+            self._resolve_fetch_start(today, last_gen_date), yesterday
+        )
+        return normal, False
+
+    def _persist_solar_heal(self, fetch_complete: bool) -> None:
+        """Record heal progress in entry.data (Codex P1/P3 on #150).
+
+        A full-window re-import that reached yesterday without a 429 is complete
+        and never re-runs; an interrupted one stays pending and retries next
+        cycle. Written like the rotated refresh token — no reload listener fires.
+        """
+        new_state = SOLAR_HEAL_DONE if fetch_complete else SOLAR_HEAL_PENDING
+        if self.config_entry.data.get(CONF_SOLAR_HEAL_STATE) != new_state:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={**self.config_entry.data, CONF_SOLAR_HEAL_STATE: new_state},
+            )
+
     async def _generation_needs_heal(
         self, stat_id_gen: str, floor: date, today: date
     ) -> bool:
@@ -673,8 +723,12 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         bill_start: date | None,
         *,
         known_bands: frozenset[str] = frozenset(),
-    ) -> None:
+    ) -> bool:
         """Fetch per-series day ranges with smart endpoint selection, then import.
+
+        Returns True if the sweep reached the end of the range, False if an AGL
+        429 halted it early — the caller keeps a solar heal SOLAR_HEAL_PENDING
+        until a run returns True.
 
         Each series carries its own (start, end) so a generation series that is
         behind (e.g. solar support added by upgrade while consumption is caught
@@ -694,7 +748,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         """
         ranges = [r for r in (cons_range, solar_range) if r is not None]
         if not ranges:
-            return
+            return True
         all_intervals: list[IntervalReading] = []
         solar_intervals: list[IntervalReading] = []
         fetched_solar_days: list[date] = []
@@ -716,6 +770,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 first = False
                 readings = await self._fetch_day_consumption(current, previous)
                 if readings is None:  # rate-limited
+                    rate_limited = True
                     break
                 all_intervals.extend(readings)
             if fetch_solar:
@@ -755,6 +810,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave the cumulative seeds as the caller set them — the
         # most recent stored cumulative remains the sensor value.
+        return not rate_limited
 
     async def _fetch_day_consumption(
         self, day: date, previous: bool

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -542,11 +542,12 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         #114 class).
 
         Completion is tracked in entry.data, not inferred (Codex P1/P2/P3). The
-        `floor` is FROZEN when the heal starts and re-read from the pending record
-        on every retry, so a 429-interrupted heal re-fetches the same window
-        instead of sliding forward and dropping its oldest day. The heal stays
-        pending — retrying — until a sweep completes with no skipped day, then
-        goes done and never re-arms.
+        `floor` is FROZEN when the heal starts — persisted BEFORE the fetch (Codex
+        P2, pass 3) so an HA restart mid-heal resumes the same window instead of
+        recomputing it from a later `today` and dropping the oldest day — and
+        re-read from the pending record on every retry. The heal stays pending —
+        retrying — until a sweep completes with no skipped day, then goes done and
+        never re-arms.
         """
         heal = self.config_entry.data.get(CONF_SOLAR_HEAL) or {}
         state = heal.get("state")
@@ -556,6 +557,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 return (floor, yesterday), (floor, int(heal.get("attempts", 0)))
             floor = today - timedelta(days=BACKFILL_DAYS)
             if await self._generation_needs_heal(stat_id_gen, floor, today):
+                # Freeze the floor NOW, before the multi-second fetch, so a
+                # restart mid-heal survives with the window intact. A resume
+                # cycle already has this record, so this is a no-op then.
+                self._write_solar_heal(
+                    {
+                        "state": SOLAR_HEAL_PENDING,
+                        "floor": floor.isoformat(),
+                        "attempts": 0,
+                    }
+                )
                 return (floor, yesterday), (floor, 0)
         normal = self._chunked_range(
             self._resolve_fetch_start(today, last_gen_date), yesterday
@@ -590,10 +601,15 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 "floor": floor.isoformat(),
                 "attempts": attempts + 1,
             }
-        if self.config_entry.data.get(CONF_SOLAR_HEAL) != new:
+        self._write_solar_heal(new)
+
+    def _write_solar_heal(self, record: dict[str, object]) -> None:
+        """Persist the heal record to entry.data if changed (like the rotated
+        refresh token — no reload listener fires)."""
+        if self.config_entry.data.get(CONF_SOLAR_HEAL) != record:
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
-                data={**self.config_entry.data, CONF_SOLAR_HEAL: new},
+                data={**self.config_entry.data, CONF_SOLAR_HEAL: record},
             )
 
     async def _generation_needs_heal(

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -23,8 +23,11 @@ from custom_components.haggle.const import (
     CONF_ACCOUNT_NUMBER,
     CONF_CONTRACT_NUMBER,
     CONF_REFRESH_TOKEN,
+    CONF_SOLAR_HEAL_STATE,
     DOMAIN,
     REWINDOW_DAYS,
+    SOLAR_HEAL_DONE,
+    SOLAR_HEAL_PENDING,
     STAT_CONSUMPTION,
 )
 from custom_components.haggle.coordinator import HaggleCoordinator
@@ -2039,3 +2042,127 @@ class TestGenerationHeal:
 
         solar_range = mock_range.call_args[0][1]
         assert solar_range == (today - timedelta(days=REWINDOW_DAYS), yesterday)
+
+
+class TestGenerationHealState:
+    """The persisted heal state machine (Codex P1/P2/P3 on #150).
+
+    Completion is tracked in entry.data, not inferred from the sum chain: an
+    interrupted heal resumes until it finishes; a completed one never re-arms.
+    """
+
+    @staticmethod
+    def _solar_client() -> AsyncMock:
+        client = AsyncMock()
+        client.async_get_usage_summary.return_value = _empty_summary()
+        client.async_get_plan.return_value = _empty_plan()
+        client.async_get_overview.return_value = [_solar_contract()]
+        return client
+
+    async def _run(
+        self,
+        hass: HomeAssistant,
+        *,
+        preset: str | None = None,
+        needs_heal: bool = True,
+        fetch_complete: bool = True,
+    ) -> tuple[HaggleCoordinator, MagicMock, MagicMock, object]:
+        coord = _make_coordinator(hass, client=self._solar_client())
+        if preset is not None:
+            hass.config_entries.async_update_entry(
+                coord.config_entry,
+                data={**coord.config_entry.data, CONF_SOLAR_HEAL_STATE: preset},
+            )
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)  # consumption caught up
+            return (12.3, today - timedelta(days=8))  # generation seeded recent
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(
+                coord,
+                "_generation_needs_heal",
+                new_callable=AsyncMock,
+                return_value=needs_heal,
+            ) as mock_needs,
+            patch.object(
+                coord,
+                "_get_generation_period_totals",
+                new_callable=AsyncMock,
+                return_value=(4.0, 1.0),
+            ),
+            patch.object(
+                coord,
+                "_fetch_range",
+                new_callable=AsyncMock,
+                return_value=fetch_complete,
+            ) as mock_range,
+        ):
+            data = await coord._fetch_and_import()
+        return coord, mock_range, mock_needs, data
+
+    async def test_completed_heal_marks_done(self, hass: HomeAssistant) -> None:
+        today = datetime.now(UTC).date()
+        coord, mock_range, _, _ = await self._run(hass, fetch_complete=True)
+        assert mock_range.call_args[0][1] == (
+            today - timedelta(days=BACKFILL_DAYS),
+            today - timedelta(days=1),
+        )
+        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_DONE
+
+    async def test_interrupted_heal_stays_pending(self, hass: HomeAssistant) -> None:
+        """A 429 mid-heal (_fetch_range → False) keeps the heal pending (P1)."""
+        coord, _, _, _ = await self._run(hass, fetch_complete=False)
+        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_PENDING
+
+    async def test_pending_resumes_without_redetection(
+        self, hass: HomeAssistant
+    ) -> None:
+        """PENDING resumes the full-window heal regardless of the detector — the
+        P1 fix: completion is tracked, not re-inferred (a partial fill the
+        stateless sum-step check would have missed still gets finished)."""
+        today = datetime.now(UTC).date()
+        coord, mock_range, mock_needs, _ = await self._run(
+            hass, preset=SOLAR_HEAL_PENDING, needs_heal=False, fetch_complete=True
+        )
+        mock_needs.assert_not_awaited()  # short-circuits on the pending state
+        assert mock_range.call_args[0][1] == (
+            today - timedelta(days=BACKFILL_DAYS),
+            today - timedelta(days=1),
+        )
+        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_DONE
+
+    async def test_done_never_rearms(self, hass: HomeAssistant) -> None:
+        """Once DONE, a still-present leading gap (needs_heal True) is NOT
+        re-swept — the P3 fix against an unfetchable permanent leading gap
+        re-bursting a 30-day fetch every poll."""
+        today = datetime.now(UTC).date()
+        coord, mock_range, _, _ = await self._run(
+            hass, preset=SOLAR_HEAL_DONE, needs_heal=True
+        )
+        # Not the heal window: a normal trailing chunk, never starting at floor.
+        assert mock_range.call_args[0][1][0] != today - timedelta(days=BACKFILL_DAYS)
+        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_DONE
+
+    async def test_period_totals_suppressed_during_heal(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The heal rewrites rows behind bill_start this cycle, so the period
+        totals are suppressed (→ sensor `unknown`) to avoid a one-cycle over-read
+        from a stale queued baseline (P2), even though the totals helper returns
+        numbers."""
+        _, _, _, data = await self._run(hass, needs_heal=True)
+        assert data.generation_period_kwh is None
+        assert data.generation_period_credit_aud is None
+
+    async def test_period_totals_reported_when_not_healing(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, _, _, data = await self._run(hass, preset=SOLAR_HEAL_DONE, needs_heal=True)
+        assert data.generation_period_kwh == 4.0
+        assert data.generation_period_credit_aud == 1.0

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -1883,3 +1883,159 @@ class TestGenerationPeriodTotals:
             data = await coord._fetch_and_import()
 
         assert data.feed_in_rate_aud_per_kwh is None
+
+
+# ---------------------------------------------------------------------------
+# Leading-hole heal (#128 follow-up) — a generation series seeded only from the
+# trailing rewindow (beta.1 upgrade artifact) is re-imported from the floor.
+# ---------------------------------------------------------------------------
+
+
+def _ts(d: date) -> float:
+    """UTC-midnight unix timestamp for a date, matching the recorder's `start`."""
+    return datetime(d.year, d.month, d.day, tzinfo=UTC).timestamp()
+
+
+class TestGenerationHeal:
+    async def test_leading_hole_detected(self, hass: HomeAssistant) -> None:
+        """Earliest stored row well after the floor → heal needed."""
+        coord = _make_coordinator(hass)
+        stat_id_gen = coord._generation_stat_ids()[0]
+        today = datetime.now(UTC).date()
+        floor = today - timedelta(days=BACKFILL_DAYS)
+        # Rows only from the last 5 days: seeded from the trailing rewindow.
+        rows = {
+            stat_id_gen: [
+                {"start": _ts(today - timedelta(days=n)), "sum": float(10 - n)}
+                for n in range(5, 0, -1)
+            ]
+        }
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance(rows)):
+            assert await coord._generation_needs_heal(stat_id_gen, floor, today) is True
+
+    async def test_contiguous_from_floor_no_heal(self, hass: HomeAssistant) -> None:
+        """First row at the floor with a monotonic sum → no heal."""
+        coord = _make_coordinator(hass)
+        stat_id_gen = coord._generation_stat_ids()[0]
+        today = datetime.now(UTC).date()
+        floor = today - timedelta(days=BACKFILL_DAYS)
+        rows = {
+            stat_id_gen: [
+                {"start": _ts(floor + timedelta(days=n)), "sum": float(n)}
+                for n in range(BACKFILL_DAYS)
+            ]
+        }
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance(rows)):
+            assert (
+                await coord._generation_needs_heal(stat_id_gen, floor, today) is False
+            )
+
+    async def test_downward_sum_step_detected(self, hass: HomeAssistant) -> None:
+        """A downward step (interrupted heal) re-triggers even when rows reach
+        the floor — this is what makes the uncapped re-import 429-safe."""
+        coord = _make_coordinator(hass)
+        stat_id_gen = coord._generation_stat_ids()[0]
+        today = datetime.now(UTC).date()
+        floor = today - timedelta(days=BACKFILL_DAYS)
+        rows = {
+            stat_id_gen: [
+                {"start": _ts(floor), "sum": 5.0},
+                {"start": _ts(floor + timedelta(days=1)), "sum": 27.0},
+                {"start": _ts(floor + timedelta(days=2)), "sum": 3.0},  # step down
+            ]
+        }
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance(rows)):
+            assert await coord._generation_needs_heal(stat_id_gen, floor, today) is True
+
+    async def test_empty_series_no_heal(self, hass: HomeAssistant) -> None:
+        """No rows (fresh install) → normal backfill handles it, not a heal."""
+        coord = _make_coordinator(hass)
+        stat_id_gen = coord._generation_stat_ids()[0]
+        today = datetime.now(UTC).date()
+        floor = today - timedelta(days=BACKFILL_DAYS)
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance({})):
+            assert (
+                await coord._generation_needs_heal(stat_id_gen, floor, today) is False
+            )
+
+    async def test_leading_hole_triggers_full_window_reimport(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A needed heal makes solar_range span the FULL floor..yesterday window
+        (uncapped by the 7-day chunk) so the whole chain is rewritten in one
+        contiguous batch — a partial fill would step the sum down (#114 class)."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        mock_client.async_get_overview.return_value = [_solar_contract()]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        backfill_floor = today - timedelta(days=BACKFILL_DAYS)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)  # consumption caught up
+            return (12.3, today - timedelta(days=8))  # generation seeded recent
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(
+                coord,
+                "_generation_needs_heal",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                coord,
+                "_get_generation_period_totals",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        solar_range = mock_range.call_args[0][1]
+        assert solar_range == (backfill_floor, yesterday)
+
+    async def test_healthy_series_uses_normal_chunked_range(
+        self, hass: HomeAssistant
+    ) -> None:
+        """No heal needed → solar_range stays the normal trailing-rewindow chunk."""
+        mock_client = AsyncMock()
+        mock_client.async_get_usage_summary.return_value = _empty_summary()
+        mock_client.async_get_plan.return_value = _empty_plan()
+        mock_client.async_get_overview.return_value = [_solar_contract()]
+        coord = _make_coordinator(hass, client=mock_client)
+
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(12.3, yesterday),
+            ),
+            patch.object(
+                coord,
+                "_generation_needs_heal",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                coord,
+                "_get_generation_period_totals",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", new_callable=AsyncMock) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        solar_range = mock_range.call_args[0][1]
+        assert solar_range == (today - timedelta(days=REWINDOW_DAYS), yesterday)

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -2111,6 +2111,49 @@ class TestGenerationHealState:
     def _heal(coord: HaggleCoordinator) -> dict:
         return coord.config_entry.data.get(CONF_SOLAR_HEAL) or {}
 
+    async def test_pending_persisted_before_fetch(self, hass: HomeAssistant) -> None:
+        """The frozen-floor pending record is written BEFORE the long fetch, so an
+        HA restart mid-heal resumes the same window (Codex P2, pass 3). Captured
+        by reading entry.data at the moment _fetch_range is entered."""
+        coord = _make_coordinator(hass, client=self._solar_client())
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+        seen: dict[str, object] = {}
+
+        async def _capture_fetch(*_a: object, **_k: object) -> bool:
+            seen["heal"] = coord.config_entry.data.get(CONF_SOLAR_HEAL)
+            return True
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)
+            return (12.3, today - timedelta(days=8))
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(
+                coord,
+                "_generation_needs_heal",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                coord,
+                "_get_generation_period_totals",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(coord, "_fetch_range", side_effect=_capture_fetch),
+        ):
+            await coord._fetch_and_import()
+
+        assert seen["heal"] == {
+            "state": SOLAR_HEAL_PENDING,
+            "floor": (today - timedelta(days=BACKFILL_DAYS)).isoformat(),
+            "attempts": 0,
+        }
+
     async def test_completed_heal_marks_done(self, hass: HomeAssistant) -> None:
         today = datetime.now(UTC).date()
         coord, mock_range, _, _ = await self._run(hass, fetch_complete=True)

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -23,8 +23,9 @@ from custom_components.haggle.const import (
     CONF_ACCOUNT_NUMBER,
     CONF_CONTRACT_NUMBER,
     CONF_REFRESH_TOKEN,
-    CONF_SOLAR_HEAL_STATE,
+    CONF_SOLAR_HEAL,
     DOMAIN,
+    MAX_SOLAR_HEAL_ATTEMPTS,
     REWINDOW_DAYS,
     SOLAR_HEAL_DONE,
     SOLAR_HEAL_PENDING,
@@ -2063,7 +2064,7 @@ class TestGenerationHealState:
         self,
         hass: HomeAssistant,
         *,
-        preset: str | None = None,
+        preset: dict | None = None,
         needs_heal: bool = True,
         fetch_complete: bool = True,
     ) -> tuple[HaggleCoordinator, MagicMock, MagicMock, object]:
@@ -2071,7 +2072,7 @@ class TestGenerationHealState:
         if preset is not None:
             hass.config_entries.async_update_entry(
                 coord.config_entry,
-                data={**coord.config_entry.data, CONF_SOLAR_HEAL_STATE: preset},
+                data={**coord.config_entry.data, CONF_SOLAR_HEAL: preset},
             )
         today = datetime.now(UTC).date()
         yesterday = today - timedelta(days=1)
@@ -2106,6 +2107,10 @@ class TestGenerationHealState:
             data = await coord._fetch_and_import()
         return coord, mock_range, mock_needs, data
 
+    @staticmethod
+    def _heal(coord: HaggleCoordinator) -> dict:
+        return coord.config_entry.data.get(CONF_SOLAR_HEAL) or {}
+
     async def test_completed_heal_marks_done(self, hass: HomeAssistant) -> None:
         today = datetime.now(UTC).date()
         coord, mock_range, _, _ = await self._run(hass, fetch_complete=True)
@@ -2113,29 +2118,74 @@ class TestGenerationHealState:
             today - timedelta(days=BACKFILL_DAYS),
             today - timedelta(days=1),
         )
-        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_DONE
+        assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
 
     async def test_interrupted_heal_stays_pending(self, hass: HomeAssistant) -> None:
-        """A 429 mid-heal (_fetch_range → False) keeps the heal pending (P1)."""
-        coord, _, _, _ = await self._run(hass, fetch_complete=False)
-        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_PENDING
-
-    async def test_pending_resumes_without_redetection(
-        self, hass: HomeAssistant
-    ) -> None:
-        """PENDING resumes the full-window heal regardless of the detector — the
-        P1 fix: completion is tracked, not re-inferred (a partial fill the
-        stateless sum-step check would have missed still gets finished)."""
+        """A 429/skip mid-heal (_fetch_range → False) keeps the heal pending and
+        bumps the attempt count, freezing the floor for the retry (Codex P1/P2)."""
         today = datetime.now(UTC).date()
+        coord, _, _, _ = await self._run(hass, fetch_complete=False)
+        heal = self._heal(coord)
+        assert heal["state"] == SOLAR_HEAL_PENDING
+        assert heal["attempts"] == 1
+        assert heal["floor"] == (today - timedelta(days=BACKFILL_DAYS)).isoformat()
+
+    async def test_pending_resumes_from_frozen_floor(self, hass: HomeAssistant) -> None:
+        """PENDING resumes the full-window heal from the FROZEN floor regardless
+        of the detector (Codex P1/P2): the retry re-fetches the same window, not a
+        today-recomputed one that would slide off the oldest day."""
+        today = datetime.now(UTC).date()
+        frozen_floor = today - timedelta(days=25)  # deliberately != today-30
         coord, mock_range, mock_needs, _ = await self._run(
-            hass, preset=SOLAR_HEAL_PENDING, needs_heal=False, fetch_complete=True
+            hass,
+            preset={
+                "state": SOLAR_HEAL_PENDING,
+                "floor": frozen_floor.isoformat(),
+                "attempts": 1,
+            },
+            needs_heal=False,
+            fetch_complete=True,
         )
         mock_needs.assert_not_awaited()  # short-circuits on the pending state
-        assert mock_range.call_args[0][1] == (
-            today - timedelta(days=BACKFILL_DAYS),
-            today - timedelta(days=1),
+        assert mock_range.call_args[0][1] == (frozen_floor, today - timedelta(days=1))
+        assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
+
+    async def test_frozen_floor_preserved_across_retry(
+        self, hass: HomeAssistant
+    ) -> None:
+        """An interrupted retry keeps the same frozen floor (not today-recomputed)
+        and increments attempts."""
+        today = datetime.now(UTC).date()
+        frozen_floor = today - timedelta(days=25)
+        coord, _, _, _ = await self._run(
+            hass,
+            preset={
+                "state": SOLAR_HEAL_PENDING,
+                "floor": frozen_floor.isoformat(),
+                "attempts": 1,
+            },
+            fetch_complete=False,
         )
-        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_DONE
+        heal = self._heal(coord)
+        assert heal["state"] == SOLAR_HEAL_PENDING
+        assert heal["floor"] == frozen_floor.isoformat()  # unchanged
+        assert heal["attempts"] == 2
+
+    async def test_gives_up_after_max_attempts(self, hass: HomeAssistant) -> None:
+        """A permanently-erroring day can't wedge the heal: after
+        MAX_SOLAR_HEAL_ATTEMPTS incomplete sweeps it gives up to DONE (Codex P3)."""
+        today = datetime.now(UTC).date()
+        frozen_floor = today - timedelta(days=25)
+        coord, _, _, _ = await self._run(
+            hass,
+            preset={
+                "state": SOLAR_HEAL_PENDING,
+                "floor": frozen_floor.isoformat(),
+                "attempts": MAX_SOLAR_HEAL_ATTEMPTS - 1,
+            },
+            fetch_complete=False,
+        )
+        assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
 
     async def test_done_never_rearms(self, hass: HomeAssistant) -> None:
         """Once DONE, a still-present leading gap (needs_heal True) is NOT
@@ -2143,11 +2193,11 @@ class TestGenerationHealState:
         re-bursting a 30-day fetch every poll."""
         today = datetime.now(UTC).date()
         coord, mock_range, _, _ = await self._run(
-            hass, preset=SOLAR_HEAL_DONE, needs_heal=True
+            hass, preset={"state": SOLAR_HEAL_DONE}, needs_heal=True
         )
         # Not the heal window: a normal trailing chunk, never starting at floor.
         assert mock_range.call_args[0][1][0] != today - timedelta(days=BACKFILL_DAYS)
-        assert coord.config_entry.data.get(CONF_SOLAR_HEAL_STATE) == SOLAR_HEAL_DONE
+        assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
 
     async def test_period_totals_suppressed_during_heal(
         self, hass: HomeAssistant
@@ -2163,6 +2213,40 @@ class TestGenerationHealState:
     async def test_period_totals_reported_when_not_healing(
         self, hass: HomeAssistant
     ) -> None:
-        _, _, _, data = await self._run(hass, preset=SOLAR_HEAL_DONE, needs_heal=True)
+        _, _, _, data = await self._run(
+            hass, preset={"state": SOLAR_HEAL_DONE}, needs_heal=True
+        )
         assert data.generation_period_kwh == 4.0
         assert data.generation_period_credit_aud == 1.0
+
+    async def test_fetch_range_incomplete_when_solar_day_skipped(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A skipped solar day (transient AGL error → None) makes _fetch_range
+        report incomplete, so a heal retries it instead of declaring DONE with a
+        hole (Codex P1)."""
+        coord = _make_coordinator(hass)
+        day = datetime.now(UTC).date() - timedelta(days=10)
+        with (
+            patch.object(
+                coord, "_fetch_day_solar", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(coord, "_import_generation", new_callable=AsyncMock),
+        ):
+            complete = await coord._fetch_range(None, (day, day), None)
+        assert complete is False
+
+    async def test_fetch_range_complete_when_solar_day_ok(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A cleanly-fetched (even empty) solar day reports complete."""
+        coord = _make_coordinator(hass)
+        day = datetime.now(UTC).date() - timedelta(days=10)
+        with (
+            patch.object(
+                coord, "_fetch_day_solar", new_callable=AsyncMock, return_value=[]
+            ),
+            patch.object(coord, "_import_generation", new_callable=AsyncMock),
+        ):
+            complete = await coord._fetch_range(None, (day, day), None)
+        assert complete is True


### PR DESCRIPTION
## Summary

Heals a **leading hole** in the solar generation statistics for contracts upgraded through beta.1 (#128 round 3).

**Root cause** (confirmed via a 4-way adversarial review of the tester's captures + git archaeology): beta.1 computed one fetch range from the *consumption* resume point, so on a caught-up install the generation series imported only the trailing `REWINDOW_DAYS` — it was born starting ~`today-7` (≈ 28 June for the reporter) with nothing before it. beta.2's per-series fix keys `_resolve_fetch_start` off the series' **last** row, so it's structurally blind to a leading hole and never revisits those older days. For the reporter this permanently stranded **24–27 June (~27 kWh)**, making *Solar sold this period* read 39.75 kWh vs the app's 67 (39.75 + 27.34 = 67.09).

It is **not** an endpoint bug (the `Previous/Hourly` theory was refuted — 24–27 June are on/after `bill_start`, so they'd be `Current/Hourly`), and **not** a field-mapping bug (the hourly `feedIn` outer mapping is capture-reconciled and untouched here). A daily-endpoint rewrite was considered and rejected: the daily response lags the app by 1–2 days (metered-to-date, not period total), uses fake-`Z` local-date timestamps, and mixing daily rows into the hourly series would irreversibly corrupt existing installs.

## Fix

- **`_generation_needs_heal()`** — stateless detector (no persisted flag), two triggers:
  1. **Leading hole** — earliest stored row more than a day past the backfill floor.
  2. **Broken chain** — a downward step in the cumulative sum (what an interrupted heal leaves). This is what makes the re-import **429-safe**: an interrupted heal is re-detected and finished next cycle.
- When a heal is needed, `solar_range` becomes the full `(backfill_floor, yesterday)` window — uncapped by the 7-day chunk — so `_import_generation` re-imports it in one contiguous batch and `_emit_series` recomputes the whole cumulative chain from a correct baseline. A partial fill would strand later rows on their old baseline and step the sum down (#114 class), so the contiguous re-import is essential.

**Scope:** solar-only; consumption path untouched. Fresh installs and flat/ToU/non-solar contracts never enter the heal path (guarded by `last_gen_date is not None` + the detector). The `#116` earliest-fetched-hour baseline and `#114` monotonicity invariants are preserved.

## Tests

`tests/test_coordinator_statistics.py::TestGenerationHeal` (6 cases): leading-hole detected, contiguous-from-floor no-heal, downward-step detected, empty-series no-heal, heal → full-window re-import, healthy → normal chunked range. Full suite: **177 passed**, ruff + mypy clean.

## Docs

- `CHANGELOG.md` → `## [Unreleased]` → Fixed.

## Notes

- Does **not** close #128 — leave open until it reconciles on the reporter's install after beta.3 ships.
- Ship target: **v0.4.0-beta.3**, gating stable 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
