### PR TITLE
chore(deps): ignore pytest in Dependabot — phcc exact-pins it internally

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+    ignore:
+      # pytest's effective version is dictated by the exact pin inside
+      # pytest-homeassistant-custom-component (e.g. 0.13.346 pins
+      # pytest==9.0.3). An independent pytest floor bump is meaningless at
+      # best and deadlocks the resolver at worst — proven twice (#120,
+      # #170). pytest upgrades arrive automatically when phcc bumps its
+      # internal pin.
+      - dependency-name: "pytest"
 
   - package-ecosystem: github-actions
     directory: /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,7 +702,12 @@ The HA Energy dashboard requires:
   patch.** Upstream releases near-daily, so an exact pin manufactures a
   guaranteed weekly Dependabot PR and has caused resolver deadlocks
   (#106, #120). Keep it a range (`<0.14`); `uv.lock` is the
-  reproducibility authority.
+  reproducibility authority. The same logic is why Dependabot **ignores
+  `pytest`** (`dependabot.yml`): phcc exact-pins pytest internally
+  (0.13.346 → `pytest==9.0.3`), so an independent pytest floor bump can
+  never install anything different and a floor above phcc's pin deadlocks
+  the whole grouped PR (#170). Don't remove that ignore rule, and don't
+  bump the pytest floor by hand past phcc's internal pin.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ user-facing impact — the integration still ships zero pip requirements):
 
 ### Changed
 
+- **Dependabot now ignores `pytest`** (`dependabot.yml`): its effective
+  version is exact-pinned inside `pytest-homeassistant-custom-component`
+  (0.13.346 → `pytest==9.0.3`), so independent floor bumps install
+  nothing different and a floor above phcc's pin deadlocks the whole
+  grouped update (#120 replayed on #170). pytest upgrades arrive via
+  phcc's own bumps.
 - **Dependabot PRs are now grouped** (one weekly PR per ecosystem instead
   of ~8 individual ones — the previous flow hand-batched them anyway; 8 of
   the repo's 50 commits were dependency-maintenance churn).


### PR DESCRIPTION
## Summary

- Adds a Dependabot `ignore` rule for `pytest` in the pip ecosystem: `pytest-homeassistant-custom-component` exact-pins pytest internally (0.13.346 → `pytest==9.0.3`, confirmed against PyPI metadata), so an independent pytest floor bump can never change the installed version — and a floor above phcc's pin deadlocks the resolver for the entire grouped PR. Proven twice: #120, and #170 where `uv sync` failed before a single test ran.
- Documents the rule in AGENTS.md "What NOT to Do" (extending the existing phcc range-pin prohibition) and CHANGELOG, so the reasoning survives context resets.
- #170 is being closed in favour of next week's regenerated group: its other five bumps are all compatible with phcc 0.13.346's pins (`pytest-asyncio==1.4.0`, `homeassistant==2026.7.2`; ruff/mypy unconstrained) and will land cleanly once pytest is excluded.

## Test plan

- [x] `dependabot.yml` YAML parse-validated locally
- [ ] CI green on this PR (config + docs only; no code or dependency resolution touched)
- [ ] Next weekly Dependabot `dev-dependencies` group PR resolves and passes CI (the real proof — expected within a week)

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry a `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
- [ ] The human maintainer has reviewed and understands every change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBb8BtmUX13XgG56gQFDS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBb8BtmUX13XgG56gQFDS9)_