### PR TITLE
docs: scorecard verification sweep results + ruleset-era release flow

### DIFF
--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,6 +1,6 @@
 ---
 name: release-manager
-description: Use only when cutting a release via the /release command. Bumps manifest.json version, syncs hacs.json, updates CHANGELOG.md, and creates an annotated git tag. Refuses to run if the working tree is dirty or CI is not green.
+description: Use only when cutting a release via the /release command. Bumps manifest.json version, updates CHANGELOG.md, routes the bump through a short-lived PR (the protect-main ruleset blocks direct commits), then signs and pushes the release tag. Refuses to run if the working tree is dirty or CI is not green.
 model: claude-haiku-4-5-20251001
 tools:
   - Read
@@ -10,14 +10,21 @@ tools:
 
 You are a release manager for the haggle Home Assistant integration.
 
+**Flow overview (ruleset era, since 2026-07-12):** `main` has the
+`protect-main` ruleset (PR + status checks required), so the version bump
+CANNOT be committed directly to main. The bump goes via a short-lived PR;
+the tag is then created on the squash-merge commit and pushed separately
+(tag pushes are not blocked by the branch ruleset).
+
 ## Pre-flight checks (always run first)
 
 ```bash
 # 1. Working tree must be clean
 git status --porcelain  # → must be empty
 
-# 2. On main branch
+# 2. On main branch, up to date with origin
 git rev-parse --abbrev-ref HEAD  # → must be "main"
+git fetch origin main && git status  # → "up to date"
 
 # 3. Latest CI must be green
 gh run list --branch main --limit 3
@@ -38,20 +45,49 @@ If any check fails, report the failure and stop. Do not create a release from a 
 2. (hacs.json does NOT contain a version field — skip)
 3. `CHANGELOG.md` → move `## [Unreleased]` items to `## [X.Y.Z] - YYYY-MM-DD`
 
-## Commit and tag
+## Bump via PR (the ruleset blocks direct commits to main)
+
+Make the two edits in a release worktree, commit, and open a PR:
 
 ```bash
+./scripts/wt new chore/release-$VERSION
+# ...make the manifest.json + CHANGELOG.md edits in the worktree...
+cd /Users/dave/projects/haggle.wt/chore-release-$VERSION
 git add custom_components/haggle/manifest.json CHANGELOG.md
 git commit -m "chore(release): v$VERSION
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
 
-git tag -a "v$VERSION" -m "Release v$VERSION"
-git push origin main --tags
+git push -u origin chore/release-$VERSION
+gh pr create --title "chore(release): v$VERSION" --body "Version bump for v$VERSION."
+gh pr checks --watch   # wait for green
+gh pr merge --squash
 ```
+
+## Tag the squash-merge commit (signed)
+
+Tag signing is on repo-wide (`gpg.format ssh`); the guard-main-branch hook
+requires the override prefix for any push from the main worktree — a tag
+push during a release is the sanctioned use:
+
+```bash
+cd /Users/dave/projects/haggle
+git fetch origin main && git pull --ff-only
+git tag -s "v$VERSION" origin/main -m "v$VERSION"
+HAGGLE_ALLOW_MAIN_PUSH=1 git push origin "v$VERSION"
+./scripts/wt rm chore/release-$VERSION
+```
+
+⚠️ `release.yml` uses `gh release create` — it fails if a release for the
+tag already exists, so never pre-create one in the UI.
 
 ## After release
 
-- GitHub Actions `release.yml` picks up the tag and creates a GitHub Release.
+- GitHub Actions `release.yml` picks up the tag and creates a GitHub Release
+  (prerelease if the tag contains `-`) with two assets: `haggle-$VERSION.zip`
+  and `haggle-$VERSION.zip.sigstore`.
+- Verify provenance:
+  `gh release download v$VERSION -p 'haggle-*.zip' -D /tmp && gh attestation verify /tmp/haggle-$VERSION.zip --repo NaanyaBiz/haggle`
 - HACS users will see the update within 24h (HACS polls tags).
-- Update CHANGELOG.md to add a fresh `## [Unreleased]` section.
+- CHANGELOG.md keeps its `## [Unreleased]` section (the bump PR should have
+  left `### Targets for next sprint` under it).

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -26,8 +26,12 @@ If any pre-condition fails, report the failure and stop.
 The `release-manager` subagent, providing it:
 - The target version string
 - The current CHANGELOG.md `## [Unreleased]` section as context
-- Instructions to update `manifest.json`, `CHANGELOG.md`, commit, tag, and push
+- Instructions to update `manifest.json` + `CHANGELOG.md`, route the bump
+  through a short-lived PR (the `protect-main` ruleset blocks direct
+  commits to main), then create a **signed tag on the squash-merge commit**
+  and push it
 
 ## After completion
 
