### PR TITLE
fix: make AGL parsers total over arbitrary JSON + continuous atheris fuzzing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+    ignore:
+      # pytest's effective version is dictated by the exact pin inside
+      # pytest-homeassistant-custom-component (e.g. 0.13.346 pins
+      # pytest==9.0.3). An independent pytest floor bump is meaningless at
+      # best and deadlocks the resolver at worst — proven twice (#120,
+      # #170). pytest upgrades arrive automatically when phcc bumps its
+      # internal pin.
+      - dependency-name: "pytest"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,56 @@
+name: Fuzz
+
+# Atheris fuzzing of the AGL response parsers (tests/fuzz/fuzz_parser.py).
+# The parsers are the trust boundary for attacker-influenceable JSON (TLS
+# pinning is warn-only — see SECURITY.md), so they must be total over
+# arbitrary input. Weekly deep run + a short run when the parser or the
+# harness changes. Closes the Scorecard Fuzzing gap (#173).
+
+on:
+  schedule:
+    # Weekly Monday 05:42 UTC — offset from the CodeQL (03:17) and
+    # Scorecard (04:22) crons.
+    - cron: "42 5 * * 1"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "custom_components/haggle/agl/**"
+      - "tests/fuzz/**"
+      - ".github/workflows/fuzz.yml"
+
+permissions: read-all
+
+jobs:
+  fuzz:
+    name: Fuzz AGL parsers (atheris)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Install atheris (hash-pinned)
+        run: uv pip install --require-hashes -r tests/fuzz/requirements.txt
+
+      - name: Fuzz parsers
+        env:
+          PYTHONPATH: .
+          # Short smoke on PRs; deeper sweep on the weekly schedule.
+          TIME_BUDGET: ${{ github.event_name == 'pull_request' && '120' || '600' }}
+        run: |
+          mkdir -p /tmp/corpus
+          cp tests/fixtures/*.json /tmp/corpus/
+          uv run python tests/fuzz/fuzz_parser.py /tmp/corpus \
+            -max_total_time="${TIME_BUDGET}" -print_final_stats=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ custom_components/haggle/
 │   ├── __init__.py
 │   ├── client.py        # AglAuth (JWT expiry + token rotation) + AglClient (HTTP methods)
 │   ├── models.py        # TokenSet, Contract, IntervalReading, DailyReading, BillPeriod, PlanRates
-│   ├── parser.py        # JSON → typed dataclasses (filters type=none intervals)
+│   ├── parser.py        # JSON → typed dataclasses; TOTAL over arbitrary JSON (fuzz-enforced) — filters type=none intervals
 │   └── pinning.py       # SPKI extraction helper for Trust-On-First-Use TLS pinning
 ├── strings.json         # translatable config-flow strings
 └── translations/en.json # English strings (must mirror strings.json)
@@ -79,6 +79,9 @@ tests/
 ├── test_const.py                    # base64 sanity-check on AGL_AUTH0_CLIENT
 ├── test_parser.py                   # parse_interval_readings, parse_overview, parse_plan, ToU rate mapping, _safe_float
 ├── test_pinning.py                  # SPKI extraction + host-name guards
+├── fuzz/
+│   ├── fuzz_parser.py               # atheris harness — parser totality + numeric guards (run by fuzz.yml)
+│   └── requirements.txt             # hash-pinned atheris (Scorecard Pinned-Dependencies)
 ├── test_coordinator_statistics.py   # backfill, incremental resume, idempotency, ToU per-tariff series, numeric guards
 ├── test_sensor.py                   # sensor descriptions + conditional ToU rate-sensor registration
 └── test_diagnostics.py              # leak tests (token/contract/account/SPKI never serialize) + schema v1 shape
@@ -103,7 +106,8 @@ scripts/
 │   ├── hassfest.yml     # Home Assistant integration manifest validation
 │   ├── release.yml      # tag-triggered GitHub Release (first-party gh CLI) + attested zip asset (Sigstore)
 │   ├── codeql.yml       # weekly + per-PR CodeQL Python scan
-│   └── scorecard.yml    # weekly + on-push OpenSSF Scorecard self-assessment (feeds README badge)
+│   ├── scorecard.yml    # weekly + on-push OpenSSF Scorecard self-assessment (feeds README badge)
+│   └── fuzz.yml         # weekly + on-parser-change atheris fuzzing of agl/parser.py
 ├── CODEOWNERS           # @naanyabiz owns everything
 └── dependabot.yml       # weekly pip + github-actions updates, grouped into one PR per ecosystem
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,7 +702,12 @@ The HA Energy dashboard requires:
   patch.** Upstream releases near-daily, so an exact pin manufactures a
   guaranteed weekly Dependabot PR and has caused resolver deadlocks
   (#106, #120). Keep it a range (`<0.14`); `uv.lock` is the
-  reproducibility authority.
+  reproducibility authority. The same logic is why Dependabot **ignores
+  `pytest`** (`dependabot.yml`): phcc exact-pins pytest internally
+  (0.13.346 → `pytest==9.0.3`), so an independent pytest floor bump can
+  never install anything different and a floor above phcc's pin deadlocks
+  the whole grouped PR (#170). Don't remove that ignore rule, and don't
+  bump the pytest floor by hand past phcc's internal pin.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ user-facing impact — the integration still ships zero pip requirements):
 
 ### Changed
 
+- **Dependabot now ignores `pytest`** (`dependabot.yml`): its effective
+  version is exact-pinned inside `pytest-homeassistant-custom-component`
+  (0.13.346 → `pytest==9.0.3`), so independent floor bumps install
+  nothing different and a floor above phcc's pin deadlocks the whole
+  grouped update (#120 replayed on #170). pytest upgrades arrive via
+  phcc's own bumps.
 - **Dependabot PRs are now grouped** (one weekly PR per ecosystem instead
   of ~8 individual ones — the previous flow hand-batched them anyway; 8 of
   the repo's 50 commits were dependency-maintenance churn).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **AGL response parsers are now total over arbitrary JSON** (#173): a
+  MITM-crafted or corrupt body can no longer crash a poll cycle via the
+  parser layer. Fixed crash classes — whitespace/numeric `usage.quantity`
+  (`IndexError`/`AttributeError` in `parse_bill_period`), non-dict nodes at
+  any envelope level (`.get` on list/str/int), unhashable
+  `consumption.type` values (`TypeError` on set membership), missing
+  `contractNumber` (`KeyError` — entry now skipped), and non-str plan
+  titles (`.lower()` on int). Regression-pinned in
+  `tests/test_parser.py::TestParserTotality`.
+- **Continuous fuzzing of the parsers** (#173): atheris harness
+  (`tests/fuzz/fuzz_parser.py`) asserts totality plus the finite/
+  non-negative numeric guarantee, seeded from the anonymised fixtures;
+  runs weekly and on parser changes (`fuzz.yml`, hash-pinned install).
+  Addresses the OpenSSF Scorecard Fuzzing check.
+
 Supply-chain surface reduction from the 2026-07 dependency review (no
 user-facing impact — the integration still ships zero pip requirements):
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -167,8 +167,12 @@ Binary-Artifacts and Vulnerabilities. Remaining deductions, triaged:
   secret in CI.
 - `CII-Best-Practices: 0` — bestpractices.dev registration tracked in
   #172 (passing level only; silver+ requires two-person review).
-- `Fuzzing: 0` — tracked in #173; genuine target (`agl/parser.py` parses
-  MITM-influenceable JSON), not badge-chasing.
+- `Fuzzing: 0` — **implemented 2026-07-12** (#173): atheris harness
+  (`tests/fuzz/fuzz_parser.py`) enforcing parser totality and the
+  finite/non-negative numeric guarantee, weekly + per-parser-change CI
+  (`fuzz.yml`, hash-pinned install). If the next weekly Scorecard run
+  does not credit the atheris integration, ClusterFuzzLite is the
+  recognized fallback.
 - `Signed-Releases: -1` — releases carried no assets; from the next tag,
   `release.yml` uploads `haggle-<ver>.zip` plus its Sigstore bundle
   (`.zip.sigstore`), verifiable offline or via

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import math
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, cast
 
 from ..const import TARIFF_OFFPEAK, TARIFF_PEAK, TARIFF_SHOULDER
 from .models import BillPeriod, Contract, DailyReading, IntervalReading, PlanRates
@@ -66,22 +66,67 @@ def _safe_float(raw: Any) -> float:
     return value
 
 
+# --- totality guards -------------------------------------------------------
+# AGL envelopes are dicts/lists/strings at known positions, but response
+# bodies are attacker-influenceable (TLS pinning is warn-only by design), so
+# every parser must be TOTAL over arbitrary JSON: malformed shapes degrade to
+# empty/default results, never raise. Enforced by tests/fuzz/fuzz_parser.py
+# and TestParserTotality in tests/test_parser.py.
+
+
+def _as_dict(raw: Any) -> dict[str, Any]:
+    """Return raw if it is a dict, else {}."""
+    if isinstance(raw, dict):
+        return cast("dict[str, Any]", raw)
+    return {}
+
+
+def _as_list(raw: Any) -> list[Any]:
+    """Return raw if it is a list, else []."""
+    if isinstance(raw, list):
+        return cast("list[Any]", raw)
+    return []
+
+
+def _as_str(raw: Any, default: str = "") -> str:
+    """Return raw if it is a str, else default."""
+    return raw if isinstance(raw, str) else default
+
+
+def _as_id(raw: Any) -> str:
+    """Account/contract identifiers: accept str (or int, coerced), else ''."""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, int) and not isinstance(raw, bool):
+        return str(raw)
+    return ""
+
+
 def parse_overview(data: dict[str, Any]) -> list[Contract]:
-    """Parse /api/v3/overview response."""
+    """Parse /api/v3/overview response.
+
+    A contract entry without a usable contractNumber is skipped — a
+    malformed (or tampered) entry must drop out, not crash discovery.
+    """
     contracts: list[Contract] = []
-    for account in data.get("accounts") or []:
-        account_number: str = account.get("accountNumber", "")
-        address: str = account.get("address", "")
-        for c in account.get("contracts") or []:
+    for account_raw in _as_list(_as_dict(data).get("accounts")):
+        account = _as_dict(account_raw)
+        account_number = _as_id(account.get("accountNumber"))
+        address = _as_str(account.get("address"))
+        for c_raw in _as_list(account.get("contracts")):
+            c = _as_dict(c_raw)
+            contract_number = _as_id(c.get("contractNumber"))
+            if not contract_number:
+                continue
             contracts.append(
                 Contract(
-                    contract_number=c["contractNumber"],
+                    contract_number=contract_number,
                     account_number=account_number,
                     address=address,
-                    fuel_type=c.get("type", ""),
-                    status=c.get("status", ""),
+                    fuel_type=_as_str(c.get("type")),
+                    status=_as_str(c.get("status")),
                     has_solar=bool(c.get("hasSolar", False)),
-                    meter_type=c.get("meterType", "smart"),
+                    meter_type=_as_str(c.get("meterType"), "smart"),
                 )
             )
     return contracts
@@ -110,13 +155,16 @@ def parse_interval_readings(
     """
     _skip_types = {"none", "pending"}
     readings: list[IntervalReading] = []
-    for section in data.get("sections") or []:
-        for item in section.get("items") or []:
-            block = item.get(source_field) or {}
-            rate_type: str = block.get("type", "none")
-            if rate_type in _skip_types:
+    for section_raw in _as_list(_as_dict(data).get("sections")):
+        for item_raw in _as_list(_as_dict(section_raw).get("items")):
+            item = _as_dict(item_raw)
+            block = _as_dict(item.get(source_field))
+            rate_type = block.get("type", "none")
+            # A non-str type can't name a tariff series (and an unhashable
+            # one would blow up the set membership) — treat as malformed.
+            if not isinstance(rate_type, str) or rate_type in _skip_types:
                 continue
-            dt_str: str = item.get("dateTime", "")
+            dt_str = item.get("dateTime", "")
             try:
                 dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
                 if dt.tzinfo is None:
@@ -146,12 +194,16 @@ def parse_daily_readings(data: dict[str, Any]) -> list[DailyReading]:
     kWh from consumption.quantity (outer — see module docstring).
     """
     readings: list[DailyReading] = []
-    for section in data.get("sections") or []:
-        for item in section.get("items") or []:
-            consumption = item.get("consumption") or {}
-            if consumption.get("type") in {"none", "pending"}:
+    for section_raw in _as_list(_as_dict(data).get("sections")):
+        for item_raw in _as_list(_as_dict(section_raw).get("items")):
+            item = _as_dict(item_raw)
+            consumption = _as_dict(item.get("consumption"))
+            rate_type = consumption.get("type")
+            # str-only membership test: an unhashable type value (dict/list)
+            # must not raise; absent/odd types keep the original keep-path.
+            if isinstance(rate_type, str) and rate_type in {"none", "pending"}:
                 continue
-            dt_str: str = item.get("dateTime", "")
+            dt_str = item.get("dateTime", "")
             try:
                 dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
                 day: date = dt.date()
@@ -170,10 +222,11 @@ def parse_bill_period(data: dict[str, Any]) -> BillPeriod:
 
     Path: data["billPeriod"]["current"].
     """
-    current = (data.get("billPeriod") or {}).get("current") or {}
+    payload = _as_dict(data)
+    current = _as_dict(_as_dict(payload.get("billPeriod")).get("current"))
 
-    start_str: str = (current.get("start") or {}).get("date", "")
-    end_str: str = (current.get("end") or {}).get("date", "")
+    start_str = _as_str(_as_dict(current.get("start")).get("date"))
+    end_str = _as_str(_as_dict(current.get("end")).get("date"))
     today_utc = datetime.now(UTC).date()
     try:
         start = date.fromisoformat(start_str)
@@ -184,15 +237,22 @@ def parse_bill_period(data: dict[str, Any]) -> BillPeriod:
     except ValueError, TypeError:
         end = today_utc
 
-    usage = current.get("usage") or {}
-    cost_label: str = usage.get("amount", "$0.00")
+    usage = _as_dict(current.get("usage"))
+    cost_label = _as_str(usage.get("amount"), "$0.00")
 
     # projection is in the overview response but not in the usage summary;
     # return empty string if absent — callers can populate from overview.
-    projection_label: str = data.get("additionalLabelValue", "")
+    projection_label = _as_str(payload.get("additionalLabelValue"))
 
-    quantity_str: str = (usage.get("quantity") or "0").replace(",", "").split()[0]
-    consumption_kwh = _safe_float(quantity_str)
+    # quantity is usually a label ("1,234.5 kWh"); a bare JSON number, empty
+    # or whitespace-only string must degrade to 0.0, never crash
+    # (whitespace previously hit .split()[0] -> IndexError; fuzz-enforced).
+    quantity_raw = usage.get("quantity")
+    if isinstance(quantity_raw, int | float) and not isinstance(quantity_raw, bool):
+        consumption_kwh = _safe_float(quantity_raw)
+    else:
+        parts = _as_str(quantity_raw, "0").replace(",", "").split()
+        consumption_kwh = _safe_float(parts[0] if parts else 0.0)
 
     return BillPeriod(
         start=start,
@@ -205,7 +265,8 @@ def parse_bill_period(data: dict[str, Any]) -> BillPeriod:
 
 def parse_plan(data: dict[str, Any]) -> PlanRates:
     """Parse /api/v2/plan/energy/{contractNumber} response."""
-    product_name: str = data.get("productName", "")
+    payload = _as_dict(data)
+    product_name = _as_str(payload.get("productName"))
     unit_rates: list[dict[str, Any]] = []
     supply_charge: float = 0.0
     tou_unit_rates: dict[str, float] = {}
@@ -214,16 +275,17 @@ def parse_plan(data: dict[str, Any]) -> PlanRates:
     # inferred even when the per-rate title is generic ("First N kWh").
     current_header = ""
 
-    for rate in data.get("gstInclusiveRates") or []:
+    for rate_raw in _as_list(payload.get("gstInclusiveRates")):
+        rate = _as_dict(rate_raw)
         kind = rate.get("kind")
         if kind == "header":
-            current_header = rate.get("title") or ""
+            current_header = _as_str(rate.get("title"))
             continue
         if kind != "detail":
             continue
-        rate_type: str = rate.get("type", "")
+        rate_type = _as_str(rate.get("type"))
         price = _safe_float(rate.get("price"))
-        title: str = rate.get("title") or ""
+        title = _as_str(rate.get("title"))
         if rate_type == "c/day" and "supply" in title.lower():
             supply_charge = price
         if rate_type == "c/kWh":
@@ -249,10 +311,11 @@ def parse_plan(data: dict[str, Any]) -> PlanRates:
     # can never masquerade as the feed-in rate; unmatched plans stay None
     # (sensor reads `unavailable`, never a misleading 0.0).
     feed_in_rate: float | None = None
-    for rate in data.get("gstExclusiveRates") or []:
+    for rate_raw in _as_list(payload.get("gstExclusiveRates")):
+        rate = _as_dict(rate_raw)
         if rate.get("kind") != "detail" or rate.get("type") != "c/kWh":
             continue
-        title = rate.get("title") or ""
+        title = _as_str(rate.get("title"))
         if "feed-in" in title.lower() or "feed in" in title.lower():
             feed_in_rate = _safe_float(rate.get("price"))
             break

--- a/custom_components/haggle/agl/parser.py
+++ b/custom_components/haggle/agl/parser.py
@@ -84,7 +84,7 @@ def _as_dict(raw: Any) -> dict[str, Any]:
 def _as_list(raw: Any) -> list[Any]:
     """Return raw if it is a list, else []."""
     if isinstance(raw, list):
-        return cast("list[Any]", raw)
+        return raw
     return []
 
 

--- a/tests/fuzz/fuzz_parser.py
+++ b/tests/fuzz/fuzz_parser.py
@@ -1,0 +1,96 @@
+"""Atheris fuzz harness for custom_components/haggle/agl/parser.py.
+
+Threat model context (SECURITY.md): TLS pinning is warn-only by design, so
+AGL response bodies are attacker-influenceable. The parsers must therefore be
+TOTAL over arbitrary JSON — a parser crash is a MITM-triggerable failed poll
+cycle. This harness enforces two invariants:
+
+  1. No exception escapes any parse_* function for any json.loads() value.
+  2. Every numeric field returned is finite and >= 0 (the _safe_float
+     guarantee — protects the recorder's cumulative-sum statistics).
+
+Run locally (needs the dev env for the homeassistant import chain):
+    uv sync --extra dev
+    uv pip install --require-hashes -r tests/fuzz/requirements.txt
+    PYTHONPATH=. uv run python tests/fuzz/fuzz_parser.py tests/fixtures
+
+CI: .github/workflows/fuzz.yml — weekly plus on parser/harness changes.
+Deterministic crash regressions live in tests/test_parser.py
+(TestParserTotality); add one there for every crasher this harness finds.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from typing import Any
+
+import atheris
+
+# Pre-load the integration package (and its homeassistant import chain)
+# outside any instrumentation, then instrument only the functions under
+# test — instrumenting the whole HA tree would be prohibitively slow.
+import custom_components.haggle  # noqa: F401
+from custom_components.haggle.agl import parser
+
+for _fn_name in (
+    "parse_overview",
+    "parse_interval_readings",
+    "parse_daily_readings",
+    "parse_bill_period",
+    "parse_plan",
+    "_classify_tariff",
+    "_safe_float",
+    "_as_dict",
+    "_as_list",
+    "_as_str",
+    "_as_id",
+):
+    setattr(parser, _fn_name, atheris.instrument_func(getattr(parser, _fn_name)))
+
+
+def _check_amount(value: float) -> None:
+    if not math.isfinite(value):
+        raise AssertionError(f"non-finite value escaped a parser: {value!r}")
+    if value < 0:
+        raise AssertionError(f"negative value escaped a parser: {value!r}")
+
+
+def test_one_input(data: bytes) -> None:
+    try:
+        obj: Any = json.loads(data)
+    except Exception:
+        return
+
+    for source_field in ("consumption", "feedIn"):
+        for reading in parser.parse_interval_readings(obj, source_field=source_field):
+            _check_amount(reading.kwh)
+            _check_amount(reading.cost_aud)
+
+    for daily in parser.parse_daily_readings(obj):
+        _check_amount(daily.kwh)
+        _check_amount(daily.cost_aud)
+
+    bill = parser.parse_bill_period(obj)
+    _check_amount(bill.consumption_kwh)
+
+    plan = parser.parse_plan(obj)
+    _check_amount(plan.supply_charge_cents_per_day)
+    for band_price in plan.tou_unit_rates.values():
+        _check_amount(band_price)
+    if plan.feed_in_rate_cents_per_kwh is not None:
+        _check_amount(plan.feed_in_rate_cents_per_kwh)
+    for row in plan.unit_rates:
+        _check_amount(row["price"])
+
+    parser.parse_overview(obj)
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fuzz/fuzz_parser.py
+++ b/tests/fuzz/fuzz_parser.py
@@ -28,10 +28,9 @@ from typing import Any
 
 import atheris
 
-# Pre-load the integration package (and its homeassistant import chain)
-# outside any instrumentation, then instrument only the functions under
-# test — instrumenting the whole HA tree would be prohibitively slow.
-import custom_components.haggle  # noqa: F401
+# Instrument only the functions under test (instrument_func below):
+# atheris.instrument_imports()/instrument_all() would sweep in the whole
+# homeassistant import chain and make startup prohibitively slow.
 from custom_components.haggle.agl import parser
 
 for _fn_name in (

--- a/tests/fuzz/requirements.txt
+++ b/tests/fuzz/requirements.txt
@@ -1,0 +1,8 @@
+# Fuzzing-only dependency, installed on top of the uv-synced dev env by
+# .github/workflows/fuzz.yml. Hash-pinned (--require-hashes) so the fuzz
+# job doesn't regress the Scorecard Pinned-Dependencies check. Refresh:
+#   curl -s https://pypi.org/pypi/atheris/json | jq (version + sha256 digests)
+atheris==3.1.0 \
+    --hash=sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b \
+    --hash=sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39 \
+    --hash=sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -758,3 +758,106 @@ class TestParseOverviewSolar:
         assert len(contracts) == 1
         assert contracts[0].has_solar is True
         assert contracts[0].contract_number == "9999999999"
+
+
+# ---------------------------------------------------------------------------
+# Totality (fuzz-enforced) — parsers must never raise on arbitrary JSON
+# ---------------------------------------------------------------------------
+
+
+class TestParserTotality:
+    """Malformed/tampered JSON degrades to empty/default results, never raises.
+
+    Response bodies are attacker-influenceable (TLS pinning is warn-only), so
+    parser totality is a security invariant. The live enforcement is
+    tests/fuzz/fuzz_parser.py; each case below is a crash class in the
+    pre-hardened parser and pins the fix deterministically.
+    """
+
+    def test_bill_period_whitespace_quantity(self) -> None:
+        # Was IndexError: "   ".split()[0] on an empty split result.
+        data = {"billPeriod": {"current": {"usage": {"quantity": "   "}}}}
+        assert parse_bill_period(data).consumption_kwh == 0.0
+
+    def test_bill_period_numeric_quantity(self) -> None:
+        # Was AttributeError: float has no .replace.
+        data = {"billPeriod": {"current": {"usage": {"quantity": 42.5}}}}
+        assert parse_bill_period(data).consumption_kwh == 42.5
+
+    def test_bill_period_non_dict_nodes(self) -> None:
+        # Was AttributeError: .get on list/str/int at every envelope level.
+        for weird in (["x"], "str", 3, {"current": 7}, {"current": {"usage": []}}):
+            bill = parse_bill_period({"billPeriod": weird})
+            assert bill.consumption_kwh == 0.0
+            assert bill.cost_label == "$0.00"
+
+    def test_intervals_non_dict_sections_items_and_blocks(self) -> None:
+        assert parse_interval_readings({"sections": 5}) == []
+        assert parse_interval_readings({"sections": ["x", {"items": "y"}]}) == []
+        data = {"sections": [{"items": ["x", {"consumption": "oops"}]}]}
+        assert parse_interval_readings(data) == []
+
+    def test_intervals_unhashable_type_skipped(self) -> None:
+        # Was TypeError: unhashable dict in `rate_type in _skip_types`.
+        data = {
+            "sections": [
+                {
+                    "items": [
+                        {
+                            "dateTime": "2026-07-01T00:00:00Z",
+                            "consumption": {"type": {}, "quantity": 1, "amount": 1},
+                        }
+                    ]
+                }
+            ]
+        }
+        assert parse_interval_readings(data) == []
+
+    def test_daily_unhashable_type_keeps_original_keep_path(self) -> None:
+        # Daily has no default type; absent/odd types were (and stay) kept —
+        # only the unhashable-crash is fixed, not the keep semantics.
+        data = {
+            "sections": [
+                {
+                    "items": [
+                        {
+                            "dateTime": "2026-07-01T00:00:00Z",
+                            "consumption": {"type": [], "quantity": 2, "amount": 3},
+                        }
+                    ]
+                }
+            ]
+        }
+        readings = parse_daily_readings(data)
+        assert len(readings) == 1
+        assert readings[0].kwh == 2.0
+
+    def test_overview_malformed_contract_skipped_and_int_id_coerced(self) -> None:
+        # Was KeyError on {} (missing contractNumber); junk entries crash-free.
+        data = {
+            "accounts": [
+                "junk",
+                {
+                    "accountNumber": 12345,
+                    "contracts": [{}, "junk", {"contractNumber": 999}],
+                },
+            ]
+        }
+        contracts = parse_overview(data)
+        assert len(contracts) == 1
+        assert contracts[0].contract_number == "999"
+        assert contracts[0].account_number == "12345"
+
+    def test_plan_non_dict_and_non_str_rows(self) -> None:
+        # Was AttributeError: int .lower() via _classify_tariff on int titles,
+        # and .get on non-dict rate rows.
+        data = {
+            "productName": 5,
+            "gstInclusiveRates": ["x", {"kind": "header", "title": 7}, 3],
+            "gstExclusiveRates": "nope",
+        }
+        plan = parse_plan(data)
+        assert plan.product_name == ""
+        assert plan.unit_rates == []
+        assert plan.tou_unit_rates == {}
+        assert plan.feed_in_rate_cents_per_kwh is None


### PR DESCRIPTION
## Summary

- **Hardens `agl/parser.py` to be total over arbitrary JSON.** Writing the fuzz harness for #173 immediately surfaced five MITM-reachable crash classes (each = a remotely triggerable failed poll cycle, per the warn-only TLS-pinning threat model): whitespace/numeric `usage.quantity` (`IndexError`/`AttributeError` in `parse_bill_period`), non-dict nodes at any envelope level, unhashable `consumption.type` values (`TypeError` on set membership), missing `contractNumber` (`KeyError` — entry now skipped instead), and non-str plan titles (`.lower()` on int). New `_as_dict`/`_as_list`/`_as_str`/`_as_id` totality guards; malformed shapes degrade to empty/default results. Daily readings deliberately keep the original absent-type keep-path.
- **Adds continuous fuzzing** (`tests/fuzz/fuzz_parser.py`): atheris harness asserting (1) no exception escapes any `parse_*` for any `json.loads()` value and (2) every numeric output is finite and ≥ 0. Seeded from the anonymised fixtures; instruments only the parser surface (not the HA import tree). Runs weekly + on parser changes via `fuzz.yml`; atheris is hash-pinned (`tests/fuzz/requirements.txt`) so Pinned-Dependencies stays 10.
- **Deterministic regressions** for every crash class in `tests/test_parser.py::TestParserTotality`.
- Docs per checklist: CHANGELOG (Security), AGENTS.md Repo Map (fuzz/, fuzz.yml, parser role), SECURITY.md Scorecard-posture Fuzzing bullet (implemented; ClusterFuzzLite noted as fallback if the next Scorecard run doesn't credit atheris).

Closes #173.

## Test plan

- [x] `ruff check` + `ruff format --check` clean across the tree with the locked ruff 0.15.20
- [ ] Full CI (pytest incl. the new `TestParserTotality`, mypy strict, hassfest, HACS) — via this PR's checks (sandbox has no ≥3.14.2 interpreter)
- [ ] `Fuzz AGL parsers (atheris)` check runs on this PR (parser paths changed → 120 s smoke) — first live run of the harness
- Reviewer note: behavior changes beyond crash-fixes are minimal and deliberate — `parse_overview` now skips a contract entry with no usable `contractNumber` (was: `KeyError` crashing discovery), interval readings skip non-str tariff types (they cannot name a statistics series), and int account/contract numbers are coerced to str.

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry a `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
- [ ] The human maintainer has reviewed and understands every change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBb8BtmUX13XgG56gQFDS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBb8BtmUX13XgG56gQFDS9)_