### PR TITLE
docs: add OpenSSF Best Practices passing badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default (`gpg.format ssh`). Server-side signed-commit enforcement is
   deliberately NOT enabled — squash merges to `main` are already
   GitHub-signed, and remote agent sessions cannot hold the key.
+- **OpenSSF Best Practices badge earned at passing level** (#172):
+  registered as [bestpractices.dev project 13582](https://www.bestpractices.dev/projects/13582)
+  with all 66 passing criteria answered and evidenced (100%); badge added
+  to the README. Feeds the Scorecard `CII-Best-Practices` check (0 → 5 on
+  its next run).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=NaanyaBiz&repository=haggle&category=integration)
 [![Latest release](https://img.shields.io/github/v/release/NaanyaBiz/haggle?include_prereleases&label=latest)](https://github.com/NaanyaBiz/haggle/releases)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/NaanyaBiz/haggle/badge)](https://scorecard.dev/viewer/?uri=github.com/NaanyaBiz/haggle)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13582/badge)](https://www.bestpractices.dev/projects/13582)
 
 Home Assistant custom integration that pulls smart-meter usage from
 [AGL Australia](https://www.agl.com.au/) and feeds it into the HA Energy


### PR DESCRIPTION
bestpractices.dev registration done (project [13582](https://www.bestpractices.dev/projects/13582)) — passing level earned at 100% with all 66 criteria answered and evidenced against the repo (SECURITY.md, CONTRIBUTING.md, ci.yml, fuzz.yml, Sigstore attestation, etc.). This PR adds the badge next to the Scorecard badge and records the milestone in the CHANGELOG.

Closes #172. The Scorecard `CII-Best-Practices` check (currently 0) picks the badge up automatically — the scorecard workflow run triggered by merging this PR should score it 5 (expected aggregate ~7.6, tracked in #179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrnhaFhtEZzMqsKQmqo2f