### PR TITLE
docs: record Scorecard 7.5 with CII-Best-Practices 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Scorecard remediation batch verified** (#179): aggregate **7.0 → 7.3**
-  on the post-release run — Fuzzing 0→10 (atheris harness credited),
+- **Scorecard remediation batch verified** (#179): aggregate **7.0 → 7.5**
+  across the same-day runs — Fuzzing 0→10 (atheris harness credited),
   Token-Permissions 9→10, Signed-Releases −1→8 (v0.4.0-beta.5 is the first
   release with an attested zip asset; attestation verified end-to-end),
   Branch-Protection −1→3 (`protect-main` ruleset readable; the higher
-  tiers require human approvers — accepted for a solo-maintained repo).
-  All nine regression-watch checks held at 10. SECURITY.md "Own Scorecard
-  posture" rewritten to the new state. Remaining movers: bestpractices.dev
-  badge (#172) and the `Maintained` repo-age gate (~Aug 2026).
+  tiers require human approvers — accepted for a solo-maintained repo),
+  CII-Best-Practices 0→5 (badge detected: Passing). All nine
+  regression-watch checks held at 10. SECURITY.md "Own Scorecard posture"
+  rewritten to the new state. Last mover: the `Maintained` repo-age gate
+  (~Aug 2026).
 - **Release tags are now SSH-signed**, and local commits are signed by
   default (`gpg.format ssh`). Server-side signed-commit enforcement is
   deliberately NOT enabled — squash merges to `main` are already
@@ -25,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OpenSSF Best Practices badge earned at passing level** (#172):
   registered as [bestpractices.dev project 13582](https://www.bestpractices.dev/projects/13582)
   with all 66 passing criteria answered and evidenced (100%); badge added
-  to the README. Feeds the Scorecard `CII-Best-Practices` check (0 → 5 on
-  its next run).
+  to the README. Confirmed scored by the Scorecard `CII-Best-Practices`
+  check ("badge detected: Passing", 0 → 5).
 
 ### Changed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,12 +152,14 @@ decoded with hand-rolled base64, not PyJWT).
 **Own Scorecard posture.** Baseline self-assessment (Scorecard v5.3.0,
 2026-07-12) was 7.0/10. After the same-day remediation batch — `protect-main`
 ruleset (#171), atheris fuzzing (#173/#177), attested release `v0.4.0-beta.5`
-(#174/#178) — the post-release run scores **7.3/10**, with 10s on
-Pinned-Dependencies, SAST, CI-Tests, Dangerous-Workflow,
-Dependency-Update-Tool, Security-Policy, License, Binary-Artifacts,
-Vulnerabilities, **Fuzzing** (0→10, `PythonAtherisFuzzer integration found`)
-and **Token-Permissions** (9→10, top-level `permissions: {}` on
-`release.yml`). Remaining state, triaged (verification sweep in #179):
+(#174/#178), plus the OpenSSF Best Practices passing badge (#172,
+[project 13582](https://www.bestpractices.dev/projects/13582)) — the
+current run scores **7.5/10**, with 10s on Pinned-Dependencies, SAST,
+CI-Tests, Dangerous-Workflow, Dependency-Update-Tool, Security-Policy,
+License, Binary-Artifacts, Vulnerabilities, **Fuzzing** (0→10,
+`PythonAtherisFuzzer integration found`) and **Token-Permissions** (9→10,
+top-level `permissions: {}` on `release.yml`). Remaining state, triaged
+(verification sweep in #179):
 
 - `Signed-Releases: 8` (was -1) — every release now ships
   `haggle-<ver>.zip` plus its Sigstore bundle (`.zip.sigstore`); verified
@@ -181,13 +183,15 @@ and **Token-Permissions** (9→10, top-level `permissions: {}` on
 - `Packaging: -1` — means "no PyPI/registry publish workflow"; not
   applicable to a HACS-distributed integration. Inconclusive checks are
   excluded from the aggregate. Accepted.
-- `CII-Best-Practices: 0` — bestpractices.dev registration tracked in
-  #172 (passing level only; silver+ requires two-person review).
+- `CII-Best-Practices: 5` (was 0) — passing badge earned 2026-07-12 at
+  100% of criteria (all 66 answered with evidence). **Accepted at 5**:
+  silver requires further process docs and gold requires ≥2 maintainers —
+  the same team-structure wall.
 
-Realistic ceiling ≈ 8.5–9 once the Maintained age gate expires (~2026-08)
-and the #172 badge lands: the residual gap is the team-structure checks
-above (Code-Review, Contributors, Branch-Protection's review tiers), which
-a single-maintainer project cannot honestly score on.
+Realistic ceiling ≈ 8.5–9 once the Maintained age gate expires (~2026-08):
+the residual gap is the team-structure checks above (Code-Review,
+Contributors, Branch-Protection's review tiers), which a single-maintainer
+project cannot honestly score on.
 
 **Accepted risks (diminishing-returns line).**
 `pytest-homeassistant-custom-component` is a single-maintainer package


### PR DESCRIPTION
Same-day follow-up to #181/#182: the post-badge Scorecard run scores **7.5** with `CII-Best-Practices: 5` ("badge detected: Passing"). Updates SECURITY.md's posture paragraph and the CHANGELOG bullets so they don't advertise stale numbers for a month. Part of #179 — only the ~Aug `Maintained` age gate remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrnhaFhtEZzMqsKQmqo2f