### PR TITLE
ci: add secret-scan, dependency-review, workflow-audit and quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
   pull_request:
     branches: [main]
 
-permissions: read-all
+# Least-privilege: every job only reads the tree (checkout) and, for
+# dependency-review, the dependency graph — both covered by contents: read.
+# (zizmor excessive-permissions gate rejects blanket read-all.)
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -18,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -33,17 +39,90 @@ jobs:
         run: uv sync --extra dev
 
       - name: Ruff lint
-        run: uv run ruff check custom_components/ tests/
+        run: uv run ruff check custom_components/ tests/ scripts/
 
       - name: Ruff format check
-        run: uv run ruff format --check custom_components/ tests/
+        run: uv run ruff format --check custom_components/ tests/ scripts/
 
       - name: Mypy
         run: uv run mypy custom_components/haggle
+
+      # shellcheck + actionlint run through pre-commit so CI and local
+      # commits use the SAME frozen-SHA hook revs (anti-drift rule at the
+      # top of .pre-commit-config.yaml). zizmor comes from uv.lock.
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Shellcheck (pinned pre-commit rev)
+        run: uv run pre-commit run shellcheck --all-files
+
+      - name: Actionlint (pinned pre-commit rev)
+        run: uv run pre-commit run actionlint --all-files
+
+      - name: Zizmor workflow audit (uv.lock version)
+        run: uv run zizmor --offline --min-severity medium .github/workflows/
 
       # Coverage is reported inline via --cov-report=term-missing (pyproject
       # addopts). No external coverage vendor: the Codecov upload was
       # write-only (no badge, no consumer) and third-party code on every PR
       # is surface we don't need (2026-07 dependency review).
+      # --cov-fail-under lives HERE, not in pyproject addopts, so local
+      # single-file runs (uv run pytest tests/test_parser.py) stay usable —
+      # a subset run computes low coverage by construction and would always
+      # trip an addopts-level floor. Current combined (lines+branches) total:
+      # 90.0% on 2026-07-13. Floor 89 = regression gate with ~1pt headroom.
+      # Ratchet UP as the total rises; never lower it to make a PR pass.
       - name: Pytest
-        run: uv run pytest
+        run: uv run pytest --cov-fail-under=89
+
+  gitleaks:
+    name: Gitleaks (full history)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0  # full history — the scan covers every commit
+          persist-credentials: false
+
+      # Checksum-pinned release binary rather than gitleaks/gitleaks-action:
+      # stricter than a SHA-pinned action (the action downloads the gitleaks
+      # binary at runtime by mutable version tag), zero third-party action
+      # code, and the version matches the pre-commit hook rev — update BOTH
+      # together (pre-commit autoupdate --freeze + bump this URL/checksum).
+      - name: Install gitleaks v8.30.1 (checksum-pinned)
+        run: |
+          cd "$RUNNER_TEMP"
+          curl -fsSLo gitleaks.tar.gz \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+
+      - name: Scan full git history
+        run: '"$RUNNER_TEMP/gitleaks" git --no-banner --redact .'
+
+  dependency-review:
+    name: Dependency review
+    # PR-only: the action diffs base..head dependency manifests; push events
+    # to main have no base ref. WP1 makes this a required PR check.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Dependency review (vulnerabilities + licence gate)
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          vulnerability-check: true
+          license-check: true
+          # Apache-2.0 repo. The dependency estate is dev/CI-only
+          # (manifest.json ships zero runtime requirements), so this gate
+          # protects contributor machines and CI, not the shipped artifact.
+          # Deny strong/network copyleft only; weak copyleft (LGPL/MPL) dev
+          # tools are compatible with how this repo uses them.
+          deny-licenses: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later, SSPL-1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,12 @@ jobs:
           fail-on-severity: moderate
           vulnerability-check: true
           license-check: true
+          # Explicit, not default (default blocks runtime scope only).
+          # GitHub currently classifies uv.lock deps as runtime scope
+          # (verified on this PR's snapshot), so the default happens to
+          # cover us today — pinning all three scopes removes the
+          # dependence on that classification behaviour.
+          fail-on-scopes: runtime, development, unknown
           # Apache-2.0 repo. The dependency estate is dev/CI-only
           # (manifest.json ships zero runtime requirements), so this gate
           # protects contributor machines and CI, not the shipped artifact.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,23 @@ jobs:
           echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tar.gz" | sha256sum -c -
           tar -xzf gitleaks.tar.gz gitleaks
 
