### PR TITLE
ci: attested release artifact + Scorecard triage (7.0 baseline)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+# Deny-by-default at the top level; the release job below grants its own
+# scoped writes (Scorecard Token-Permissions flags a workflow with no
+# top-level permissions block).
+permissions: {}
+
 jobs:
   release:
     name: Create GitHub Release
@@ -12,7 +17,7 @@ jobs:
     permissions:
       contents: write
       # Required for actions/attest-build-provenance to mint Sigstore-rooted
-      # attestations against the integration's source tree.
+      # attestations against the release artifact.
       id-token: write
       attestations: write
 
@@ -31,28 +36,41 @@ jobs:
           # Extract the section between ## [VERSION] and the next ## [
           awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md > release_notes.txt
 
+      # Real release artifact (HACS still installs from the source tarball —
+      # hacs.json zip_release stays false — but the zip gives Scorecard's
+      # Signed-Releases check a signed asset to score, and users a direct,
+      # verifiable download).
+      - name: Build release artifact
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          (cd custom_components && zip -r "../haggle-${VERSION}.zip" haggle)
+
       - name: Generate build provenance attestation
+        id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          # Attest the published source tree under custom_components/haggle/.
-          # HACS installs from GitHub Release tarballs; the attestation lets
-          # downstream consumers verify the tag's content via `gh attestation`.
-          subject-path: |
-            custom_components/haggle/**/*
+          # Attest the actual artifact users can download. Verify with:
+          #   gh attestation verify haggle-<ver>.zip --repo NaanyaBiz/haggle
+          subject-path: haggle-${{ steps.version.outputs.version }}.zip
 
       # First-party gh CLI (preinstalled on the runner) instead of a
       # third-party action: this is the only workflow with contents:write +
       # id-token:write, so no third-party code runs in it (2026-07
-      # dependency review).
+      # dependency review). The Sigstore bundle is uploaded next to the zip
+      # so the release carries its own offline-verifiable signature.
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cp "${{ steps.attest.outputs.bundle-path }}" "haggle-${VERSION}.zip.sigstore"
           args=()
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then
             args+=(--prerelease)
           fi
           gh release create "$GITHUB_REF_NAME" \
-            --title "v${{ steps.version.outputs.version }}" \
+            --title "v${VERSION}" \
             --notes-file release_notes.txt \
-            "${args[@]}"
+            "${args[@]}" \
+            "haggle-${VERSION}.zip" \
+            "haggle-${VERSION}.zip.sigstore"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ scripts/
 │   ├── ci.yml           # ruff + mypy + pytest matrix (Python 3.14); coverage inline, no external vendor
 │   ├── hacs.yml         # HACS validation
 │   ├── hassfest.yml     # Home Assistant integration manifest validation
-│   ├── release.yml      # tag-triggered GitHub Release (first-party gh CLI) + build-provenance attestation
+│   ├── release.yml      # tag-triggered GitHub Release (first-party gh CLI) + attested zip asset (Sigstore)
 │   ├── codeql.yml       # weekly + per-PR CodeQL Python scan
 │   └── scorecard.yml    # weekly + on-push OpenSSF Scorecard self-assessment (feeds README badge)
 ├── CODEOWNERS           # @naanyabiz owns everything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ user-facing impact — the integration still ships zero pip requirements):
   SHA-pinned, `publish_results: true`). At review time the repo's direct
   dependencies measured 5.4–7.4; the repo itself attests releases — a check
   none of its dependencies pass.
+- **Releases now ship an attested artifact**: `release.yml` builds
+  `haggle-<ver>.zip` and uploads it with its Sigstore provenance bundle
+  (`.zip.sigstore`) as release assets (verify:
+  `gh attestation verify haggle-<ver>.zip --repo NaanyaBiz/haggle`). HACS
+  install path unchanged (`zip_release` stays false). Also adds the
+  missing top-level `permissions: {}` to `release.yml` (Scorecard
+  Token-Permissions 9→10). First Scorecard self-assessment: **7.0/10**;
+  the remaining deductions are triaged in `SECURITY.md` ("Own Scorecard
+  posture") with follow-ups in #171 (ruleset), #172 (Best Practices
+  badge), #173 (parser fuzzing).
 - **Threat model updated**: `SECURITY.md` "Supply chain" now records the
   full posture — zero shipped requirements and the dev-only bump risk
   calculus, the 167-package lockfile attribution (~90% HA-ecosystem tax,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -149,6 +149,34 @@ dependencies measured 5.4–7.4 on OpenSSF Scorecard (transitives up to
 sits in code paths this integration never imports — JWT expiry is
 decoded with hand-rolled base64, not PyJWT).
 
+**Own Scorecard posture.** First self-assessment (Scorecard v5.3.0,
+2026-07-12): **7.0/10**, with 10s on Pinned-Dependencies, SAST, CI-Tests,
+Dangerous-Workflow, Dependency-Update-Tool, Security-Policy, License,
+Binary-Artifacts and Vulnerabilities. Remaining deductions, triaged:
+
+- `Maintained: 0` — pure repo-age gate (<90 days); self-resolves ~2026-08.
+- `Code-Review: 0`, `Contributors: 0` — measure team structure (a second
+  human reviewer; multi-organization contributors). **Accepted at 0** for
+  a solo-maintained repo; bot reviews (Codex/Claude) are excluded by
+  Scorecard's design and self-review would be theater.
+- `Packaging: -1` — means "no PyPI/registry publish workflow"; not
+  applicable to a HACS-distributed integration. Inconclusive checks are
+  excluded from the aggregate. Accepted.
+- `Branch-Protection: -1` — default workflow token cannot read classic
+  protection rules; remediation is a ruleset on `main` (#171), not a PAT
+  secret in CI.
+- `CII-Best-Practices: 0` — bestpractices.dev registration tracked in
+  #172 (passing level only; silver+ requires two-person review).
+- `Fuzzing: 0` — tracked in #173; genuine target (`agl/parser.py` parses
+  MITM-influenceable JSON), not badge-chasing.
+- `Signed-Releases: -1` — releases carried no assets; from the next tag,
+  `release.yml` uploads `haggle-<ver>.zip` plus its Sigstore bundle
+  (`.zip.sigstore`), verifiable offline or via
+  `gh attestation verify haggle-<ver>.zip --repo NaanyaBiz/haggle`.
+
+Realistic ceiling ≈ 8.5–9: the residual gap is the team-structure checks
+above, which a single-maintainer project cannot honestly score on.
+
 **Accepted risks (diminishing-returns line).**
 `pytest-homeassistant-custom-component` is a single-maintainer package
 tracked as a range (`<0.14`) — vendoring it would mean self-maintaining


### PR DESCRIPTION
## Summary

- **Signed-Releases (was `-1`, "no releases found")**: `release.yml` now builds `haggle-<ver>.zip`, attests *that artifact* with `actions/attest-build-provenance`, and uploads the zip plus its Sigstore bundle (`.zip.sigstore`) as release assets. Auto-generated source tarballs don't count as assets for Scorecard, so previous releases had nothing to score. HACS install path unchanged (`hacs.json` `zip_release` stays `false`); verify with `gh attestation verify haggle-<ver>.zip --repo NaanyaBiz/haggle`.
- **Token-Permissions (9→10)**: adds the missing top-level `permissions: {}` to `release.yml` — the job block already scoped its writes; only the workflow-level default was flagged.
- **Scorecard triage captured in the threat model**: new "Own Scorecard posture" section in `SECURITY.md` records the 7.0/10 baseline (v5.3.0, 2026-07-12) and disposition of every remaining deduction — `Maintained: 0` is the <90-day age gate (self-resolves ~Aug 2026); `Code-Review`/`Contributors: 0` accepted as team-structure checks a solo repo can't honestly score; `Packaging: -1` N/A for HACS distribution; the actionable tail is filed as issues: **#171** (ruleset on `main` for Branch-Protection), **#172** (OpenSSF Best Practices badge), **#173** (fuzz `agl/parser.py` — a genuine target per the threat model, not badge-chasing).

Note: this PR comes from `claude/haggle-scorecard-followup` — the canonical review branch still holds the pre-squash #168 history on the remote and this session's credential can neither delete it nor force-push (repo deny rule). The stale `claude/haggle-dependency-review-x2lupw` branch is safe to delete from the UI whenever convenient.

## Test plan

- [ ] CI / CodeQL / HACS / Hassfest green on this PR (workflow + docs changes only; no integration code touched)
- [x] `release.yml` YAML parse-validated locally
- [ ] Release-path change is exercised on the next tag push (`v*.*.*`) — expect two new assets on the release: `haggle-<ver>.zip` and `haggle-<ver>.zip.sigstore`
- Reviewer note: `attest-build-provenance`'s subject moved from the source tree glob to the zip artifact — the tree attestation was unverifiable-in-practice for downloaders, the zip attestation is what `gh attestation verify` checks against.

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry a `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
- [ ] The human maintainer has reviewed and understands every change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBb8BtmUX13XgG56gQFDS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBb8BtmUX13XgG56gQFDS9)_