### PR TITLE
docs: rot-proof README version references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -672,6 +672,12 @@ The HA Energy dashboard requires:
   When adding a new client method, route it through `_get` or replicate the
   shield; `_fetch_with_heal_accounting` is the belt-and-braces layer that
   counts an attempt on ANY sweep exit regardless.
+- **Don't hardcode release version strings in README/info.md/docs.** The
+  release flow bumps `manifest.json` + `CHANGELOG.md` only, so a pinned
+  `vX.Y.Z` anywhere else rots on the next release (the README advertised
+  `beta.2` while `beta.4` was live). Use the shields.io release badge or
+  "latest pre-release via HACS" phrasing; version numbers belong in the
+  CHANGELOG and the releases page.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # haggle
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=NaanyaBiz&repository=haggle&category=integration)
+[![Latest release](https://img.shields.io/github/v/release/NaanyaBiz/haggle?include_prereleases&label=latest)](https://github.com/NaanyaBiz/haggle/releases)
 
 Home Assistant custom integration that pulls smart-meter usage from
 [AGL Australia](https://www.agl.com.au/) and feeds it into the HA Energy
@@ -14,11 +15,12 @@ dashboard.
 > **Australia only.** Requires an AGL Energy electricity account with a smart
 > meter (most Australian metropolitan installations).
 
-> **Status:** `v0.4.0-beta.2`. The flat-rate consumption/cost path is stable
-> and runs live in the maintainer's Home Assistant. **Time-of-Use** support is
-> in validation with real ToU customers
-> ([#126](https://github.com/NaanyaBiz/haggle/issues/126)), and **solar
-> feed-in** support is in beta validation
+> **Status** (current version: see the badge above or the
+> [releases page](https://github.com/NaanyaBiz/haggle/releases)): the
+> flat-rate consumption/cost path is stable and runs live in the maintainer's
+> Home Assistant. **Time-of-Use** support is in validation with real ToU
+> customers ([#126](https://github.com/NaanyaBiz/haggle/issues/126)), and
+> **solar feed-in** support is in beta validation
 > ([#128](https://github.com/NaanyaBiz/haggle/issues/128)) — enable
 > "Show beta versions" in HACS to try either. See
 > [`CHANGELOG.md`](./CHANGELOG.md) for milestone detail.
@@ -91,8 +93,8 @@ credit). Sensors cover the current billing period (matching the AGL app's
 
 > Solar is in beta validation
 > ([#128](https://github.com/NaanyaBiz/haggle/issues/128)) — the field
-> mapping is confirmed against a real capture and the AGL app; install
-> `v0.4.0-beta.2` via HACS "Show beta versions" to try it.
+> mapping is confirmed against a real capture and the AGL app; install the
+> latest pre-release via HACS "Show beta versions" to try it.
 
 ## Develop
 


### PR DESCRIPTION
README still said `v0.4.0-beta.2` (two releases stale) — the release flow only touches manifest.json + CHANGELOG. Replaces both hardcoded versions with a shields.io latest-release badge + version-agnostic phrasing, and adds an AGENTS.md rule banning pinned versions in prose docs.

No code changes; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)