+      # Self-test: prove the scanner detects before trusting its verdict.
+      # A scanner that silently matches nothing (the failure mode alleged —
+      # and refuted — in gitleaks#2170, but real for any broken build) must
+      # fail this job, never greenlight the history scan. The seeded value
+      # is assembled at runtime so the workflow source itself can't match
+      # the github-pat rule.
+      - name: Scanner self-test (must detect seeded token)
+        run: |
+          mkdir -p "$RUNNER_TEMP/gitleaks-selftest"
+          printf 'token = "ghp_%s"\n' "Xk92mQfR7vLpTz3NwYbJc5HdGs81uEaMnB4o" \
+            > "$RUNNER_TEMP/gitleaks-selftest/seed.txt"
+          if "$RUNNER_TEMP/gitleaks" dir --no-banner --redact "$RUNNER_TEMP/gitleaks-selftest"; then
+            echo "::error::gitleaks did not detect the seeded token — scanner silently broken; history scan verdict is untrustworthy"
+            exit 1
+          fi
+          echo "self-test OK: seeded token detected"
+
       - name: Scan full git history
         run: '"$RUNNER_TEMP/gitleaks" git --no-banner --redact .'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main@2026-01-26
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -14,4 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master@2026-04-07

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,10 +2,13 @@
 # The two highest-consequence leak classes for this repo are NOT provider
 # patterns (GitHub push protection cannot see them; the default gitleaks
 # rules were tested and also miss them):
-#   1. An Auth0 opaque rotating refresh token (the user's AGL credential).
-#   2. An un-anonymised AGL API capture (real accountNumber/contractNumber).
+#   1. An Auth0 opaque rotating refresh token (the user's AGL credential) —
+#      quoted (JSON/py) or unquoted (.env / form-encoded / curl captures).
+#   2. An un-anonymised AGL customer identifier: camelCase API fields,
+#      snake_case persisted HA keys, or embedded in a usage-endpoint URL
+#      path (pasted logs/captures) — the three places the client puts it.
 # Canonical anonymised placeholders (AGENTS.md "Contributing" §2) are
-# allowlisted; anything else in those fields is treated as a leak.
+# allowlisted; anything else in those positions is treated as a leak.
 # Used automatically by: the pre-commit gitleaks hook, and the CI
 # "Gitleaks (full history)" job (gitleaks auto-loads the target repo's
 # root .gitleaks.toml).
@@ -15,8 +18,8 @@ useDefault = true
 
 [[rules]]
 id = "auth0-opaque-refresh-token"
-description = "Auth0/AGL opaque refresh token (key-anchored, long value)"
-regex = '''(?i)refresh[_-]?token["']?\s*[:=]\s*["']([A-Za-z0-9._~+/=-]{60,400})["']'''
+description = "Auth0/AGL opaque refresh token (key-anchored, long value, quoted or unquoted)"
+regex = '''(?i)refresh[_-]?token["']?\s*[:=]\s*["']?([A-Za-z0-9._~+/-]{60,400})'''
 secretGroup = 1
 entropy = 3.0
 keywords = ["refresh_token", "refreshtoken", "refresh-token"]
@@ -27,11 +30,24 @@ regexes = ['''(?i)fake|test|example|placeholder|redacted''']
 
 [[rules]]
 id = "agl-real-customer-identifier"
-description = "AGL accountNumber/contractNumber that is not the canonical anonymised placeholder"
-regex = '''"(?:accountNumber|contractNumber)"\s*:\s*"?(\d{6,12})'''
+description = "AGL accountNumber/contractNumber (camelCase API field or snake_case persisted key) that is not the canonical anonymised placeholder"
+regex = '''(?i)["']?(?:accountNumber|contractNumber|account_number|contract_number)["']?\s*[:=]\s*["']?(\d{6,12})'''
 secretGroup = 1
