### PR TITLE
ci(fuzz): run smoke on every PR, persist corpus, upload crash artifacts

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,8 +3,11 @@ name: Fuzz
 # Atheris fuzzing of the AGL response parsers (tests/fuzz/fuzz_parser.py).
 # The parsers are the trust boundary for attacker-influenceable JSON (TLS
 # pinning is warn-only — see SECURITY.md), so they must be total over
-# arbitrary input. Weekly deep run + a short run when the parser or the
-# harness changes. Closes the Scorecard Fuzzing gap (#173).
+# arbitrary input. Weekly deep run (600 s) + a 120 s smoke on EVERY PR —
+# unconditional (no paths: filter) so the check can be made required; a
+# path-filtered required check wedges non-matching PRs on an "expected"
+# status forever. Corpus persists across runs via actions/cache; crash
+# inputs upload as artifacts on failure. (#173; SDLC review CO-7.2)
 
 on:
   schedule:
@@ -14,10 +17,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - "custom_components/haggle/agl/**"
-      - "tests/fuzz/**"
-      - ".github/workflows/fuzz.yml"
 
 permissions: read-all
 
@@ -46,13 +45,50 @@ jobs:
       - name: Install atheris (hash-pinned)
         run: uv pip install --require-hashes -r tests/fuzz/requirements.txt
 
+      # Caches are immutable per key: every run saves under a fresh key and
+      # restores the newest prior snapshot via the restore-keys prefix.
+      # PR runs can read main-scoped caches (default-branch caches are
+      # visible to every ref) but save only into their own PR scope — the
+      # weekly scheduled runs are what deepen the persistent corpus.
+      - name: Restore fuzz corpus
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/corpus
+          key: fuzz-corpus-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            fuzz-corpus-
+
+      - name: Seed corpus from fixtures
+        # Plain cp, not cp -n: coreutils >= 9.2 exits non-zero when -n skips
+        # an existing file, and re-copying identical fixtures is idempotent.
+        # Evolved corpus entries have content-hash names — never clobbered.
+        run: |
+          mkdir -p /tmp/corpus /tmp/crash-artifacts
+          cp tests/fixtures/*.json /tmp/corpus/
+
       - name: Fuzz parsers
         env:
           PYTHONPATH: .
           # Short smoke on PRs; deeper sweep on the weekly schedule.
           TIME_BUDGET: ${{ github.event_name == 'pull_request' && '120' || '600' }}
         run: |
-          mkdir -p /tmp/corpus
-          cp tests/fixtures/*.json /tmp/corpus/
           uv run python tests/fuzz/fuzz_parser.py /tmp/corpus \
+            -artifact_prefix=/tmp/crash-artifacts/ \
             -max_total_time="${TIME_BUDGET}" -print_final_stats=1
+
+      # Save even when fuzzing failed: coverage-increasing inputs found
+      # before a crash are exactly the ones worth keeping for the rerun.
+      - name: Save fuzz corpus
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/corpus
+          key: fuzz-corpus-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crash-artifacts
+          path: /tmp/crash-artifacts/
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ scripts/
 │   ├── release.yml      # tag-triggered GitHub Release (first-party gh CLI) + attested zip asset (Sigstore)
 │   ├── codeql.yml       # weekly + per-PR CodeQL Python scan
 │   ├── scorecard.yml    # weekly + on-push OpenSSF Scorecard self-assessment (feeds README badge)
-│   └── fuzz.yml         # weekly + on-parser-change atheris fuzzing of agl/parser.py
+│   └── fuzz.yml         # weekly deep run + unconditional 120s PR smoke; corpus cached across runs; crash artifacts uploaded
 ├── CODEOWNERS           # @naanyabiz owns everything
 └── dependabot.yml       # weekly pip + github-actions updates, grouped into one PR per ecosystem
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI
 
+- **Fuzzing on every PR** (SDLC remediation WP2, PR-B): the atheris smoke
+  (120 s) now runs unconditionally on every PR — no `paths:` filter — so it
+  can become a required check; the corpus persists across runs via
+  `actions/cache` (weekly 600 s runs deepen it) and crash inputs upload as
+  artifacts on failure.
 - **Merge-blocking security and quality gates** (SDLC remediation WP2, PR-A):
   gitleaks full-history secret scan with repo-specific Auth0/AGL rules
   (`.gitleaks.toml`) closing the `--no-verify` bypass; PR dependency-review


### PR DESCRIPTION
## SDLC remediation — WP2 PR-B

Full rewrite of fuzz.yml per `docs/compliance/remediation-2026-07-workpapers/specs/wp2-ci-gates.md` Step 9:

- **Unconditional PR smoke (120 s)** — `paths:` filter dropped, prerequisite for making `Fuzz AGL parsers (atheris)` a required check (a path-filtered required check wedges non-matching PRs on an 'expected' status forever)
- **Corpus persistence** — `actions/cache` restore/save split: immutable per-run keys, newest snapshot restored via prefix; PR runs read main-scoped caches but save into their own scope; the weekly 600 s scheduled run deepens the persistent corpus
- **Crash artifacts** — uploaded on failure (`-artifact_prefix`); corpus saved `if: always()` so coverage-increasing inputs found before a crash survive for the rerun
- **Seeding** — plain `cp` (not `cp -n`: coreutils ≥ 9.2 on ubuntu-24.04 exits nonzero when `-n` skips files already restored from cache)

Known cache caveat (accepted in the spec): GH evicts caches unused for 7 days and the weekly cron is exactly 7 days apart — a quiet week can lose the corpus; degradation is graceful (reseeds from fixtures). PR traffic keeps it warm in practice.

This PR's own fuzz run executes the **new** workflow (pull_request runs use the PR branch's definition), so it self-validates the corpus-cache plumbing and invocation.

### Follow-up decision (WP1 Step 7 tail)
After this merges and the smoke reports green on the next unrelated PR: decide whether to add `Fuzz AGL parsers (atheris)` to required checks (now safe — unconditional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsw8k4NU2AqSkrWZStXnj4