### PR TITLE
fix: coordinator resilience batch — #151 #152 #153 #154 #155

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,7 @@ trying to fold everything into the current PR.
 | Daily series | 6 h | Picks up newly available days |
 | Plan / overview | 7 days | Rarely changes |
 | Token refresh | Just-in-time (< 2 min to `exp`) | tokens expire at 15 min |
+| **After a FAILED poll** | 30 min (`RETRY_INTERVAL_ON_ERROR`) | #155: a transient error previously cost a full 24 h and looked like "the poll never ran" (#126). Restored to 24 h on the next success; auth failures go to reauth, not fast retry |
 
 **Do not poll for today's hourly data** — it will be empty. Fetch *yesterday*.
 
@@ -388,10 +389,25 @@ and each item carries **both** a `consumption` block and a shape-identical
   P1). After `MAX_SOLAR_HEAL_ATTEMPTS` incomplete sweeps it gives up to
   `SOLAR_HEAL_DONE` so a permanently-erroring old day can't wedge the heal or
   re-sweep every poll (Codex P3; matches `_fetch_day_solar`'s accepted rare-hole
-  tradeoff). Once `SOLAR_HEAL_DONE` it **never re-arms**. Bill-period solar
-  totals are suppressed for a heal cycle (the rewritten pre-`bill_start` rows are
-  still queued, so a live baseline read would transiently over-count). Written
-  like the rotated refresh token — no reload listener fires.
+  tradeoff). Once `SOLAR_HEAL_DONE` the **leading-hole trigger never re-arms**;
+  a **broken chain** (downward sum step frozen by a 429 on the give-up sweep)
+  detected after done arms ONE bounded repair generation — fresh attempt
+  budget, `repair: true` in the record, never re-arms once marked, lifetime
+  sweeps hard-capped at 2x `MAX_SOLAR_HEAL_ATTEMPTS` (#153). Bill-period solar
+  totals during a heal cycle: a COMPLETE sweep drains the recorder queue
+  (`_recorder_drained`, bounded by `RECORDER_DRAIN_TIMEOUT`) and publishes the
+  healed number the same cycle (#152); an incomplete sweep or drain timeout
+  stays suppressed — a wrong number is worse than a blank one. Attempt
+  accounting is exception-proof: `_fetch_with_heal_accounting` persists an
+  attempt on ANY sweep exit (#151), and `AglClient` wraps transport/parse
+  failures into `AGLError` so nothing escapes the family the catch sites
+  expect. Written like the rotated refresh token — no reload listener fires.
+- **Normal-path backfill give-up** (#154): a chunk where every attempted solar
+  day errors (no 429 involved) counts toward `_track_solar_stall`; after
+  `SOLAR_STALL_GIVE_UP_CYCLES` consecutive zero-progress cycles on the SAME
+  chunk, zero-delta markers advance the resume past the span (WARNING logged).
+  In-memory counter — restart resets it (conservative). Rate-limited sweeps
+  and heal sweeps are excluded by design.
 - The beta.1 "numbers don't match" report (#128) was a **window artifact** —
   a cumulative-since-backfill sensor compared against the app's
   billing-period tile — not a field bug. When validating against the app,
@@ -642,6 +658,20 @@ The HA Energy dashboard requires:
   forever. The persisted heal is therefore a record `{state, floor, attempts}`,
   not a bare state string. First pass: Codex P1/P2/P3; second pass: the
   floor-slide and skipped-day P2s — all on PR #150.
+- **Don't let non-`AGLError` exception types escape `AglClient`.** Every
+  coordinator catch site (`except AGLError`, the heal's attempt accounting,
+  the failure-retry interval) is designed around the AGLError family. An
+  unwrapped `aiohttp.ClientError`, `TimeoutError`, or `JSONDecodeError` from a
+  200 non-JSON body (Akamai challenge page) crashes the whole cycle *before*
+  any of that machinery runs — the red-team trace showed a deterministic one
+  on an old heal-window day wedging an unbounded 30-day sweep every cycle,
+  integration unavailable throughout (#151). `AglClient._get` and
+  `async_force_refresh` wrap transport/parse failures into `AGLError` (a
+  network blip during token refresh must be retryable `AGLError`, never
+  `AGLAuthError` — it is not an auth failure and must not trigger reauth).
+  When adding a new client method, route it through `_get` or replicate the
+  shield; `_fetch_with_heal_accounting` is the belt-and-braces layer that
+  counts an attempt on ANY sweep exit regardless.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   makes a #128-class leading hole visible at a glance. Versioned by
   `schema_version` (see `docs/diagnostics.md`); the bug-report form now asks
   for the file.
+- **Faster recovery from failed polls** (#155): a poll that fails with a
+  transient AGL error now retries after 30 minutes instead of silently
+  waiting a full 24 h (which looked exactly like "the poll never ran",
+  #126). The 24 h cadence restores on the next success; auth failures still
+  hand over to the reauth flow untouched.
+- **Bounded give-up for stalled backfill chunks** (#154): a contiguous span
+  of permanently-erroring solar days no longer refetches the identical
+  chunk forever — after 3 consecutive zero-progress cycles the span is
+  marked as covered (with a WARNING) so the backfill moves on. Rate-limited
+  sweeps never count toward the give-up.
+
+### Fixed
+
+- **AGL client transport shield** (#151): network errors, timeouts, and a
+  200 response with a non-JSON body (e.g. a bot-protection challenge page)
+  now surface as retryable `AGLError` instead of crashing the whole update
+  cycle. Previously a deterministic transport failure on an old
+  heal-window day could re-fire an unbounded 30-day sweep every cycle with
+  the integration unavailable throughout — the heal's give-up cap never
+  engaged because the crash bypassed its attempt accounting. Belt-and-
+  braces: a heal attempt is now counted on *any* sweep exit, even for
+  exception types the client fails to wrap. A network blip during token
+  refresh is likewise retryable and no longer masquerades as an auth
+  failure.
+- **Period solar sensors no longer go blank during the one-time heal**
+  (#152): a heal sweep that completes cleanly now waits for the recorder to
+  commit the rewritten rows and then publishes *Solar sold this period* /
+  *feed-in credit this period* the same cycle — no more 1–3 days of
+  `unknown` after upgrading. Incomplete sweeps (rate-limited or skipped
+  days) stay suppressed: a wrong number is worse than a blank one.
+- **Broken-chain repair survives heal give-up** (#153): a downward
+  cumulative-sum step frozen by a rate limit on the heal's final attempt is
+  now detected after the heal is done and repaired by one bounded repair
+  generation (fresh attempt budget, marked `repair` so it can never loop).
+  Lifetime sweeps are hard-capped either way.
 
 ### Security
 

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -74,6 +74,17 @@ class AGLError(Exception):
     """Base class for AGL API errors."""
 
 
+class AGLTransportError(AGLError):
+    """Below-HTTP failure: network error, timeout, or non-JSON body.
+
+    Distinct from a plain AGLError so per-day backfill fetchers can HALT the
+    chunk (transport failures are endpoint-wide and transient — retrying the
+    whole chunk next cycle is right) instead of SKIPPING the day, which would
+    advance the resume point past it and leave a permanent hole (Codex on
+    #157). Still an AGLError, so every existing catch site behaves.
+    """
+
+
 class AGLAuthError(AGLError):
     """Auth failure — refresh token invalid / revoked; reauth required."""
 
@@ -174,11 +185,11 @@ class AglAuth:
             # A network blip is NOT an auth failure — wrap as retryable
             # AGLError, never AGLAuthError (which triggers the reauth flow)
             # and never a raw escape (which crashes the cycle, #151).
-            raise AGLError(
+            raise AGLTransportError(
                 f"transport error during token refresh: {type(err).__name__}"
             ) from err
         except json.JSONDecodeError as err:
-            raise AGLError("non-JSON response from token endpoint") from err
+            raise AGLTransportError("non-JSON response from token endpoint") from err
 
         error = data.get("error")
         if error:
@@ -250,10 +261,10 @@ class AglClient:
         try:
             return await self._get_raw(url)
         except _TRANSPORT_ERRORS as err:
-            raise AGLError(f"transport error: {type(err).__name__}") from err
+            raise AGLTransportError(f"transport error: {type(err).__name__}") from err
         except json.JSONDecodeError as err:
             # Body may be an Akamai/HTML page; never surface it (#151).
-            raise AGLError("non-JSON response from AGL endpoint") from err
+            raise AGLTransportError("non-JSON response from AGL endpoint") from err
 
     async def _get_raw(self, url: str) -> Any:
         token = await self._auth.async_ensure_valid_token(self._session)

--- a/custom_components/haggle/agl/client.py
+++ b/custom_components/haggle/agl/client.py
@@ -25,6 +25,8 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
+
 from ..const import (
     AGL_ACCEPT_FEATURES,
     AGL_AUTH0_CLIENT,
@@ -53,9 +55,14 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from datetime import date
 
-    import aiohttp
-
 _LOGGER = logging.getLogger(__name__)
+
+# Failures below the HTTP-status layer. Every coordinator catch site is
+# designed around the AGLError family; letting these escape raw crashes the
+# whole update cycle BEFORE the solar heal's attempt accounting runs, which
+# can wedge a pending heal in an unbounded uncounted retry loop (#151).
+# TimeoutError covers asyncio.TimeoutError (alias since Python 3.11).
+_TRANSPORT_ERRORS = (TimeoutError, aiohttp.ClientError)
 
 # Refresh when this many seconds remain before expiry.
 _REFRESH_MARGIN_SECONDS = 120
@@ -149,18 +156,29 @@ class AglAuth:
             "refresh_token": self._refresh_token,
         }
 
-        async with session.post(TOKEN_ENDPOINT, json=body, headers=headers) as resp:
-            if resp.status == 401:
-                raise AGLAuthError("Token refresh rejected (401) — reauth required")
-            if resp.status != 200:
-                # Auth0 error bodies can include diagnostic fields (mfa_token,
-                # error_description, internal trace IDs); keep them out of the
-                # exception that propagates to ConfigEntryAuthFailed → HA
-                # Persistent Notifications. Body lives in DEBUG only.
-                text = await resp.text()
-                _LOGGER.debug("Token refresh non-200 body: %s", text[:200])
-                raise AGLAuthError(f"Token refresh failed HTTP {resp.status}")
-            data: dict[str, Any] = await resp.json(content_type=None)
+        try:
+            async with session.post(TOKEN_ENDPOINT, json=body, headers=headers) as resp:
+                if resp.status == 401:
+                    raise AGLAuthError("Token refresh rejected (401) — reauth required")
+                if resp.status != 200:
+                    # Auth0 error bodies can include diagnostic fields
+                    # (mfa_token, error_description, internal trace IDs); keep
+                    # them out of the exception that propagates to
+                    # ConfigEntryAuthFailed → HA Persistent Notifications.
+                    # Body lives in DEBUG only.
+                    text = await resp.text()
+                    _LOGGER.debug("Token refresh non-200 body: %s", text[:200])
+                    raise AGLAuthError(f"Token refresh failed HTTP {resp.status}")
+                data: dict[str, Any] = await resp.json(content_type=None)
+        except _TRANSPORT_ERRORS as err:
+            # A network blip is NOT an auth failure — wrap as retryable
+            # AGLError, never AGLAuthError (which triggers the reauth flow)
+            # and never a raw escape (which crashes the cycle, #151).
+            raise AGLError(
+                f"transport error during token refresh: {type(err).__name__}"
+            ) from err
+        except json.JSONDecodeError as err:
+            raise AGLError("non-JSON response from token endpoint") from err
 
         error = data.get("error")
         if error:
@@ -221,7 +239,23 @@ class AglClient:
         }
 
     async def _get(self, url: str) -> Any:
-        """GET a URL with auth, retrying once on 401."""
+        """GET a URL with auth, retrying once on 401.
+
+        Transport- and parse-level failures (network errors, timeouts, a 200
+        with a non-JSON body such as an Akamai challenge page) are wrapped
+        into AGLError so callers see the one exception family every catch
+        site was designed around (#151). Typed AGL errors pass through
+        unchanged.
+        """
+        try:
+            return await self._get_raw(url)
+        except _TRANSPORT_ERRORS as err:
+            raise AGLError(f"transport error: {type(err).__name__}") from err
+        except json.JSONDecodeError as err:
+            # Body may be an Akamai/HTML page; never surface it (#151).
+            raise AGLError("non-JSON response from AGL endpoint") from err
+
+    async def _get_raw(self, url: str) -> Any:
         token = await self._auth.async_ensure_valid_token(self._session)
         headers = {**self._default_headers, "Authorization": f"Bearer {token}"}
 

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -33,6 +33,13 @@ SCAN_INTERVAL_HOURLY: Final = timedelta(hours=24)  # 30-min intervals: fetch yes
 # ran" (#126). Restored to SCAN_INTERVAL_HOURLY on the next success; polling
 # faster than 24 h on success buys nothing (AGL data lags 24-48 h).
 RETRY_INTERVAL_ON_ERROR: Final = timedelta(minutes=30)
+# Normal-path backfill give-up (#154): after this many consecutive cycles in
+# which the SAME solar chunk made zero progress (every attempted day errored,
+# no 429 involved), write zero-delta marker rows past the span so the resume
+# point advances — mirroring the accepted rare-hole tradeoff for single days.
+# In-memory counter; an HA restart resets it (conservative: more retries,
+# never fewer).
+SOLAR_STALL_GIVE_UP_CYCLES: Final = 3
 
 # Number of days of history to backfill on first install.
 BACKFILL_DAYS: Final = 30

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -28,6 +28,11 @@ AGL_OAUTH_AUDIENCE: Final = "https://api.platform.agl.com.au/"
 # Polling cadence.
 # AGL interval data is delayed 24-48 h from the meter (AEMO feed lag).
 SCAN_INTERVAL_HOURLY: Final = timedelta(hours=24)  # 30-min intervals: fetch yesterday
+# Retry cadence after a FAILED poll (#155). A transient AGL error at poll time
+# previously cost a full 24 h of data — indistinguishable from "the poll never
+# ran" (#126). Restored to SCAN_INTERVAL_HOURLY on the next success; polling
+# faster than 24 h on success buys nothing (AGL data lags 24-48 h).
+RETRY_INTERVAL_ON_ERROR: Final = timedelta(minutes=30)
 
 # Number of days of history to backfill on first install.
 BACKFILL_DAYS: Final = 30

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -42,6 +42,10 @@ BACKFILL_INTER_REQUEST_DELAY: Final = 0.5
 # async_add_external_statistics is idempotent on (statistic_id, start), so
 # this is a safe overwrite.
 REWINDOW_DAYS: Final = 7
+# Max seconds to wait for the recorder to commit queued statistics after a
+# COMPLETE heal sweep before reading the bill-period baseline (#152). On
+# timeout the period sensors stay `unknown` for the cycle (safe fallback).
+RECORDER_DRAIN_TIMEOUT: Final = 30.0
 
 # AGL BFF requires these headers on Hourly/Daily usage endpoints (HTTP 500 without them).
 # Documented from AGL mobile app 8.38.0-531 — 2026-05-01.

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -548,28 +548,54 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         P2, pass 3) so an HA restart mid-heal resumes the same window instead of
         recomputing it from a later `today` and dropping the oldest day — and
         re-read from the pending record on every retry. The heal stays pending —
-        retrying — until a sweep completes with no skipped day, then goes done and
-        never re-arms.
+        retrying — until a sweep completes with no skipped day, then goes done.
+
+        After done, the LEADING-HOLE trigger never re-arms (a permanently
+        unfetchable gap must not re-sweep every poll), but a BROKEN CHAIN —
+        the downward step a 429 on the give-up sweep can freeze — re-arms ONE
+        bounded repair generation (#153): a fresh MAX_SOLAR_HEAL_ATTEMPTS
+        budget marked `repair: true` in the record. A record that already
+        carries the repair mark never re-arms again, so total lifetime sweeps
+        are hard-capped at 2x MAX_SOLAR_HEAL_ATTEMPTS.
         """
         heal = self.config_entry.data.get(CONF_SOLAR_HEAL) or {}
         state = heal.get("state")
-        if state != SOLAR_HEAL_DONE and last_gen_date is not None:
+        if last_gen_date is not None:
             if state == SOLAR_HEAL_PENDING:
                 floor = date.fromisoformat(heal["floor"])  # frozen at heal start
                 return (floor, yesterday), (floor, int(heal.get("attempts", 0)))
             floor = today - timedelta(days=BACKFILL_DAYS)
-            if await self._generation_needs_heal(stat_id_gen, floor, today):
-                # Freeze the floor NOW, before the multi-second fetch, so a
-                # restart mid-heal survives with the window intact. A resume
-                # cycle already has this record, so this is a no-op then.
-                self._write_solar_heal(
-                    {
-                        "state": SOLAR_HEAL_PENDING,
-                        "floor": floor.isoformat(),
-                        "attempts": 0,
-                    }
+            if state != SOLAR_HEAL_DONE:
+                if await self._generation_needs_heal(stat_id_gen, floor, today):
+                    # Freeze the floor NOW, before the multi-second fetch, so a
+                    # restart mid-heal survives with the window intact. A resume
+                    # cycle already has this record, so this is a no-op then.
+                    self._write_solar_heal(
+                        {
+                            "state": SOLAR_HEAL_PENDING,
+                            "floor": floor.isoformat(),
+                            "attempts": 0,
+                        }
+                    )
+                    return (floor, yesterday), (floor, 0)
+            elif not heal.get("repair"):
+                _, broken = await self._generation_heal_triggers(
+                    stat_id_gen, floor, today
                 )
-                return (floor, yesterday), (floor, 0)
+                if broken:
+                    _LOGGER.warning(
+                        "Generation sum chain broken after heal completion; "
+                        "arming one bounded repair generation (#153)"
+                    )
+                    self._write_solar_heal(
+                        {
+                            "state": SOLAR_HEAL_PENDING,
+                            "floor": floor.isoformat(),
+                            "attempts": 0,
+                            "repair": True,
+                        }
+                    )
+                    return (floor, yesterday), (floor, 0)
         normal = self._chunked_range(
             self._resolve_fetch_start(today, last_gen_date), yesterday
         )
@@ -643,15 +669,29 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         the rotated refresh token — no reload listener fires.
         """
         floor, attempts = heal_ctx
+        # The one-shot repair mark must survive every transition, or a broken
+        # chain could re-arm repair generations forever (#153).
+        repairing = bool(
+            (self.config_entry.data.get(CONF_SOLAR_HEAL) or {}).get("repair")
+        )
         new: dict[str, object]
         if complete:
             new = {"state": SOLAR_HEAL_DONE}
         elif attempts + 1 >= MAX_SOLAR_HEAL_ATTEMPTS:
-            _LOGGER.warning(
-                "Solar heal gave up after %d attempts; some pre-rewindow days may "
-                "remain unfetched (persistent AGL error on old solar dates)",
-                attempts + 1,
-            )
+            if repairing:
+                _LOGGER.error(
+                    "Solar chain repair gave up after %d attempts — a downward "
+                    "step may persist in the generation statistics; manual "
+                    "repair via Developer Tools → Statistics if it matters",
+                    attempts + 1,
+                )
+            else:
+                _LOGGER.warning(
+                    "Solar heal gave up after %d attempts; some pre-rewindow "
+                    "days may remain unfetched (persistent AGL error on old "
+                    "solar dates)",
+                    attempts + 1,
+                )
             new = {"state": SOLAR_HEAL_DONE}
         else:
             new = {
@@ -659,6 +699,8 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 "floor": floor.isoformat(),
                 "attempts": attempts + 1,
             }
+        if repairing:
+            new["repair"] = True
         self._write_solar_heal(new)
 
     def _write_solar_heal(self, record: dict[str, object]) -> None:
@@ -675,25 +717,40 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     ) -> bool:
         """True if the generation series must be re-imported from the floor.
 
-        Two stateless triggers, both re-derived from the recorder each cycle so
-        no heal-progress flag has to be persisted:
+        Starts the one-time heal only — retry, completion, and termination are
+        owned by the persisted `solar_heal` record, not this detector (Codex
+        docstring correction, 2026-07-08). Either trigger arms it; see
+        _generation_heal_triggers for the two failure geometries.
+        """
+        leading, broken = await self._generation_heal_triggers(
+            stat_id_gen, floor, today
+        )
+        return leading or broken
 
-        1. LEADING HOLE — the earliest stored generation hour sits well after
-           the backfill floor. A series backfilled from the floor carries a row
-           (a real read, or a zero-export marker) at every day since the floor,
-           so its first row is at/near the floor. A series seeded only from the
-           trailing rewindow (the beta.1 upgrade artifact, #128) starts ~today-7
-           with nothing before it; _resolve_fetch_start keys off the LAST row
-           and never revisits those older days, stranding them permanently.
+    async def _generation_heal_triggers(
+        self, stat_id_gen: str, floor: date, today: date
+    ) -> tuple[bool, bool]:
+        """Return (leading_hole, chain_broken) for the generation series.
 
-        2. BROKEN CHAIN — a downward step in the cumulative sum. A heal
-           interrupted mid-way (AGL 429) re-imports a contiguous prefix but
-           leaves the later rows on their old baseline, stepping the sum down at
-           the frontier. Re-detecting that step re-triggers the heal next cycle
-           so it completes — this is what makes the uncapped re-import 429-safe.
+        LEADING HOLE — the earliest stored generation hour sits well after the
+        backfill floor. A series backfilled from the floor carries a row (a
+        real read, or a zero-export marker) at every day since the floor, so
+        its first row is at/near the floor. A series seeded only from the
+        trailing rewindow (the beta.1 upgrade artifact, #128) starts ~today-7
+        with nothing before it; _resolve_fetch_start keys off the LAST row and
+        never revisits those older days, stranding them permanently. This
+        trigger is disarmed for good once the heal record is done — a
+        permanently unfetchable leading gap must not re-sweep every poll.
 
-        A series with no rows in the window (fresh install) never heals; normal
-        backfill from the floor handles it.
+        CHAIN BROKEN — a downward step in the cumulative sum, what a heal
+        sweep interrupted mid-import leaves behind (#114 class). Checked
+        separately because it must survive the done state (#153): a 429
+        landing on the give-up sweep can freeze a step that the leading-hole
+        logic never revisits. The repair it arms is bounded — see
+        _plan_solar_fetch.
+
+        A series with no rows in the window (fresh install) triggers neither;
+        normal backfill from the floor handles it.
         """
         from homeassistant.components.recorder.statistics import (
             statistics_during_period,
@@ -714,18 +771,19 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         rows = result.get(stat_id_gen) or []
         if not rows:
-            return False
+            return False, False
 
         # Leading hole: earliest stored hour is more than a day past the floor.
         # One day of slack absorbs the local-midnight-vs-UTC offset (a local day
         # begins on the previous UTC date in a positive-offset zone).
+        leading = False
         first_start = rows[0].get("start")
         if first_start is not None:
             first_date = datetime.fromtimestamp(float(first_start), tz=UTC).date()
-            if first_date > floor + timedelta(days=1):
-                return True
+            leading = first_date > floor + timedelta(days=1)
 
         # Broken chain: any downward step in the cumulative sum.
+        broken = False
         prev: float | None = None
         for row in rows:
             raw = row.get("sum")
@@ -733,9 +791,10 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 continue
             s = float(raw)
             if prev is not None and s < prev - 1e-6:
-                return True
+                broken = True
+                break
             prev = s
-        return False
+        return leading, broken
 
     async def _get_stored_tou_bands(self) -> set[str]:
         """Return the ToU bands (peak/offpeak/shoulder) that already have stats.

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -36,7 +36,12 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 
-from .agl.client import AGLAuthError, AGLError, AGLRateLimitError
+from .agl.client import (
+    AGLAuthError,
+    AGLError,
+    AGLRateLimitError,
+    AGLTransportError,
+)
 from .const import (
     BACKFILL_CHUNK_DAYS,
     BACKFILL_DAYS,
@@ -270,8 +275,18 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # per-tariff baseline sums themselves are resolved in _import_intervals.
         self._active_tou_bands |= await self._get_stored_tou_bands()
 
+        # Stall tracking (#154) only for chunks strictly BEYOND the last
+        # stored generation day: the trailing rewindow deliberately overlaps
+        # existing rows, and give-up markers written over real data would
+        # corrupt the cumulative chain (Codex on #157). Heal sweeps have
+        # their own attempt accounting.
+        track_stall = (
+            heal_ctx is None
+            and solar_range is not None
+            and (last_gen_date is None or solar_range[0] > last_gen_date)
+        )
         fetch_complete = await self._fetch_with_heal_accounting(
-            cons_range, solar_range, bill_start, heal_ctx
+            cons_range, solar_range, bill_start, heal_ctx, track_stall=track_stall
         )
 
         # Extract rates from plan.
@@ -654,6 +669,8 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         solar_range: tuple[date, date] | None,
         bill_start: date | None,
         heal_ctx: tuple[date, int] | None,
+        *,
+        track_stall: bool = False,
     ) -> bool:
         """Run the fetch, guaranteeing heal attempts are counted on ANY exit.
 
@@ -673,8 +690,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 solar_range,
                 bill_start,
                 known_bands=frozenset(self._active_tou_bands),
-                track_stall=heal_ctx is None,
+                track_stall=track_stall,
             )
+        except asyncio.CancelledError:
+            # HA unload/restart mid-sweep is not an AGL failure — the frozen
+            # floor is already persisted, so the heal simply resumes on the
+            # next start. Counting it would let a few quick restarts exhaust
+            # the attempt budget with zero fetch failures (Codex on #157).
+            raise
         except BaseException:
             if heal_ctx is not None:
                 self._persist_solar_heal(heal_ctx, complete=False)
@@ -963,13 +986,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 status = await self._fetch_solar_day_into(
                     current, previous, solar_intervals, fetched_solar_days
                 )
-                if status == "ratelimit":
+                if status == "halt":
+                    # 429 or transport failure — endpoint-wide, not per-day;
+                    # halt and retry the whole chunk next cycle.
                     rate_limited = True
                 elif status == "skip":
-                    # Transient AGL error on this solar day: unmarked, and the
-                    # sweep is flagged incomplete so a heal retries it rather than
-                    # declaring done with a hole. On normal cycles the return is
-                    # ignored and the trailing rewindow re-fetches it next cycle.
+                    # Per-day AGL HTTP error on this solar day: unmarked, and
+                    # the sweep is flagged incomplete so a heal retries it
+                    # rather than declaring done with a hole. On normal cycles
+                    # the return is ignored and the trailing rewindow
+                    # re-fetches it next cycle.
                     solar_skipped = True
             current += timedelta(days=1)
 
@@ -1044,8 +1070,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     ) -> list[IntervalReading] | None:
         """Fetch one day of consumption intervals.
 
-        Returns [] on a skippable AGLError (logged, the loop continues) and
-        None on AGLRateLimitError so the caller halts the chunk.
+        Returns [] on a skippable AGL HTTP error (logged, the loop continues)
+        and None on AGLRateLimitError OR AGLTransportError so the caller halts
+        the chunk. Transport failures (network blip, timeout, challenge page)
+        are endpoint-wide and transient — skipping the day would advance the
+        resume point past it and leave a permanent hole (Codex on #157);
+        halting retries the whole chunk next cycle instead. The skip tradeoff
+        stays for genuine per-day HTTP errors (AGL permanently 500s very old
+        dates — #34).
         """
         try:
             if previous:
@@ -1056,6 +1088,11 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         except AGLRateLimitError as err:
             _LOGGER.warning(
                 "AGL rate-limited at %s; halting backfill chunk: %s", day, err
+            )
+            return None
+        except AGLTransportError as err:
+            _LOGGER.warning(
+                "Transport failure at %s; halting backfill chunk: %s", day, err
             )
             return None
         except AGLError as err:
@@ -1076,13 +1113,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         errored day would let a permanently-500ing old day (AGL does this on
         very old dates) stall the backfill and the period sensors forever,
         which is worse than a rare one-day historical hole.
-        AGLRateLimitError propagates so the caller halts the whole chunk.
+        AGLRateLimitError and AGLTransportError propagate so the caller halts
+        the whole chunk — transport failures are endpoint-wide/transient, and
+        skipping the day would trade a retry for a permanent hole (Codex on
+        #157).
         """
         try:
             return await self.client.async_get_solar_hourly(
                 self.contract_number, day, previous=previous
             )
-        except AGLRateLimitError:
+        except (AGLRateLimitError, AGLTransportError):
             raise
         except AGLError as err:
             _LOGGER.debug("Solar fetch skip %s: %s", day, err)
@@ -1097,20 +1137,24 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
     ) -> str:
         """Fetch one solar day into the accumulators; classify the outcome.
 
-        Returns "ok" (day fetched, marked covered), "skip" (transient AGL error
-        — unmarked, sweep is incomplete), or "ratelimit" (429 — caller halts the
-        chunk). Only a *successful* fetch appends to `fetched_solar_days`, so a
+        Returns "ok" (day fetched, marked covered), "skip" (per-day AGL HTTP
+        error — unmarked, sweep is incomplete), or "halt" (429 or transport
+        failure — caller halts the chunk; the whole thing retries next cycle).
+        Only a *successful* fetch appends to `fetched_solar_days`, so a
         skipped day is retried while a heal is pending.
         """
         try:
             readings = await self._fetch_day_solar(day, previous)
-        except AGLRateLimitError as err:
+        except (AGLRateLimitError, AGLTransportError) as err:
             _LOGGER.warning(
-                "AGL rate-limited at %s (solar); halting backfill chunk: %s",
+                "AGL %s at %s (solar); halting backfill chunk: %s",
+                "rate limit"
+                if isinstance(err, AGLRateLimitError)
+                else "transport failure",
                 day,
                 err,
             )
-            return "ratelimit"
+            return "halt"
         if readings is None:
             return "skip"
         solar_intervals.extend(readings)

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_SOLAR_HEAL,
     DOMAIN,
     MAX_SOLAR_HEAL_ATTEMPTS,
+    RECORDER_DRAIN_TIMEOUT,
     REWINDOW_DAYS,
     SCAN_INTERVAL_HOURLY,
     SOLAR_HEAL_DONE,
@@ -244,17 +245,9 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # per-tariff baseline sums themselves are resolved in _import_intervals.
         self._active_tou_bands |= await self._get_stored_tou_bands()
 
-        fetch_complete = True
-        if cons_range or solar_range:
-            fetch_complete = await self._fetch_range(
-                cons_range,
-                solar_range,
-                bill_start,
-                known_bands=frozenset(self._active_tou_bands),
-            )
-
-        if heal_ctx is not None:
-            self._persist_solar_heal(heal_ctx, fetch_complete)
+        fetch_complete = await self._fetch_with_heal_accounting(
+            cons_range, solar_range, bill_start, heal_ctx
+        )
 
         # Extract rates from plan.
         unit_rate_aud: float | None = None
@@ -278,14 +271,20 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         feed_in_rate_aud = feed_in_cents / 100.0 if feed_in_cents is not None else None
 
         # Bill-period solar totals — after the fetch so this cycle's rows are
-        # included in the in-memory latest sums. Suppressed (→ sensor `unknown`)
-        # during a heal cycle (Codex P2): the heal rewrites rows behind
-        # bill_start this cycle, so the baseline query could still read the old
-        # queued sum while _latest_generation_kwh already holds the rebuilt total
-        # — a one-cycle over-read. The next non-heal cycle reports correctly.
+        # included in the in-memory latest sums. On a heal cycle the rewritten
+        # pre-bill_start rows are still in the recorder's async write queue,
+        # so a live baseline read would over-count (Codex P2 on #150). Rather
+        # than blanking the sensors for the whole cycle, a COMPLETE sweep
+        # drains the queue first and then reads through the proven totals
+        # path (#152) — the sensors show the healed number the same cycle the
+        # heal finishes. Incomplete sweep or drain timeout → stay suppressed
+        # (`unknown`); a wrong number is worse than a blank one here.
         generation_period_kwh: float | None = None
         generation_period_credit: float | None = None
-        if self._has_solar and heal_ctx is None:
+        publish_period = heal_ctx is None or (
+            fetch_complete and await self._recorder_drained()
+        )
+        if self._has_solar and publish_period:
             (
                 generation_period_kwh,
                 generation_period_credit,
@@ -575,6 +574,62 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             self._resolve_fetch_start(today, last_gen_date), yesterday
         )
         return normal, None
+
+    async def _recorder_drained(self) -> bool:
+        """Await the recorder committing queued statistics, bounded (#152).
+
+        After a COMPLETE heal sweep the rewritten pre-bill_start rows are
+        still in the recorder's async write queue; reading the bill_start
+        baseline before they commit would over-read the period totals (the
+        Codex P2 race on #150). Draining lets the proven
+        _get_generation_period_totals path run against exact data on the same
+        cycle the heal finishes. Returns False on timeout or recorder error —
+        the caller keeps the suppression and the next normal cycle publishes.
+        """
+        from homeassistant.helpers.recorder import get_instance
+
+        try:
+            await asyncio.wait_for(
+                get_instance(self.hass).async_block_till_done(),
+                timeout=RECORDER_DRAIN_TIMEOUT,
+            )
+        except Exception:
+            return False
+        return True
+
+    async def _fetch_with_heal_accounting(
+        self,
+        cons_range: tuple[date, date] | None,
+        solar_range: tuple[date, date] | None,
+        bill_start: date | None,
+        heal_ctx: tuple[date, int] | None,
+    ) -> bool:
+        """Run the fetch, guaranteeing heal attempts are counted on ANY exit.
+
+        Belt-and-braces for #151: even an exception type the AGL client failed
+        to wrap must count a heal attempt — otherwise a deterministic raise on
+        an old heal-window day (a day only heal sweeps ever fetch) would
+        re-fire an unbounded, uncounted 30-day sweep every cycle forever, with
+        the whole integration unavailable throughout.
+        """
+        if not (cons_range or solar_range):
+            if heal_ctx is not None:
+                self._persist_solar_heal(heal_ctx, complete=True)
+            return True
+        try:
+            complete = await self._fetch_range(
+                cons_range,
+                solar_range,
+                bill_start,
+                known_bands=frozenset(self._active_tou_bands),
+            )
+        except BaseException:
+            if heal_ctx is not None:
+                self._persist_solar_heal(heal_ctx, complete=False)
+            raise
+        if heal_ctx is not None:
+            self._persist_solar_heal(heal_ctx, complete=complete)
+        return complete
 
     def _persist_solar_heal(self, heal_ctx: tuple[date, int], complete: bool) -> None:
         """Record heal progress in entry.data (Codex P1/P2/P3 on #150).

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -170,6 +170,10 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # (chunk-start-iso, zero-progress cycle count) for the normal-path
         # backfill give-up (#154). In-memory by design — see _track_solar_stall.
         self._solar_stall: tuple[str, int] | None = None
+        # True when the last sweep was HALTED mid-chunk (429/transport) —
+        # _async_update_data schedules the #155 fast retry off this instead of
+        # waiting a full day for the halted chunk (Codex on #157).
+        self._sweep_halted: bool = False
 
     def _tariff_stat_ids(self, tariff: str) -> tuple[str, str]:
         """Return (consumption_id, cost_id) for a per-tariff series."""
@@ -195,8 +199,13 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         RETRY_INTERVAL_ON_ERROR instead of silently waiting a full 24 h (a
         transient AGL error at poll time previously looked exactly like "the
         poll never ran" — #126). The 24 h cadence is restored on the next
-        success. ConfigEntryAuthFailed is left alone — the reauth flow owns
-        that path, and hammering a rejected token would not help.
+        clean success. ConfigEntryAuthFailed is left alone — the reauth flow
+        owns that path, and hammering a rejected token would not help.
+
+        A cycle whose backfill sweep was HALTED (429 or transport failure)
+        still returns data — the partial import is safe and the sensors keep
+        their values — but schedules the fast retry too, so the halted chunk
+        is re-fetched in 30 minutes rather than tomorrow (Codex on #157).
         """
         try:
             data = await self._fetch_and_import()
@@ -212,7 +221,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 )
                 self.update_interval = RETRY_INTERVAL_ON_ERROR
             raise UpdateFailed(str(err)) from err
-        if self.update_interval != SCAN_INTERVAL_HOURLY:
+        if self._sweep_halted:
+            if self.update_interval != RETRY_INTERVAL_ON_ERROR:
+                _LOGGER.info(
+                    "Backfill sweep halted mid-chunk; retrying in %s",
+                    RETRY_INTERVAL_ON_ERROR,
+                )
+                self.update_interval = RETRY_INTERVAL_ON_ERROR
+        elif self.update_interval != SCAN_INTERVAL_HOURLY:
             _LOGGER.info("Poll succeeded; restoring %s cadence", SCAN_INTERVAL_HOURLY)
             self.update_interval = SCAN_INTERVAL_HOURLY
         return data
@@ -791,12 +807,15 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         trigger is disarmed for good once the heal record is done — a
         permanently unfetchable leading gap must not re-sweep every poll.
 
-        CHAIN BROKEN — a downward step in the cumulative sum, what a heal
-        sweep interrupted mid-import leaves behind (#114 class). Checked
-        separately because it must survive the done state (#153): a 429
-        landing on the give-up sweep can freeze a step that the leading-hole
-        logic never revisits. The repair it arms is bounded — see
-        _plan_solar_fetch.
+        CHAIN BROKEN — a downward step in the cumulative sum of EITHER solar
+        series, what a heal sweep interrupted mid-import leaves behind (#114
+        class). The AUD credit chain is checked alongside kWh (Codex on #157):
+        the two accumulate independently, so differing feed-in rates across a
+        partial re-import can step credit down while kWh stays monotonic.
+        Checked separately from the leading hole because it must survive the
+        done state (#153): a 429 landing on the give-up sweep can freeze a
+        step that the leading-hole logic never revisits. The repair it arms
+        is bounded — see _plan_solar_fetch.
 
         A series with no rows in the window (fresh install) triggers neither;
         normal backfill from the floor handles it.
@@ -806,6 +825,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         )
         from homeassistant.helpers.recorder import get_instance
 
+        _, stat_id_credit = self._generation_stat_ids()
         floor_dt = dt_util.as_utc(dt_util.start_of_local_day(floor))
         now = datetime.now(UTC)
         result = await get_instance(self.hass).async_add_executor_job(
@@ -813,7 +833,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             self.hass,
             floor_dt,
             now,
-            {stat_id_gen},
+            {stat_id_gen, stat_id_credit},
             "hour",
             None,
             {"start", "sum"},
@@ -824,25 +844,28 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
 
         # Leading hole: earliest stored hour is more than a day past the floor.
         # One day of slack absorbs the local-midnight-vs-UTC offset (a local day
-        # begins on the previous UTC date in a positive-offset zone).
+        # begins on the previous UTC date in a positive-offset zone). Keyed off
+        # the kWh series only — credit rides along in the same import batches.
         leading = False
         first_start = rows[0].get("start")
         if first_start is not None:
             first_date = datetime.fromtimestamp(float(first_start), tz=UTC).date()
             leading = first_date > floor + timedelta(days=1)
 
-        # Broken chain: any downward step in the cumulative sum.
-        broken = False
-        prev: float | None = None
-        for row in rows:
-            raw = row.get("sum")
-            if raw is None:
-                continue
-            s = float(raw)
-            if prev is not None and s < prev - 1e-6:
-                broken = True
-                break
-            prev = s
+        # Broken chain: any downward step in EITHER cumulative sum.
+        def _has_step(series_rows: list[Any]) -> bool:
+            prev: float | None = None
+            for row in series_rows:
+                raw = row.get("sum")
+                if raw is None:
+                    continue
+                s = float(raw)
+                if prev is not None and s < prev - 1e-6:
+                    return True
+                prev = s
+            return False
+
+        broken = _has_step(rows) or _has_step(result.get(stat_id_credit) or [])
         return leading, broken
 
     async def _get_stored_tou_bands(self) -> set[str]:
@@ -952,6 +975,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         reconciled against a real bill.
         """
         ranges = [r for r in (cons_range, solar_range) if r is not None]
+        self._sweep_halted = False
         if not ranges:
             return True
         all_intervals: list[IntervalReading] = []
@@ -1019,6 +1043,11 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave the cumulative seeds as the caller set them — the
         # most recent stored cumulative remains the sensor value.
+        # Halted (429/transport) → _async_update_data schedules the #155 fast
+        # retry so the chunk is re-fetched in minutes, not tomorrow. Skips are
+        # NOT halts: per-day AGL HTTP errors are server-side and won't clear
+        # in 30 minutes — the rewindow/heal machinery owns those.
+        self._sweep_halted = rate_limited
         return not rate_limited and not solar_skipped
 
     async def _track_solar_stall(

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -50,6 +50,7 @@ from .const import (
     SCAN_INTERVAL_HOURLY,
     SOLAR_HEAL_DONE,
     SOLAR_HEAL_PENDING,
+    SOLAR_STALL_GIVE_UP_CYCLES,
     STAT_CONSUMPTION,
     STAT_COST,
     STAT_GENERATION,
@@ -161,6 +162,9 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # Last-seen bill period start — surfaced in diagnostics so period-vs-app
         # mismatch reports can be reasoned about without asking the user.
         self.last_bill_start: date | None = None
+        # (chunk-start-iso, zero-progress cycle count) for the normal-path
+        # backfill give-up (#154). In-memory by design — see _track_solar_stall.
+        self._solar_stall: tuple[str, int] | None = None
 
     def _tariff_stat_ids(self, tariff: str) -> tuple[str, str]:
         """Return (consumption_id, cost_id) for a per-tariff series."""
@@ -669,6 +673,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 solar_range,
                 bill_start,
                 known_bands=frozenset(self._active_tou_bands),
+                track_stall=heal_ctx is None,
             )
         except BaseException:
             if heal_ctx is not None:
@@ -896,6 +901,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         bill_start: date | None,
         *,
         known_bands: frozenset[str] = frozenset(),
+        track_stall: bool = False,
     ) -> bool:
         """Fetch per-series day ranges with smart endpoint selection, then import.
 
@@ -977,10 +983,61 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             await self._import_generation(
                 solar_intervals, fetched_days=fetched_solar_days
             )
+        # Normal-path give-up (#154): only non-heal, non-rate-limited sweeps
+        # count toward the stall detector — a 429 halts before days are even
+        # attempted, and heal sweeps have their own attempt accounting.
+        if track_stall and solar_range is not None and not rate_limited:
+            await self._track_solar_stall(
+                solar_range, bool(fetched_solar_days), solar_skipped
+            )
         # If no intervals were fetched (e.g. AGL had no data for the whole
         # range), leave the cumulative seeds as the caller set them — the
         # most recent stored cumulative remains the sensor value.
         return not rate_limited and not solar_skipped
+
+    async def _track_solar_stall(
+        self, solar_range: tuple[date, date], progressed: bool, skipped: bool
+    ) -> None:
+        """Give-up counter for a solar chunk stuck on permanently-erroring days.
+
+        Only a *successful* fetch marks a day as covered, so a contiguous span
+        of ≥ BACKFILL_CHUNK_DAYS permanently-erroring days at `resume+1..`
+        would refetch the identical chunk forever — the resume point never
+        moves and the bill-period sensors stay gated for good (#154; realistic
+        after HA has been offline past AGL's retention edge).
+
+        After SOLAR_STALL_GIVE_UP_CYCLES consecutive cycles of zero progress
+        on the SAME chunk, write zero-delta marker rows past the span (the
+        beta.2 marker mechanism) with a WARNING — the accepted rare-hole
+        tradeoff, now bounded. In-memory: a restart resets the count
+        (conservative — more retries, never fewer).
+        """
+        if progressed or not skipped:
+            self._solar_stall = None  # progress or clean sweep → reset
+            return
+        key = solar_range[0].isoformat()
+        count = (
+            self._solar_stall[1] + 1
+            if self._solar_stall and self._solar_stall[0] == key
+            else 1
+        )
+        if count < SOLAR_STALL_GIVE_UP_CYCLES:
+            self._solar_stall = (key, count)
+            return
+        span = [
+            solar_range[0] + timedelta(days=n)
+            for n in range((solar_range[1] - solar_range[0]).days + 1)
+        ]
+        _LOGGER.warning(
+            "Solar backfill made no progress on %s..%s for %d consecutive "
+            "cycles (persistent AGL errors); marking the span as covered so "
+            "the backfill can move on — those days remain a permanent hole",
+            span[0],
+            span[-1],
+            count,
+        )
+        await self._import_generation([], fetched_days=span)
+        self._solar_stall = None
 
     async def _fetch_day_consumption(
         self, day: date, previous: bool

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -45,6 +45,7 @@ from .const import (
     DOMAIN,
     MAX_SOLAR_HEAL_ATTEMPTS,
     RECORDER_DRAIN_TIMEOUT,
+    RETRY_INTERVAL_ON_ERROR,
     REWINDOW_DAYS,
     SCAN_INTERVAL_HOURLY,
     SOLAR_HEAL_DONE,
@@ -179,13 +180,33 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         """No-op: first-install backfill is handled incrementally in _fetch_and_import."""
 
     async def _async_update_data(self) -> HaggleData:
-        """Fetch yesterday's intervals, import statistics, return sensor data."""
+        """Fetch yesterday's intervals, import statistics, return sensor data.
+
+        Failure-aware cadence (#155): a failed poll retries after
+        RETRY_INTERVAL_ON_ERROR instead of silently waiting a full 24 h (a
+        transient AGL error at poll time previously looked exactly like "the
+        poll never ran" — #126). The 24 h cadence is restored on the next
+        success. ConfigEntryAuthFailed is left alone — the reauth flow owns
+        that path, and hammering a rejected token would not help.
+        """
         try:
-            return await self._fetch_and_import()
+            data = await self._fetch_and_import()
         except AGLAuthError as err:
             raise ConfigEntryAuthFailed(str(err)) from err
         except AGLError as err:
+            if self.update_interval != RETRY_INTERVAL_ON_ERROR:
+                _LOGGER.info(
+                    "Poll failed (%s); retrying in %s instead of %s",
+                    err,
+                    RETRY_INTERVAL_ON_ERROR,
+                    SCAN_INTERVAL_HOURLY,
+                )
+                self.update_interval = RETRY_INTERVAL_ON_ERROR
             raise UpdateFailed(str(err)) from err
+        if self.update_interval != SCAN_INTERVAL_HOURLY:
+            _LOGGER.info("Poll succeeded; restoring %s cadence", SCAN_INTERVAL_HOURLY)
+            self.update_interval = SCAN_INTERVAL_HOURLY
+        return data
 
     async def _fetch_and_import(self) -> HaggleData:
         """Core update: fetch missing intervals + trailing rewindow, return data."""

--- a/tests/test_agl_client.py
+++ b/tests/test_agl_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from custom_components.haggle.agl.client import (
@@ -357,6 +359,67 @@ class TestAglClient:
             pytest.raises(AGLError),
         ):
             await client.async_get_overview()
+
+    async def test_non_json_200_body_raises_agl_error(self) -> None:
+        """A 200 with a non-JSON body (e.g. an Akamai challenge page) must
+        become AGLError, not a raw JSONDecodeError that crashes the update
+        cycle and bypasses the solar heal's attempt accounting (#151)."""
+        client, session = self._make_client({}, status=200)
+        session.get.return_value.json = AsyncMock(
+            side_effect=json.JSONDecodeError("Expecting value", "<html>", 0)
+        )
+        with (
+            patch.object(
+                client._auth,
+                "async_ensure_valid_token",
+                new_callable=AsyncMock,
+                return_value="tok",
+            ),
+            pytest.raises(AGLError, match="non-JSON"),
+        ):
+            await client.async_get_overview()
+
+    async def test_transport_error_raises_agl_error(self) -> None:
+        """aiohttp transport failures wrap into AGLError (#151)."""
+        client, session = self._make_client({}, status=200)
+        session.get = MagicMock(side_effect=aiohttp.ClientError("conn reset"))
+        with (
+            patch.object(
+                client._auth,
+                "async_ensure_valid_token",
+                new_callable=AsyncMock,
+                return_value="tok",
+            ),
+            pytest.raises(AGLError, match="transport error"),
+        ):
+            await client.async_get_overview()
+
+    async def test_timeout_raises_agl_error(self) -> None:
+        """TimeoutError (alias of asyncio.TimeoutError) wraps into AGLError
+        (#151)."""
+        client, session = self._make_client({}, status=200)
+        session.get = MagicMock(side_effect=TimeoutError())
+        with (
+            patch.object(
+                client._auth,
+                "async_ensure_valid_token",
+                new_callable=AsyncMock,
+                return_value="tok",
+            ),
+            pytest.raises(AGLError, match="transport error"),
+        ):
+            await client.async_get_overview()
+
+    async def test_force_refresh_transport_error_is_not_auth_error(self) -> None:
+        """A network blip during token refresh must be retryable AGLError,
+        never AGLAuthError (which triggers the reauth flow) and never a raw
+        escape (#151)."""
+        session = MagicMock()
+        session.post = MagicMock(side_effect=aiohttp.ClientError("dns fail"))
+        auth = AglAuth("v1.tok", AsyncMock())
+        with pytest.raises(AGLError, match="transport error") as exc_info:
+            await auth.async_force_refresh(session)
+        assert not isinstance(exc_info.value, AGLAuthError)
 
     async def test_http_error_keeps_url_and_body_out_of_exception(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -29,6 +29,7 @@ from custom_components.haggle.const import (
     REWINDOW_DAYS,
     SOLAR_HEAL_DONE,
     SOLAR_HEAL_PENDING,
+    SOLAR_STALL_GIVE_UP_CYCLES,
     STAT_CONSUMPTION,
 )
 from custom_components.haggle.coordinator import HaggleCoordinator
@@ -2395,6 +2396,18 @@ class TestGenerationHealState:
         assert mock_range.call_args[0][1][0] != today - timedelta(days=BACKFILL_DAYS)
         assert self._heal(coord) == {"state": SOLAR_HEAL_DONE, "repair": True}
 
+    async def test_normal_cycle_tracks_stall_heal_cycle_does_not(
+        self, hass: HomeAssistant
+    ) -> None:
+        """#154 wiring: _fetch_range gets track_stall=True only on non-heal
+        cycles — heal sweeps have their own attempt accounting."""
+        _, mock_range, _, _ = await self._run(hass, needs_heal=True)
+        assert mock_range.call_args.kwargs["track_stall"] is False
+        _, mock_range, _, _ = await self._run(
+            hass, preset={"state": SOLAR_HEAL_DONE}, needs_heal=False
+        )
+        assert mock_range.call_args.kwargs["track_stall"] is True
+
     async def test_repair_giveup_keeps_mark(self, hass: HomeAssistant) -> None:
         """A repair generation that exhausts its budget goes done WITH the
         mark, permanently blocking further re-arms."""
@@ -2486,3 +2499,100 @@ class TestGenerationHealState:
         ):
             complete = await coord._fetch_range(None, (day, day), None)
         assert complete is True
+
+
+class TestSolarStallGiveUp:
+    """#154 — the normal-path backfill give-up counter.
+
+    A contiguous span of permanently-erroring days at resume+1.. refetched the
+    identical chunk forever; after SOLAR_STALL_GIVE_UP_CYCLES zero-progress
+    cycles on the SAME chunk, marker rows advance the resume point past it.
+    """
+
+    @staticmethod
+    def _chunk() -> tuple[date, date]:
+        start = datetime.now(UTC).date() - timedelta(days=20)
+        return (start, start + timedelta(days=BACKFILL_CHUNK_DAYS - 1))
+
+    async def test_gives_up_after_n_zero_progress_cycles(
+        self, hass: HomeAssistant
+    ) -> None:
+        coord = _make_coordinator(hass)
+        chunk = self._chunk()
+        with patch.object(
+            coord, "_import_generation", new_callable=AsyncMock
+        ) as mock_import:
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES - 1):
+                await coord._track_solar_stall(chunk, progressed=False, skipped=True)
+            mock_import.assert_not_awaited()  # still retrying
+            await coord._track_solar_stall(chunk, progressed=False, skipped=True)
+
+        mock_import.assert_awaited_once()
+        marked = mock_import.await_args.kwargs["fetched_days"]
+        assert marked[0] == chunk[0]
+        assert marked[-1] == chunk[1]
+        assert len(marked) == BACKFILL_CHUNK_DAYS
+        assert coord._solar_stall is None  # counter reset after give-up
+
+    async def test_progress_resets_counter(self, hass: HomeAssistant) -> None:
+        """Any successful day (even alongside skips) resets the count — the
+        chunk is moving, not stalled."""
+        coord = _make_coordinator(hass)
+        chunk = self._chunk()
+        with patch.object(
+            coord, "_import_generation", new_callable=AsyncMock
+        ) as mock_import:
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES - 1):
+                await coord._track_solar_stall(chunk, progressed=False, skipped=True)
+            await coord._track_solar_stall(chunk, progressed=True, skipped=True)
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES - 1):
+                await coord._track_solar_stall(chunk, progressed=False, skipped=True)
+        mock_import.assert_not_awaited()
+
+    async def test_different_chunk_restarts_counter(self, hass: HomeAssistant) -> None:
+        """A moved resume point means the old span cleared — the count must
+        not carry over to the new chunk."""
+        coord = _make_coordinator(hass)
+        a = self._chunk()
+        b = (a[0] + timedelta(days=7), a[1] + timedelta(days=7))
+        with patch.object(
+            coord, "_import_generation", new_callable=AsyncMock
+        ) as mock_import:
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES - 1):
+                await coord._track_solar_stall(a, progressed=False, skipped=True)
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES - 1):
+                await coord._track_solar_stall(b, progressed=False, skipped=True)
+        mock_import.assert_not_awaited()
+
+    async def test_rate_limited_sweep_does_not_count(self, hass: HomeAssistant) -> None:
+        """A 429-halted sweep never reaches the tracker (days were not
+        attempted) — verified at the _fetch_range call site."""
+        from custom_components.haggle.agl.client import AGLRateLimitError
+
+        coord = _make_coordinator(hass)
+        day = datetime.now(UTC).date() - timedelta(days=10)
+        with (
+            patch.object(
+                coord,
+                "_fetch_day_solar",
+                new_callable=AsyncMock,
+                side_effect=AGLRateLimitError("429"),
+            ),
+            patch.object(
+                coord, "_track_solar_stall", new_callable=AsyncMock
+            ) as mock_track,
+        ):
+            await coord._fetch_range(None, (day, day), None, track_stall=True)
+        mock_track.assert_not_awaited()
+
+    async def test_clean_zero_export_sweep_resets(self, hass: HomeAssistant) -> None:
+        """A sweep with no skips (all days fetched clean, even if zero export)
+        resets the counter."""
+        coord = _make_coordinator(hass)
+        chunk = self._chunk()
+        with patch.object(coord, "_import_generation", new_callable=AsyncMock):
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES - 1):
+                await coord._track_solar_stall(chunk, progressed=False, skipped=True)
+            assert coord._solar_stall is not None
+            await coord._track_solar_stall(chunk, progressed=False, skipped=False)
+        assert coord._solar_stall is None

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -2067,6 +2067,7 @@ class TestGenerationHealState:
         preset: dict | None = None,
         needs_heal: bool = True,
         fetch_complete: bool = True,
+        drained: bool = False,
     ) -> tuple[HaggleCoordinator, MagicMock, MagicMock, object]:
         coord = _make_coordinator(hass, client=self._solar_client())
         if preset is not None:
@@ -2099,6 +2100,12 @@ class TestGenerationHealState:
             ),
             patch.object(
                 coord,
+                "_recorder_drained",
+                new_callable=AsyncMock,
+                return_value=drained,
+            ),
+            patch.object(
+                coord,
                 "_fetch_range",
                 new_callable=AsyncMock,
                 return_value=fetch_complete,
@@ -2110,6 +2117,45 @@ class TestGenerationHealState:
     @staticmethod
     def _heal(coord: HaggleCoordinator) -> dict:
         return coord.config_entry.data.get(CONF_SOLAR_HEAL) or {}
+
+    async def test_unexpected_raise_mid_heal_still_bumps_attempts(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Belt-and-braces (#151): even a non-AGLError escaping _fetch_range
+        must count a heal attempt — otherwise a deterministic raise on an old
+        heal-window day re-fires an unbounded, uncounted 30-day sweep every
+        cycle with the whole integration unavailable."""
+        coord = _make_coordinator(hass, client=self._solar_client())
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)
+            return (12.3, today - timedelta(days=8))
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(
+                coord,
+                "_generation_needs_heal",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                coord,
+                "_fetch_range",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("unwrapped transport bug"),
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await coord._fetch_and_import()
+
+        heal = self._heal(coord)
+        assert heal["state"] == SOLAR_HEAL_PENDING
+        assert heal["attempts"] == 1  # the crashed sweep still counted
 
     async def test_pending_persisted_before_fetch(self, hass: HomeAssistant) -> None:
         """The frozen-floor pending record is written BEFORE the long fetch, so an
@@ -2242,14 +2288,38 @@ class TestGenerationHealState:
         assert mock_range.call_args[0][1][0] != today - timedelta(days=BACKFILL_DAYS)
         assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
 
-    async def test_period_totals_suppressed_during_heal(
+    async def test_period_totals_published_after_complete_drained_heal(
         self, hass: HomeAssistant
     ) -> None:
-        """The heal rewrites rows behind bill_start this cycle, so the period
-        totals are suppressed (→ sensor `unknown`) to avoid a one-cycle over-read
-        from a stale queued baseline (P2), even though the totals helper returns
-        numbers."""
-        _, _, _, data = await self._run(hass, needs_heal=True)
+        """#152: a COMPLETE heal sweep drains the recorder queue and then
+        publishes through the proven totals path — the sensors show the healed
+        number the same cycle the heal finishes, no blank day."""
+        _, _, _, data = await self._run(
+            hass, needs_heal=True, fetch_complete=True, drained=True
+        )
+        assert data.generation_period_kwh == 4.0
+        assert data.generation_period_credit_aud == 1.0
+
+    async def test_period_totals_suppressed_on_drain_timeout(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Drain timeout → keep the suppression (a wrong number is worse than
+        a blank one); the next normal cycle publishes."""
+        _, _, _, data = await self._run(
+            hass, needs_heal=True, fetch_complete=True, drained=False
+        )
+        assert data.generation_period_kwh is None
+        assert data.generation_period_credit_aud is None
+
+    async def test_period_totals_suppressed_on_incomplete_heal_sweep(
+        self, hass: HomeAssistant
+    ) -> None:
+        """An incomplete sweep (429/skipped day) must NOT publish even if the
+        recorder would drain — the partial chain undercounts (Codex P2/RT4
+        condition on #152)."""
+        _, _, _, data = await self._run(
+            hass, needs_heal=True, fetch_complete=False, drained=True
+        )
         assert data.generation_period_kwh is None
         assert data.generation_period_credit_aud is None
 

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -433,6 +433,73 @@ class TestUpdateDataAuthError:
         ):
             await coord._async_update_data()
 
+    async def test_failed_poll_shortens_retry_interval(
+        self, hass: HomeAssistant
+    ) -> None:
+        """#155: a transient AGL failure retries after RETRY_INTERVAL_ON_ERROR
+        instead of silently waiting a full 24 h (#126 'poll never ran')."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        from custom_components.haggle.agl.client import AGLError
+        from custom_components.haggle.const import (
+            RETRY_INTERVAL_ON_ERROR,
+            SCAN_INTERVAL_HOURLY,
+        )
+
+        coord = _make_coordinator(hass)
+        assert coord.update_interval == SCAN_INTERVAL_HOURLY
+        with (
+            patch.object(
+                coord,
+                "_fetch_and_import",
+                new_callable=AsyncMock,
+                side_effect=AGLError("HTTP 500 fetching AGL data"),
+            ),
+            pytest.raises(UpdateFailed),
+        ):
+            await coord._async_update_data()
+        assert coord.update_interval == RETRY_INTERVAL_ON_ERROR
+
+    async def test_successful_poll_restores_cadence(self, hass: HomeAssistant) -> None:
+        from custom_components.haggle.const import (
+            RETRY_INTERVAL_ON_ERROR,
+            SCAN_INTERVAL_HOURLY,
+        )
+
+        coord = _make_coordinator(hass)
+        coord.update_interval = RETRY_INTERVAL_ON_ERROR  # as after a failure
+        with patch.object(
+            coord,
+            "_fetch_and_import",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ):
+            await coord._async_update_data()
+        assert coord.update_interval == SCAN_INTERVAL_HOURLY
+
+    async def test_auth_failure_leaves_interval_untouched(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Auth failures hand over to the reauth flow — no fast retry that
+        would hammer a rejected token."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.haggle.agl.client import AGLAuthError
+        from custom_components.haggle.const import SCAN_INTERVAL_HOURLY
+
+        coord = _make_coordinator(hass)
+        with (
+            patch.object(
+                coord,
+                "_fetch_and_import",
+                new_callable=AsyncMock,
+                side_effect=AGLAuthError("token revoked"),
+            ),
+            pytest.raises(ConfigEntryAuthFailed),
+        ):
+            await coord._async_update_data()
+        assert coord.update_interval == SCAN_INTERVAL_HOURLY
+
 
 # ---------------------------------------------------------------------------
 # _fetch_range — smart endpoint selection

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -2068,6 +2068,7 @@ class TestGenerationHealState:
         needs_heal: bool = True,
         fetch_complete: bool = True,
         drained: bool = False,
+        chain_broken: bool = False,
     ) -> tuple[HaggleCoordinator, MagicMock, MagicMock, object]:
         coord = _make_coordinator(hass, client=self._solar_client())
         if preset is not None:
@@ -2092,6 +2093,12 @@ class TestGenerationHealState:
                 new_callable=AsyncMock,
                 return_value=needs_heal,
             ) as mock_needs,
+            patch.object(
+                coord,
+                "_generation_heal_triggers",
+                new_callable=AsyncMock,
+                return_value=(False, chain_broken),
+            ),
             patch.object(
                 coord,
                 "_get_generation_period_totals",
@@ -2287,6 +2294,55 @@ class TestGenerationHealState:
         # Not the heal window: a normal trailing chunk, never starting at floor.
         assert mock_range.call_args[0][1][0] != today - timedelta(days=BACKFILL_DAYS)
         assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
+
+    async def test_chain_break_after_done_arms_bounded_repair(
+        self, hass: HomeAssistant
+    ) -> None:
+        """#153: a downward sum step frozen by a 429 on the give-up sweep
+        re-arms ONE repair generation — full window, fresh attempt budget,
+        marked `repair` so it can never re-arm again."""
+        today = datetime.now(UTC).date()
+        coord, mock_range, _, _ = await self._run(
+            hass,
+            preset={"state": SOLAR_HEAL_DONE},
+            chain_broken=True,
+            fetch_complete=True,
+        )
+        assert mock_range.call_args[0][1] == (
+            today - timedelta(days=BACKFILL_DAYS),
+            today - timedelta(days=1),
+        )
+        heal = self._heal(coord)
+        assert heal["state"] == SOLAR_HEAL_DONE  # repair completed this cycle
+        assert heal["repair"] is True  # mark survives → no second generation
+
+    async def test_repair_mark_blocks_second_rearm(self, hass: HomeAssistant) -> None:
+        """A record already marked `repair` never re-arms, even with the chain
+        still broken — lifetime sweeps hard-capped at 2x MAX (#153)."""
+        today = datetime.now(UTC).date()
+        coord, mock_range, _, _ = await self._run(
+            hass,
+            preset={"state": SOLAR_HEAL_DONE, "repair": True},
+            chain_broken=True,
+        )
+        assert mock_range.call_args[0][1][0] != today - timedelta(days=BACKFILL_DAYS)
+        assert self._heal(coord) == {"state": SOLAR_HEAL_DONE, "repair": True}
+
+    async def test_repair_giveup_keeps_mark(self, hass: HomeAssistant) -> None:
+        """A repair generation that exhausts its budget goes done WITH the
+        mark, permanently blocking further re-arms."""
+        today = datetime.now(UTC).date()
+        coord, _, _, _ = await self._run(
+            hass,
+            preset={
+                "state": SOLAR_HEAL_PENDING,
+                "floor": (today - timedelta(days=25)).isoformat(),
+                "attempts": MAX_SOLAR_HEAL_ATTEMPTS - 1,
+                "repair": True,
+            },
+            fetch_complete=False,
+        )
+        assert self._heal(coord) == {"state": SOLAR_HEAL_DONE, "repair": True}
 
     async def test_period_totals_published_after_complete_drained_heal(
         self, hass: HomeAssistant

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -9,6 +9,7 @@ and get_last_statistics — so no real SQLite DB is needed.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2400,13 +2401,99 @@ class TestGenerationHealState:
         self, hass: HomeAssistant
     ) -> None:
         """#154 wiring: _fetch_range gets track_stall=True only on non-heal
-        cycles — heal sweeps have their own attempt accounting."""
+        cycles — heal sweeps have their own attempt accounting. The _run
+        harness leaves the generation series 8 days behind, so the normal
+        chunk starts strictly beyond the last stored day."""
         _, mock_range, _, _ = await self._run(hass, needs_heal=True)
         assert mock_range.call_args.kwargs["track_stall"] is False
         _, mock_range, _, _ = await self._run(
             hass, preset={"state": SOLAR_HEAL_DONE}, needs_heal=False
         )
         assert mock_range.call_args.kwargs["track_stall"] is True
+
+    async def test_rewindow_overlap_never_tracks_stall(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Codex on #157: a caught-up series' chunk IS the trailing rewindow,
+        overlapping real rows — give-up markers there would corrupt the
+        cumulative chain, so tracking must stay off."""
+        coord = _make_coordinator(hass, client=self._solar_client())
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+
+        with (
+            patch.object(
+                coord,
+                "_get_last_stat",
+                new_callable=AsyncMock,
+                return_value=(500.0, yesterday),  # both series caught up
+            ),
+            patch.object(
+                coord,
+                "_generation_needs_heal",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                coord,
+                "_generation_heal_triggers",
+                new_callable=AsyncMock,
+                return_value=(False, False),
+            ),
+            patch.object(
+                coord,
+                "_get_generation_period_totals",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(
+                coord, "_fetch_range", new_callable=AsyncMock, return_value=True
+            ) as mock_range,
+        ):
+            await coord._fetch_and_import()
+
+        # Chunk starts inside the rewindow (start <= last stored day).
+        assert mock_range.call_args.kwargs["track_stall"] is False
+
+    async def test_cancelled_mid_heal_does_not_bump_attempts(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Codex on #157: HA unload/restart cancels the update task — that is
+        not an AGL failure and must not consume heal budget; the frozen floor
+        already makes restarts resume-safe."""
+        coord = _make_coordinator(hass, client=self._solar_client())
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+        preset = {
+            "state": SOLAR_HEAL_PENDING,
+            "floor": (today - timedelta(days=25)).isoformat(),
+            "attempts": 1,
+        }
+        hass.config_entries.async_update_entry(
+            coord.config_entry,
+            data={**coord.config_entry.data, CONF_SOLAR_HEAL: preset},
+        )
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)
+            return (12.3, today - timedelta(days=8))
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(
+                coord,
+                "_fetch_range",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError(),
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await coord._fetch_and_import()
+
+        # Record untouched: same attempts, still pending, same frozen floor.
+        assert self._heal(coord) == preset
 
     async def test_repair_giveup_keeps_mark(self, hass: HomeAssistant) -> None:
         """A repair generation that exhausts its budget goes done WITH the
@@ -2596,3 +2683,58 @@ class TestSolarStallGiveUp:
             assert coord._solar_stall is not None
             await coord._track_solar_stall(chunk, progressed=False, skipped=False)
         assert coord._solar_stall is None
+
+
+class TestTransportHaltSemantics:
+    """Codex on #157: transport failures HALT the chunk (retry next cycle);
+    only per-day AGL HTTP errors keep the documented skip tradeoff. A skip on
+    a transient network blip would advance the resume past the day forever.
+    """
+
+    async def test_consumption_transport_error_halts_chunk(
+        self, hass: HomeAssistant
+    ) -> None:
+        from custom_components.haggle.agl.client import AGLTransportError
+
+        coord = _make_coordinator(hass)
+        coord.client.async_get_usage_hourly = AsyncMock(
+            side_effect=AGLTransportError("transport error: ClientError")
+        )
+        day = datetime.now(UTC).date() - timedelta(days=2)
+        assert await coord._fetch_day_consumption(day, previous=False) is None
+
+    async def test_consumption_http_error_still_skips(
+        self, hass: HomeAssistant
+    ) -> None:
+        from custom_components.haggle.agl.client import AGLError
+
+        coord = _make_coordinator(hass)
+        coord.client.async_get_usage_hourly = AsyncMock(
+            side_effect=AGLError("HTTP 500 fetching AGL data")
+        )
+        day = datetime.now(UTC).date() - timedelta(days=2)
+        assert await coord._fetch_day_consumption(day, previous=False) == []
+
+    async def test_solar_transport_error_halts_not_skips(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Transport failure mid-solar-sweep halts the whole chunk (like a
+        429) and leaves the day unmarked — no resume advance past it."""
+        from custom_components.haggle.agl.client import AGLTransportError
+
+        coord = _make_coordinator(hass)
+        day = datetime.now(UTC).date() - timedelta(days=10)
+        with (
+            patch.object(
+                coord,
+                "_fetch_day_solar",
+                new_callable=AsyncMock,
+                side_effect=AGLTransportError("transport error: TimeoutError"),
+            ),
+            patch.object(
+                coord, "_import_generation", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            complete = await coord._fetch_range(None, (day, day), None)
+        assert complete is False
+        mock_import.assert_not_awaited()  # nothing marked, nothing advanced

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -479,6 +479,35 @@ class TestUpdateDataAuthError:
             await coord._async_update_data()
         assert coord.update_interval == SCAN_INTERVAL_HOURLY
 
+    async def test_halted_sweep_schedules_fast_retry(self, hass: HomeAssistant) -> None:
+        """Codex on #157: a chunk halted by 429/transport returns data (cycle
+        succeeds, sensors keep values) but must still schedule the 30-min
+        retry — otherwise the halted chunk waits a full day."""
+        from custom_components.haggle.const import (
+            RETRY_INTERVAL_ON_ERROR,
+            SCAN_INTERVAL_HOURLY,
+        )
+
+        coord = _make_coordinator(hass)
+        assert coord.update_interval == SCAN_INTERVAL_HOURLY
+
+        async def _fetch_and_mark_halt() -> MagicMock:
+            coord._sweep_halted = True  # as _fetch_range sets on a halt
+            return MagicMock()
+
+        with patch.object(coord, "_fetch_and_import", side_effect=_fetch_and_mark_halt):
+            await coord._async_update_data()
+        assert coord.update_interval == RETRY_INTERVAL_ON_ERROR
+
+        # Next clean cycle restores the daily cadence.
+        async def _fetch_clean() -> MagicMock:
+            coord._sweep_halted = False
+            return MagicMock()
+
+        with patch.object(coord, "_fetch_and_import", side_effect=_fetch_clean):
+            await coord._async_update_data()
+        assert coord.update_interval == SCAN_INTERVAL_HOURLY
+
     async def test_auth_failure_leaves_interval_untouched(
         self, hass: HomeAssistant
     ) -> None:
@@ -2019,6 +2048,30 @@ class TestGenerationHeal:
         }
         with patch(_PATCH_GET_INSTANCE, _mock_get_instance(rows)):
             assert await coord._generation_needs_heal(stat_id_gen, floor, today) is True
+
+    async def test_credit_only_step_also_triggers(self, hass: HomeAssistant) -> None:
+        """Codex on #157: the AUD credit chain accumulates independently — a
+        step in credit alone (kWh monotonic) must still arm the repair."""
+        coord = _make_coordinator(hass)
+        stat_id_gen, stat_id_credit = coord._generation_stat_ids()
+        today = datetime.now(UTC).date()
+        floor = today - timedelta(days=BACKFILL_DAYS)
+        rows = {
+            stat_id_gen: [
+                {"start": _ts(floor), "sum": 5.0},
+                {"start": _ts(floor + timedelta(days=1)), "sum": 6.0},  # monotonic
+            ],
+            stat_id_credit: [
+                {"start": _ts(floor), "sum": 2.0},
+                {"start": _ts(floor + timedelta(days=1)), "sum": 0.5},  # step down
+            ],
+        }
+        with patch(_PATCH_GET_INSTANCE, _mock_get_instance(rows)):
+            leading, broken = await coord._generation_heal_triggers(
+                stat_id_gen, floor, today
+            )
+        assert broken is True
+        assert leading is False
 
     async def test_empty_series_no_heal(self, hass: HomeAssistant) -> None:
         """No rows (fresh install) → normal backfill handles it, not a heal."""


### PR DESCRIPTION
## Summary

The full post-#150 resilience queue in one pass — all five issues touch the same coordinator fetch/heal/retry seam, so their interactions are designed together rather than layered across releases. One commit per issue (plus a docs commit); each landed with its own tests and a green gate.

| Commit | Issue | Fix |
|---|---|---|
| `9f9ae9c` | **#151** (+#152) | **Transport shield**: `AglClient._get` + `async_force_refresh` wrap network errors, timeouts, and 200-non-JSON bodies into retryable `AGLError` (a refresh-time blip is never `AGLAuthError`). Belt-and-braces: `_fetch_with_heal_accounting` counts a heal attempt on ANY sweep exit — the red-team's unbounded-uncounted-sweep trace is closed even for exception types nobody anticipated |
| `9f9ae9c` | **#152** | **Drain-then-read**: a COMPLETE heal sweep awaits the recorder queue (bounded, 30 s) and publishes the period totals through the *existing proven* path the same cycle — no more 1–3 days of `unknown` after upgrading. Incomplete sweep / drain timeout stays suppressed (a wrong number is worse than a blank one) |
| `d5c19b8` | **#153** | **Chain repair survives give-up**: detector split into leading-hole (disarmed forever at done — the P3 guarantee holds) and chain-broken (re-arms ONE `repair`-marked generation with a fresh budget). Lifetime sweeps hard-capped at 2× `MAX_SOLAR_HEAL_ATTEMPTS`; repair give-up logs ERROR |
| `66742de` | **#155** | **Failure-aware cadence**: failed poll → retry in 30 min instead of silently waiting 24 h (#126's "poll never ran"); restored on success; auth failures untouched (reauth flow owns them) |
| `e75b055` | **#154** | **Backfill stall give-up**: 3 consecutive zero-progress cycles on the SAME solar chunk → marker rows advance the resume past the span (WARNING). Rate-limited sweeps and heal sweeps excluded by design — a 429 must never become a data hole |

## Interactions (the reason for batching)

- #155's faster retries flow through #151's exception-proof attempt accounting, so retry acceleration cannot burn heal budget on crash-class failures.
- #153's repair generation reuses the #150 record machinery (`{state, floor, attempts}` + `repair` mark) — no second state machine.
- #154 is explicitly scoped away from heal sweeps (#150/#153 own those) and 429 halts.

## Verification

**222 tests pass** (24 new across the five fixes), ruff + mypy clean, per-commit gates green. Docs: CHANGELOG entries per issue; AGENTS.md polling-cadence row, heal-bullet rewrite, and a new What-NOT-to-Do rule ("never let non-AGLError types escape AglClient").

Closes #151. Closes #152. Closes #153. Closes #154. Closes #155.

Ship target: **v0.4.0-beta.4** (also first release carrying the #149 diagnostics platform). #128 remains open pending the reporter's beta.3 → beta.4 confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