-keywords = ["accountnumber", "contractnumber"]
+keywords = ["accountnumber", "contractnumber", "account_number", "contract_number"]
 
 [[rules.allowlists]]
 regexTarget = "secret"
-regexes = ['''^(?:1234567890|9999999999)$''']
+# Canonical placeholders plus any all-same-digit synthetic value
+# (tests use 0000000000 / 1111111111 shapes; RE2 has no backrefs).
+regexes = ['''^(?:1234567890|9999999999|0+|1+|2+|3+|4+|5+|6+|7+|8+|9+)$''']
+
+[[rules]]
+id = "agl-contract-in-usage-url"
+description = "AGL contract number embedded in a usage-endpoint URL path (pasted capture/log)"
+regex = '''(?i)/usage/smart/Electricity(?:Solar)?/(\d{6,12})[/?]'''
+secretGroup = 1
+keywords = ["usage/smart"]
+
+[[rules.allowlists]]
+regexTarget = "secret"
+regexes = ['''^(?:1234567890|9999999999|0+|1+|2+|3+|4+|5+|6+|7+|8+|9+)$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,37 @@
+# Haggle-specific gitleaks rules layered on the default ruleset.
+# The two highest-consequence leak classes for this repo are NOT provider
+# patterns (GitHub push protection cannot see them; the default gitleaks
+# rules were tested and also miss them):
+#   1. An Auth0 opaque rotating refresh token (the user's AGL credential).
+#   2. An un-anonymised AGL API capture (real accountNumber/contractNumber).
+# Canonical anonymised placeholders (AGENTS.md "Contributing" §2) are
+# allowlisted; anything else in those fields is treated as a leak.
+# Used automatically by: the pre-commit gitleaks hook, and the CI
+# "Gitleaks (full history)" job (gitleaks auto-loads the target repo's
+# root .gitleaks.toml).
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "auth0-opaque-refresh-token"
+description = "Auth0/AGL opaque refresh token (key-anchored, long value)"
+regex = '''(?i)refresh[_-]?token["']?\s*[:=]\s*["']([A-Za-z0-9._~+/=-]{60,400})["']'''
+secretGroup = 1
+entropy = 3.0
+keywords = ["refresh_token", "refreshtoken", "refresh-token"]
+
+[[rules.allowlists]]
+regexTarget = "secret"
+regexes = ['''(?i)fake|test|example|placeholder|redacted''']
+
+[[rules]]
+id = "agl-real-customer-identifier"
+description = "AGL accountNumber/contractNumber that is not the canonical anonymised placeholder"
+regex = '''"(?:accountNumber|contractNumber)"\s*:\s*"?(\d{6,12})'''
+secretGroup = 1
+keywords = ["accountnumber", "contractnumber"]
+
+[[rules.allowlists]]
+regexTarget = "secret"
+regexes = ['''^(?:1234567890|9999999999)$''']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,9 +51,37 @@ repos:
 
   # Secret scanning
   - repo: https://github.com/gitleaks/gitleaks
-    rev: 43fae355e6fe4d99d2a7b240a224b85e2903aeb4 # frozen: v8.21.2
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # frozen: v8.30.1
     hooks:
       - id: gitleaks
+
+  # Shell scripts — scripts/check_claude_coauthor.sh, scripts/wt (shebang-
+  # detected), .claude/hooks/*.sh. Several implement repo controls (the
+  # provenance trailer, the branch guard), so they get linted like code.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # GitHub Actions workflow lint. language: golang — pre-commit >= 3.0
+  # bootstraps its own Go toolchain, no dev-machine Go install required.
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
+    hooks:
+      - id: actionlint
+
+  # Workflow security audit — zizmor from uv.lock (same anti-drift rule as
+  # the ruff/mypy local hooks above; Dependabot maintains the version).
+  # --offline: online audits need GitHub API access; offline covers all the
+  # rules we gate on. Threshold mirrors the CI step exactly.
+  - repo: local
+    hooks:
+      - id: zizmor
+        name: zizmor (uv.lock version)
+        language: system
+        entry: uv run zizmor --offline --min-severity medium
+        files: ^\.github/workflows/.*\.ya?ml$
+        require_serial: true
 
   # Conventional Commits
   - repo: https://github.com/compilerla/conventional-pre-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ scripts/
 
 .github/
 ├── workflows/
-│   ├── ci.yml           # ruff + mypy + pytest matrix (Python 3.14); coverage inline, no external vendor
+│   ├── ci.yml           # ruff + mypy + pytest (Python 3.14, coverage floor 89) + gitleaks full-history scan + dependency-review + shellcheck/actionlint/zizmor
 │   ├── hacs.yml         # HACS validation
 │   ├── hassfest.yml     # Home Assistant integration manifest validation
 │   ├── release.yml      # tag-triggered GitHub Release (first-party gh CLI) + attested zip asset (Sigstore)
@@ -112,6 +112,7 @@ scripts/
 └── dependabot.yml       # weekly pip + github-actions updates, grouped into one PR per ecosystem
 
 # Repo-root posture files
+.gitleaks.toml           # repo-specific secret rules (Auth0 refresh tokens, real AGL account/contract numbers) layered on gitleaks defaults
 SECURITY.md              # disclosure path + threat-model summary
 CONTRIBUTING.md          # dev loop + commit conventions + PR checklist
 CODE_OF_CONDUCT.md       # Contributor Covenant 2.1
@@ -714,6 +715,12 @@ The HA Energy dashboard requires:
   review removed the write-only Codecov upload from `ci.yml` — don't
   re-add external telemetry vendors to CI without a consumer for their
   output.
+- **Don't lower `--cov-fail-under` in ci.yml to make a PR pass, and don't
+  raise `max-complexity` to absorb a new C901 offender.** Both floors are
+  deliberate ratchet gates (SDLC review CO-17.2): coverage ratchets UP as the
+  total rises; a new over-complexity function gets decomposed, not legalized.
+  The single sanctioned exemption is `coordinator._fetch_range` (noqa'd with
+  rationale + debt issue).
 - **Don't exact-pin `pytest-homeassistant-custom-component` to a single
   patch.** Upstream releases near-daily, so an exact pin manufactures a
   guaranteed weekly Dependabot PR and has caused resolver deadlocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- **Merge-blocking security and quality gates** (SDLC remediation WP2, PR-A):
+  gitleaks full-history secret scan with repo-specific Auth0/AGL rules
+  (`.gitleaks.toml`) closing the `--no-verify` bypass; PR dependency-review
+  (vulnerabilities ≥ moderate + strong-copyleft licence denylist); coverage
+  floor `--cov-fail-under=89`; ruff C901 complexity gate at 12; shellcheck +
+  actionlint + zizmor (medium+) over scripts and workflows;
+  `persist-credentials: false` on every checkout.
+
 ### Security
 
 - **Scorecard remediation batch verified** (#179): aggregate **7.0 → 7.5**

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -940,7 +940,11 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         credit = max(0.0, self._latest_generation_credit - base_credit)
         return kwh, credit
 
-    async def _fetch_range(
+    # C901: complexity 13 vs gate of 12 — the 429-break / heal-accounting /
+    # per-series-range logic is deliberately in one place. Decomposition is
+    # tracked in the debt issue created with this change; do not grow this
+    # function further.
+    async def _fetch_range(  # noqa: C901
         self,
         cons_range: tuple[date, date] | None,
         solar_range: tuple[date, date] | None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
     "ruff>=0.15.20",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
+    # Workflow security audit (CI step + pre-commit local hook). Rust binary
+    # wheels from PyPI; version governed by uv.lock like ruff/mypy.
+    "zizmor>=1.26",
 ]
 
 [project.urls]
@@ -72,6 +75,7 @@ select = [
     "I",           # isort
     "UP",          # pyupgrade
     "B",           # flake8-bugbear
+    "C901",        # mccabe complexity (threshold under [tool.ruff.lint.mccabe])
     "SIM",         # flake8-simplify
     "RUF",         # ruff-specific
     "ASYNC",       # flake8-async (catches blocking I/O in async)
@@ -96,6 +100,12 @@ ignore = [
 "custom_components/haggle/const.py" = ["S105"]   # CONF_*_TOKEN strings are key names, not secrets
 "custom_components/haggle/coordinator.py" = ["PLC0415"]   # recorder imports must be local — optional HA component
 "custom_components/haggle/diagnostics.py" = ["PLC0415"]   # same recorder-import constraint as coordinator.py
+
+[tool.ruff.lint.mccabe]
+# Gate new code at 12. The single function above this today,
+# coordinator._fetch_range (13), carries a rationale'd noqa and a debt issue
+# to decompose it — do not raise this number to absorb new offenders.
+max-complexity = 12
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -1068,6 +1068,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -1081,6 +1082,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-homeassistant-custom-component", marker = "extra == 'dev'", specifier = ">=0.13.344,<0.14" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20" },
+    { name = "zizmor", marker = "extra == 'dev'", specifier = ">=1.26" },
 ]
 provides-extras = ["dev"]
 
@@ -2911,4 +2913,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/77/3c292c091b636c3a0af5c69e1d1ffe83261737d34075efc889fe25380b32/zeroconf-0.150.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c8ccc9e1772ce0030f77e6a49542e9b7ca4e8ae9ce1bef84a3a983be68ddf81c", size = 4225357, upload-time = "2026-06-22T18:25:30.468Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5b/54758b003fe687757f9d8313a8ceaa7560e1c392ac109890782283ba1840/zeroconf-0.150.0-cp314-cp314t-win32.whl", hash = "sha256:576e72a9e9140d96ae110ceb0935f06fa41eeea8b2be53e442a6a00c84035194", size = 2599274, upload-time = "2026-06-22T18:25:32.463Z" },
     { url = "https://files.pythonhosted.org/packages/ff/be/9eb576ae5eeede25cd1e59f0be1ce6b2fcf7aa5a4ab4d6d05de2d30efc4a/zeroconf-0.150.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bdae152e80b848117691ab59aa8b16bf15323c0e9f3ddc38c6345af95a700a84", size = 3106484, upload-time = "2026-06-22T18:25:34.89Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a0/a29b38e24981b4bb41db4f292b2c9fb9ddf8b05d6b724abddd7bd108b621/zizmor-1.26.1.tar.gz", hash = "sha256:0c2cc575007a4db99d89d5acc6120cfa7b61504bc2394c3b50af348c73f1916e", size = 535275, upload-time = "2026-06-21T02:47:21.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/a9/2f47f7db8db9491025e00a7f1a0f25d32b642c0285b2fe070ac63e679b47/zizmor-1.26.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7ea21ca959c8e888de238fee81d73a1fdf89a82067eac75b8f1acdbd23e2eeaf", size = 9086061, upload-time = "2026-06-21T02:46:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/58/92/cf6801f01e1d65cbda89a2e2926ea42caf1daad9ffa3f1fc88e4c68f48a9/zizmor-1.26.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:78083b495593f8b0b9dec14036a0836a5afcddda8a40738336ff4e399476b741", size = 8626865, upload-time = "2026-06-21T02:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b1/ff38fc2921f1fb13244bb3a3642c4b45ecf3946c279942aafcb5dbf55a57/zizmor-1.26.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:bb7ebbe565a3742eb49a590352127ad549bb122b9b4ff9424ebab7525fa3b6b6", size = 8843965, upload-time = "2026-06-21T02:47:03.318Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/06/c07fd0eeef0427d93e99d552d5386526fbcd0bf05fc95cd37bdc6229fccb/zizmor-1.26.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:d3049010b6bd6f849413b6d20c28e0c677b90e0a5b2bc73cbee7f7bd86dc5828", size = 8386985, upload-time = "2026-06-21T02:47:05.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/61ab13d45d6ce57ef5a08bb3246981f62e30bb4938098b17bb7b88110b79/zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6a958d8a0941d7e1d0de8436670b5cb7fc64c8028b4d16e3f519ccc77f953cef", size = 9257232, upload-time = "2026-06-21T02:47:07.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ad/bd74a96cb02045414ec5b573cd97ff3b82a97fd0bd6658f93c36a011c439/zizmor-1.26.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d2744cdf944436ca7a009ae8b626a017a40381ec990216abd6cf6b8beb23323a", size = 8873798, upload-time = "2026-06-21T02:47:10.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7e/fb3d608ee11e2f619d43ad93bab46eb7b32769fa82b1d86fd23f27c2585b/zizmor-1.26.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:44099f426af9da750ff9f548a0084e11d7d83e0158fe1a2778672398d728efdd", size = 8350857, upload-time = "2026-06-21T02:47:12.748Z" },
+    { url = "https://files.pythonhosted.org/packages/27/cc/82d7a838c2d490071555c364f90eb851044b3eeefc1d68612179a2cd1ae5/zizmor-1.26.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8313cc264dec792f00a7328eb7c8e89e7d62d54f950fc897d1e6a5a6e5762203", size = 9351148, upload-time = "2026-06-21T02:47:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ee/d2a2301f30b9e1bf0d721bfd31739acd71e048757f9ba79279583eb30ac0/zizmor-1.26.1-py3-none-win32.whl", hash = "sha256:c96d7787d69fb298eae939e00dfdf7f534d7dfbd9cc17ab442c0650a56851415", size = 7531021, upload-time = "2026-06-21T02:47:17.247Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/ad561f3a5057d3c0f152002e180a3a5745e72ea9d69bf66450ef9f5d3fe5/zizmor-1.26.1-py3-none-win_amd64.whl", hash = "sha256:0a05acf6068609fb6df3b137276cf18a686226a1e0e207941cb34a85929f16cf", size = 8616584, upload-time = "2026-06-21T02:47:19.094Z" },
 ]


### PR DESCRIPTION
## SDLC remediation — WP2 PR-A

Implements the merge-blocking CI gates from [`docs/compliance/remediation-program-2026-07.md`](../blob/main/docs/compliance/remediation-program-2026-07.md) work package 2 (spec: `remediation-2026-07-workpapers/specs/wp2-ci-gates.md`).

### What gates now
- **Gitleaks (full history)** — checksum-pinned v8.30.1 binary + repo-specific `.gitleaks.toml` rules for Auth0 opaque refresh tokens and un-anonymised AGL account/contract numbers. Default rules were empirically proven to miss both classes; custom rules caught 2/2 planted true positives with 0 false positives over full history. Closes the `--no-verify`/hookless bypass (CO-8.1).
- **Dependency review** — PR-only; fails on vulnerabilities ≥ moderate and strong/network-copyleft licences (GPL/AGPL/SSPL). Known limitation: NOASSERTION-licence packages are listed but not blocked (no fail-on-unknown option in the action). (CO-5.1, CO-7.1)
- **Coverage floor 89** — on the ci.yml pytest command, deliberately NOT in pyproject addopts so local subset runs stay usable. Live branch-combined total: exactly 90.00%. Ratchet up only. (CO-15.2, CO-17.2)
- **C901 complexity ≤ 12** — one sanctioned noqa on `coordinator._fetch_range` (13) with rationale; decomposition debt issue follows post-merge. (CO-17.2)
- **shellcheck + actionlint + zizmor (medium+)** — frozen-SHA pre-commit hooks mirrored as CI steps; zizmor version governed by uv.lock. All 6 shell scripts + 7 workflows pass today. (CO-17.1)

### Hardening ride-alongs
- `persist-credentials: false` on every checkout (zizmor artipacked; matches the scorecard.yml precedent from #168) — includes the one-line change to release.yml. No workflow performs authenticated git ops after checkout.
- ci.yml `permissions: read-all` → `contents: read` (zizmor excessive-permissions medium, surfaced by the new gate itself).
- Not fixed here by design: release.yml's 4 info-level template-injection findings — below the medium gate; routed to the release-chain work package which rewrites that file.

### Validation (all local, from the spec's ladder)
- `pre-commit run --all-files`: 12/12 hooks pass incl. the three new ones
- `pytest --cov-fail-under=89`: 237 passed, total 90.00%
- `zizmor --offline --min-severity medium .github/workflows/`: exit 0
- gitleaks full-history scan: no leaks; planted-secret probe outside the repo: 2/2 rules fire

### Follow-ups (not this PR)
- WP1 Step 7 marks `Gitleaks (full history)` + `Dependency review` required after they report green here
- Debt issue for `_fetch_range` decomposition (created post-merge)
- PR-B rewrites fuzz.yml (unconditional PR smoke + corpus persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsw8k4NU2AqSkrWZStXnj4