-Print the GitHub Release URL and remind about flipping the repo to public when submitting to HACS.
+Print the GitHub Release URL and confirm the attested assets exist
+(`haggle-<ver>.zip` + `.zip.sigstore`; verify with `gh attestation verify`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -683,6 +683,18 @@ The HA Energy dashboard requires:
   `beta.2` while `beta.4` was live). Use the shields.io release badge or
   "latest pre-release via HACS" phrasing; version numbers belong in the
   CHANGELOG and the releases page.
+- **Don't commit the release version bump directly to `main`.** The
+  `protect-main` ruleset (2026-07-12, #171) requires a PR + green status
+  checks even for the repo owner, so the pre-ruleset release flow
+  (`git commit` on main + `git push origin main --tags`) bounces. The
+  ruleset-era flow: bump via a short-lived PR, then create a **signed** tag
+  on the squash-merge commit (`git tag -s vX.Y.Z origin/main`) and push
+  just the tag with the `HAGGLE_ALLOW_MAIN_PUSH=1` hook override — tag
+  pushes are not blocked by the branch ruleset. See
+  `.claude/agents/release-manager.md` for the full sequence. Also don't
+  enable "require signed commits" in the ruleset: remote agent sessions
+  can't hold the signing key, and squash merges to `main` are
+  GitHub-signed already.
 - **Don't re-add the remote ruff/mypy pre-commit hooks**
   (`astral-sh/ruff-pre-commit`, `pre-commit/mirrors-mypy`). Those hooks run
   a SECOND copy of the toolchain that drifts from `uv.lock` (they had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Scorecard remediation batch verified** (#179): aggregate **7.0 → 7.3**
+  on the post-release run — Fuzzing 0→10 (atheris harness credited),
+  Token-Permissions 9→10, Signed-Releases −1→8 (v0.4.0-beta.5 is the first
+  release with an attested zip asset; attestation verified end-to-end),
+  Branch-Protection −1→3 (`protect-main` ruleset readable; the higher
+  tiers require human approvers — accepted for a solo-maintained repo).
+  All nine regression-watch checks held at 10. SECURITY.md "Own Scorecard
+  posture" rewritten to the new state. Remaining movers: bestpractices.dev
+  badge (#172) and the `Maintained` repo-age gate (~Aug 2026).
+- **Release tags are now SSH-signed**, and local commits are signed by
+  default (`gpg.format ssh`). Server-side signed-commit enforcement is
+  deliberately NOT enabled — squash merges to `main` are already
+  GitHub-signed, and remote agent sessions cannot hold the key.
+
+### Changed
+
+- **Release flow updated for the `protect-main` ruleset** (`/release` +
+  `release-manager`): the version bump now goes via a short-lived PR;
+  the signed tag is created on the squash-merge commit and pushed
+  separately. The old direct-commit-to-main flow bounces off the ruleset.
+
 ### Targets for next sprint
 
 - #141 — user-configured ToU windows: derive tariff bands locally from

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -149,11 +149,30 @@ dependencies measured 5.4–7.4 on OpenSSF Scorecard (transitives up to
 sits in code paths this integration never imports — JWT expiry is
 decoded with hand-rolled base64, not PyJWT).
 
-**Own Scorecard posture.** First self-assessment (Scorecard v5.3.0,
-2026-07-12): **7.0/10**, with 10s on Pinned-Dependencies, SAST, CI-Tests,
-Dangerous-Workflow, Dependency-Update-Tool, Security-Policy, License,
-Binary-Artifacts and Vulnerabilities. Remaining deductions, triaged:
+**Own Scorecard posture.** Baseline self-assessment (Scorecard v5.3.0,
+2026-07-12) was 7.0/10. After the same-day remediation batch — `protect-main`
+ruleset (#171), atheris fuzzing (#173/#177), attested release `v0.4.0-beta.5`
+(#174/#178) — the post-release run scores **7.3/10**, with 10s on
+Pinned-Dependencies, SAST, CI-Tests, Dangerous-Workflow,
+Dependency-Update-Tool, Security-Policy, License, Binary-Artifacts,
+Vulnerabilities, **Fuzzing** (0→10, `PythonAtherisFuzzer integration found`)
+and **Token-Permissions** (9→10, top-level `permissions: {}` on
+`release.yml`). Remaining state, triaged (verification sweep in #179):
 
+- `Signed-Releases: 8` (was -1) — every release now ships
+  `haggle-<ver>.zip` plus its Sigstore bundle (`.zip.sigstore`); verified
+  end-to-end with `gh attestation verify haggle-<ver>.zip --repo
+  NaanyaBiz/haggle` (SLSA provenance v1, digest match, built from the
+  release tag). Scorecard reserves 9–10 for provenance it recognizes by
+  the `*.intoto.jsonl` filename convention; the `.zip.sigstore` bundle
+  *is* SLSA provenance, so the residual 2 points are a naming artifact.
+  **Accepted at 8.**
+- `Branch-Protection: 3` (was -1 internal error) — the `protect-main`
+  ruleset (#171) is readable by the default workflow token (the
+  fine-grained-PAT alternative stays rejected). Scoring above 3 requires
+  required human approvers / codeowner review / stale-review dismissal —
+  the same team-structure wall as Code-Review. **Accepted at 3** for a
+  solo-maintained repo.
 - `Maintained: 0` — pure repo-age gate (<90 days); self-resolves ~2026-08.
 - `Code-Review: 0`, `Contributors: 0` — measure team structure (a second
   human reviewer; multi-organization contributors). **Accepted at 0** for
@@ -162,24 +181,13 @@ Binary-Artifacts and Vulnerabilities. Remaining deductions, triaged:
 - `Packaging: -1` — means "no PyPI/registry publish workflow"; not
   applicable to a HACS-distributed integration. Inconclusive checks are
   excluded from the aggregate. Accepted.
-- `Branch-Protection: -1` — default workflow token cannot read classic
-  protection rules; remediation is a ruleset on `main` (#171), not a PAT
-  secret in CI.
 - `CII-Best-Practices: 0` — bestpractices.dev registration tracked in
   #172 (passing level only; silver+ requires two-person review).
-- `Fuzzing: 0` — **implemented 2026-07-12** (#173): atheris harness
-  (`tests/fuzz/fuzz_parser.py`) enforcing parser totality and the
-  finite/non-negative numeric guarantee, weekly + per-parser-change CI
-  (`fuzz.yml`, hash-pinned install). If the next weekly Scorecard run
-  does not credit the atheris integration, ClusterFuzzLite is the
-  recognized fallback.
-- `Signed-Releases: -1` — releases carried no assets; from the next tag,
-  `release.yml` uploads `haggle-<ver>.zip` plus its Sigstore bundle
-  (`.zip.sigstore`), verifiable offline or via
-  `gh attestation verify haggle-<ver>.zip --repo NaanyaBiz/haggle`.
 
-Realistic ceiling ≈ 8.5–9: the residual gap is the team-structure checks
-above, which a single-maintainer project cannot honestly score on.
+Realistic ceiling ≈ 8.5–9 once the Maintained age gate expires (~2026-08)
+and the #172 badge lands: the residual gap is the team-structure checks
+above (Code-Review, Contributors, Branch-Protection's review tiers), which
+a single-maintainer project cannot honestly score on.
 
 **Accepted risks (diminishing-returns line).**
 `pytest-homeassistant-custom-component` is a single-maintainer package


### PR DESCRIPTION
Close-out docs for the Scorecard verification sweep (#179 — the issue stays open for the #172-dependent CII check and the ~Aug 2026 `Maintained` age-gate update).

**Measured results** (post-release rerun of the scorecard workflow on `main`@49ca8eb, after `v0.4.0-beta.5` existed): aggregate **7.0 → 7.3**.

| Check | Was | Now | Notes |
|---|---|---|---|
| Fuzzing | 0 | **10** | atheris harness credited (`PythonAtherisFuzzer integration found`) |
| Token-Permissions | 9 | **10** | top-level `permissions: {}` in release.yml |
| Signed-Releases | −1 | **8** | 1/1 releases with signed artifact; 9–10 reserved for `*.intoto.jsonl`-named provenance — our `.zip.sigstore` IS SLSA v1 provenance (verified via `gh attestation verify`), so the residual is a filename-convention artifact. Accepted. |
| Branch-Protection | −1 | **3** | ruleset readable by default token; higher tiers = required human approvers → accepted solo-maintainer cap |
| regression watch (9 checks) | 10 | **10** | all held |

**Changes:**
- `SECURITY.md` — "Own Scorecard posture" rewritten from the 7.0 baseline narrative to the verified 7.3 state with per-check triage.
- `CHANGELOG.md` — Unreleased Security/Changed bullets (sweep results, tag signing, release-flow change).
- `.claude/agents/release-manager.md` + `.claude/commands/release.md` — rewritten for the ruleset-era flow (bump via PR → signed tag on the squash commit), which was exercised for real on #178/PR #180; the old direct-commit flow now bounces off `protect-main`.
- `AGENTS.md` — "What NOT to Do" entry for the same footgun, incl. why "require signed commits" must stay off in the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrnhaFhtEZzMqsKQmqo2f
