### PR TITLE
ci: settings-as-code baselines + weekly drift detection

### DIFF
--- a/.github/settings/README.md
+++ b/.github/settings/README.md
@@ -1,0 +1,49 @@
+# Repo settings as code
+
+This directory is the **declared state** of the GitHub control plane for this
+repository — the one part of the delivery environment that is not already
+version-controlled code (2026-07 SDLC review, CO-9). A personal-account repo
+has no audit log, so these baselines + the weekly drift check are the only
+reviewable record of settings changes.
+
+| File | Contents | Drift-checked |
+|---|---|---|
+| `ruleset-<name>.json` | One per live ruleset, normalized (`scripts/normalize-ruleset.jq`) | Weekly, by `settings-drift.yml` |
+| `repo-public.json` | Anonymous-visible repo settings (`scripts/normalize-repo-public.jq`) | Weekly, by `settings-drift.yml` |
+| `repo-admin-snapshot.json` | Admin-only settings: merge methods, security & analysis toggles, Actions policy + selected-actions allowlist, ruleset bypass actors, classic branch protection (recorded as `null` since its deliberate retirement, 2026-07-13), secrets/hooks/keys inventory | **No** — reading these needs `administration` scope, which the workflow `GITHUB_TOKEN` cannot hold, and adding a standing PAT is against the zero-standing-secrets posture (#171). Refreshed manually. |
+
+## Process rule — settings changes go PR-first
+
+1. Open a PR that updates the relevant file(s) here to the **intended** state
+   (describe the why in the PR body).
+2. Merge it (green checks as usual).
+3. Apply the change in GitHub (UI or `gh api`), then run
+   `./scripts/export-settings.sh` and confirm `git status` is clean — the
+   live state now matches the declared state. If the export differs from the
+   merged baseline, reconcile immediately (fix the setting or PR a correction).
+
+Break-glass (urgent settings change applied live first): allowed, but the
+reconciliation PR (`export-settings.sh` output) must follow within a week —
+before the next scheduled drift run — or the drift issue will file itself.
+The documented break-glass for the `v*` tag ruleset (bad release tag: disable
+→ fix → re-enable) is drift-invisible if completed within one run window, but
+record it in an issue regardless — control-plane changes are otherwise
+invisible on a personal account.
+
+## When the weekly check flags drift
+
+`settings-drift.yml` opens/updates an issue labelled `settings-drift` and the
+run goes red. Reconcile **deliberately**: either revert the live setting, or
+adopt it by PRing the refreshed export. Never silently re-export to make the
+diff go away — the diff is the change record.
+
+## Known blind spots (accepted)
+
+- `bypass_actors` on rulesets is only returned to callers with write access
+  to the ruleset, so the weekly job cannot see it; it is recorded in
+  `repo-admin-snapshot.json` and re-verified on every manual export.
+- Everything in `repo-admin-snapshot.json` drifts silently between manual
+  exports. Compensating controls: the process rule above, and the weekly
+  OpenSSF Scorecard re-measurement (Branch-Protection, Token-Permissions).
+- The repo owner holds admin and can edit any of this at any time — detection
+  is possible, prevention is not (single-maintainer reality, see SECURITY.md).

--- a/.github/settings/repo-admin-snapshot.json
+++ b/.github/settings/repo-admin-snapshot.json
@@ -1,0 +1,70 @@
+{
+  "actions_permissions": {
+    "allowed_actions": "selected",
+    "enabled": true,
+    "sha_pinning_required": true
+  },
+  "classic_protection_main": null,
+  "inventory": {
+    "actions_secrets": 0,
+    "actions_variables": 0,
+    "dependabot_secrets": 0,
+    "deploy_keys": 0,
+    "environments": 0,
+    "hooks": 0
+  },
+  "merge": {
+    "allow_auto_merge": false,
+    "allow_merge_commit": false,
+    "allow_rebase_merge": false,
+    "allow_squash_merge": true,
+    "allow_update_branch": false,
+    "delete_branch_on_merge": true,
+    "merge_commit_message": "PR_TITLE",
+    "merge_commit_title": "MERGE_MESSAGE",
+    "squash_merge_commit_message": "COMMIT_MESSAGES",
+    "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
+    "use_squash_pr_title_as_default": false
+  },
+  "ruleset_bypass": [
+    {
+      "bypass_actors": [],
+      "name": "protect-main"
+    },
+    {
+      "bypass_actors": [],
+      "name": "protect-release-tags"
+    }
+  ],
+  "security_and_analysis": {
+    "dependabot_security_updates": {
+      "status": "enabled"
+    },
+    "secret_scanning": {
+      "status": "enabled"
+    },
+    "secret_scanning_non_provider_patterns": {
+      "status": "disabled"
+    },
+    "secret_scanning_push_protection": {
+      "status": "enabled"
+    },
+    "secret_scanning_validity_checks": {
+      "status": "disabled"
+    }
+  },
+  "selected_actions": {
+    "github_owned_allowed": true,
+    "patterns_allowed": [
+      "astral-sh/setup-uv@*",
+      "hacs/action@*",
+      "home-assistant/actions/*",
+      "ossf/scorecard-action@*"
+    ],
+    "verified_allowed": false
+  },
+  "workflow_permissions": {
+    "can_approve_pull_request_reviews": false,
+    "default_workflow_permissions": "read"
+  }
+}

--- a/.github/settings/repo-public.json
+++ b/.github/settings/repo-public.json
@@ -1,0 +1,18 @@
+{
+  "allow_forking": true,
+  "archived": false,
+  "default_branch": "main",
+  "disabled": false,
+  "fork": false,
+  "has_discussions": true,
+  "has_downloads": true,
+  "has_issues": true,
+  "has_pages": false,
+  "has_projects": true,
+  "has_wiki": false,
+  "is_template": false,
+  "license": "Apache-2.0",
+  "pull_request_creation_policy": "all",
+  "visibility": "public",
+  "web_commit_signoff_required": false
+}

--- a/.github/settings/ruleset-protect-main.json
+++ b/.github/settings/ruleset-protect-main.json
@@ -1,0 +1,82 @@
+{
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "protect-main",
+  "rules": [
+    {
+      "type": "creation"
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "squash"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Analyze (Python)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CodeQL",
+            "integration_id": 57789
+          },
+          {
+            "context": "Dependency review",
+            "integration_id": 15368
+          },
+          {
+            "context": "Fuzz AGL parsers (atheris)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Gitleaks (full history)",
+            "integration_id": 15368
+          },
+          {
+            "context": "HACS validation",
+            "integration_id": 15368
+          },
+          {
+            "context": "Hassfest",
+            "integration_id": 15368
+          },
+          {
+            "context": "Test (Python 3.14)",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      },
+      "type": "required_status_checks"
+    }
+  ],
+  "target": "branch"
+}

--- a/.github/settings/ruleset-protect-release-tags.json
+++ b/.github/settings/ruleset-protect-release-tags.json
@@ -1,0 +1,24 @@
+{
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/tags/v*"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "protect-release-tags",
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "update"
+    }
+  ],
+  "target": "tag"
+}

--- a/.github/workflows/settings-drift.yml
+++ b/.github/workflows/settings-drift.yml
@@ -1,0 +1,135 @@
+name: Settings drift
+
+# Weekly re-export of the GitHub control-plane state readable by the default
+# per-run GITHUB_TOKEN (all rulesets + anonymous-visible repo settings),
+# diffed byte-for-byte against the committed baselines in .github/settings/.
+# On drift: opens/updates a `settings-drift` issue and fails the run; on
+# recovery: closes it. Admin-only settings (merge methods, security &
+# analysis, Actions policy, ruleset bypass actors) are NOT checked here —
+# they require `administration` scope, which a workflow token cannot hold —
+# see .github/settings/README.md. Zero standing secrets by design.
+#
+# The jq normalizers are shared with scripts/export-settings.sh so the two
+# sides can never disagree on canonical form.
+
+on:
+  schedule:
+    # Weekly Tuesday 04:37 UTC — offset from Scorecard (Mon 04:22) and CodeQL.
+    - cron: "37 4 * * 2"
+  push:
+    branches: [main]
+    paths:
+      - ".github/settings/**"
+      - ".github/workflows/settings-drift.yml"
+      - "scripts/normalize-ruleset.jq"
+      - "scripts/normalize-repo-public.jq"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  drift:
+    name: Detect settings drift
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Re-export live state and diff against committed baselines
+        id: diff
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/live
+          report=/tmp/drift-report.md
+          : > "$report"
+
+          # --- rulesets (normalizer strips viewer-dependent fields) ---
+          declare -A live_slugs=()
+          for id in $(gh api "repos/$GH_REPO/rulesets" --paginate --jq '.[].id'); do
+            gh api "repos/$GH_REPO/rulesets/$id" > /tmp/live/raw.json
+            name=$(jq -r '.name' /tmp/live/raw.json)
+            slug=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' \
+                   | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+            live_slugs[$slug]=1
+            jq -S -f scripts/normalize-ruleset.jq /tmp/live/raw.json \
+              > "/tmp/live/ruleset-$slug.json"
+            committed=".github/settings/ruleset-$slug.json"
+            if [ ! -f "$committed" ]; then
+              { echo "### Live ruleset \`$name\` has no committed baseline (\`$committed\`)"
+                echo '```json'; cat "/tmp/live/ruleset-$slug.json"; echo '```'
+              } >> "$report"
+            elif ! diff -u "$committed" "/tmp/live/ruleset-$slug.json" > /tmp/live/d.txt; then
+              { echo "### Ruleset \`$name\` drifted from \`$committed\`"
+                echo '```diff'; cat /tmp/live/d.txt; echo '```'
+              } >> "$report"
+            fi
+          done
+          for committed in .github/settings/ruleset-*.json; do
+            [ -e "$committed" ] || continue
+            slug=$(basename "$committed" .json); slug=${slug#ruleset-}
+            if [ -z "${live_slugs[$slug]:-}" ]; then
+              echo "### Committed baseline \`$committed\` has no matching live ruleset (deleted or renamed?)" >> "$report"
+            fi
+          done
+
+          # --- anonymous-visible repo settings ---
+          gh api "repos/$GH_REPO" \
+            | jq -S -f scripts/normalize-repo-public.jq > /tmp/live/repo-public.json
+          if ! diff -u .github/settings/repo-public.json /tmp/live/repo-public.json > /tmp/live/d.txt; then
+            { echo "### Public repo settings drifted from \`.github/settings/repo-public.json\`"
+              echo '```diff'; cat /tmp/live/d.txt; echo '```'
+            } >> "$report"
+          fi
+
+          if [ -s "$report" ]; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update drift issue
+        if: steps.diff.outputs.drift == 'true'
+        run: |
+          set -euo pipefail
+          gh label create settings-drift --color B60205 \
+            --description "Live GitHub settings diverge from .github/settings/ baselines" \
+            2>/dev/null || true
+          {
+            echo "The settings-drift check found the live GitHub configuration diverging from the committed baselines."
+            echo
+            echo "Run: $GITHUB_SERVER_URL/$GH_REPO/actions/runs/$GITHUB_RUN_ID"
+            echo
+            head -c 60000 /tmp/drift-report.md
+            echo
+            echo "Reconcile **deliberately** (see \`.github/settings/README.md\`): revert the live setting, or PR the new intended state (\`scripts/export-settings.sh\`)."
+          } > /tmp/issue-body.md
+          n=$(gh issue list --label settings-drift --state open \
+                --json number --jq '.[0].number // empty')
+          if [ -n "$n" ]; then
+            gh issue comment "$n" --body-file /tmp/issue-body.md
+          else
+            gh issue create \
+              --title "Settings drift detected against .github/settings/ baselines" \
+              --label settings-drift --body-file /tmp/issue-body.md
+          fi
+
+      - name: Close drift issue on recovery
+        if: steps.diff.outputs.drift == 'false'
+        run: |
+          set -euo pipefail
+          n=$(gh issue list --label settings-drift --state open \
+                --json number --jq '.[0].number // empty')
+          if [ -n "$n" ]; then
+            gh issue close "$n" --comment "Settings-drift check is clean again — live settings match the committed baselines. Run: $GITHUB_SERVER_URL/$GH_REPO/actions/runs/$GITHUB_RUN_ID"
+          fi
+
+      - name: Fail the run on drift (visibility)
+        if: steps.diff.outputs.drift == 'true'
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ docs/
 
 scripts/
 ├── wt                   # bash worktree helper (new / list / rm)
+├── export-settings.sh   # admin-run: re-export control-plane baselines into .github/settings/ (PR-first on any settings change)
+├── normalize-ruleset.jq / normalize-repo-public.jq  # shared normalizers (export script + settings-drift workflow)
 └── validate_manifest.py # used by the validate-manifest Claude hook
 
 .claude/
@@ -100,6 +102,7 @@ scripts/
 └── commands/            # 5 slash commands (new-entity, wt, release, hassfest, pr)
 
 .github/
+├── settings/            # declared state of the GitHub control plane (rulesets, repo settings) — see settings/README.md; weekly drift check
 ├── workflows/
 │   ├── ci.yml           # ruff + mypy + pytest (Python 3.14, coverage floor 89) + gitleaks full-history scan + dependency-review + shellcheck/actionlint/zizmor
 │   ├── hacs.yml         # HACS validation
@@ -107,7 +110,8 @@ scripts/
 │   ├── release.yml      # tag-triggered GitHub Release (first-party gh CLI) + attested zip asset (Sigstore)
 │   ├── codeql.yml       # weekly + per-PR CodeQL Python scan
 │   ├── scorecard.yml    # weekly + on-push OpenSSF Scorecard self-assessment (feeds README badge)
-│   └── fuzz.yml         # weekly deep run + unconditional 120s PR smoke; corpus cached across runs; crash artifacts uploaded
+│   ├── fuzz.yml         # weekly deep run + unconditional 120s PR smoke; corpus cached across runs; crash artifacts uploaded
+│   └── settings-drift.yml # weekly: re-export rulesets + public repo settings, diff vs .github/settings/, issue on drift
 ├── CODEOWNERS           # @naanyabiz owns everything
 └── dependabot.yml       # weekly pip + github-actions updates, grouped into one PR per ecosystem
 
@@ -721,6 +725,16 @@ The HA Energy dashboard requires:
   total rises; a new over-complexity function gets decomposed, not legalized.
   The single sanctioned exemption is `coordinator._fetch_range` (noqa'd with
   rationale + debt issue).
+- **Don't change GitHub repo settings, rulesets, or Actions policy without a
+  PR updating `.github/settings/` first.** The control plane is settings-as-code
+  (2026-07 SDLC review): PR the intended state into `.github/settings/`, merge,
+  apply the change, then run `./scripts/export-settings.sh` and confirm the
+  working tree stays clean. The weekly `settings-drift` workflow files an issue
+  on any divergence. Break-glass changes are allowed but must be reconciled
+  by PR before the next weekly run. Admin-only settings (merge methods,
+  security toggles, Actions policy + selected-actions allowlist) are
+  snapshot-only — refresh `repo-admin-snapshot.json` in the same PR whenever
+  they change.
 - **Don't exact-pin `pytest-homeassistant-custom-component` to a single
   patch.** Upstream releases near-daily, so an exact pin manufactures a
   guaranteed weekly Dependabot PR and has caused resolver deadlocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI
 
+- **Settings-as-code + weekly drift detection** (SDLC remediation WP3,
+  CO-9.1/9.3/6.3): the repo control plane (rulesets, public repo settings,
+  admin-only settings snapshot) is committed under `.github/settings/`;
+  `settings-drift.yml` re-exports weekly with the unprivileged workflow token
+  and files an issue on divergence. Settings changes are PR-first from now on;
+  the 2026-07-13 WP1 hardening batch is the recorded bootstrap exception.
 - **Fuzzing on every PR** (SDLC remediation WP2, PR-B): the atheris smoke
   (120 s) now runs unconditionally on every PR — no `paths:` filter — so it
   can become a required check; the corpus persists across runs via

--- a/scripts/export-settings.sh
+++ b/scripts/export-settings.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Re-export the GitHub control-plane state into .github/settings/.
+#
+# Run with an ADMIN-scoped `gh` login (the maintainer's own auth) whenever a
+# repo setting or ruleset changes — PR-first: commit the refreshed baselines
+# in the same PR that records the settings change (.github/settings/README.md).
+#
+# The settings-drift workflow re-runs the ruleset + public-settings exports
+# with the unprivileged per-run GITHUB_TOKEN and diffs byte-for-byte, so this
+# script and the workflow MUST share the same jq normalizers (scripts/*.jq).
+set -euo pipefail
+
+REPO=${1:-NaanyaBiz/haggle}
+cd "$(git rev-parse --show-toplevel)"
+OUT=.github/settings
+mkdir -p "$OUT"
+
+# --- 1. Rulesets: one normalized file per live ruleset (CI drift-checked) ---
+find "$OUT" -maxdepth 1 -name 'ruleset-*.json' -delete
+for id in $(gh api "repos/$REPO/rulesets" --paginate --jq '.[].id'); do
+  raw=$(gh api "repos/$REPO/rulesets/$id")
+  name=$(jq -r '.name' <<<"$raw")
+  slug=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+  jq -S -f scripts/normalize-ruleset.jq <<<"$raw" > "$OUT/ruleset-$slug.json"
+  echo "wrote $OUT/ruleset-$slug.json"
+done
+
+# --- 2. Public repo settings (CI drift-checked) ---
+gh api "repos/$REPO" | jq -S -f scripts/normalize-repo-public.jq > "$OUT/repo-public.json"
+echo "wrote $OUT/repo-public.json"
+
+# --- 3. Admin-only snapshot (NOT CI drift-checked: needs `administration`
+#        scope, which a workflow GITHUB_TOKEN cannot hold; refreshed here) ---
+repo_json=$(gh api "repos/$REPO")
+if classic=$(gh api "repos/$REPO/branches/main/protection" 2>/dev/null); then
+  classic=$(jq 'walk(if type == "object" then del(.url, .contexts_url) else . end)' <<<"$classic")
+else
+  classic=null   # classic protection removed — record its absence
+fi
+jq -n \
+  --argjson merge "$(jq '{allow_merge_commit, allow_squash_merge, allow_rebase_merge,
+      allow_auto_merge, allow_update_branch, delete_branch_on_merge,
+      squash_merge_commit_title, squash_merge_commit_message,
+      merge_commit_title, merge_commit_message,
+      use_squash_pr_title_as_default}' <<<"$repo_json")" \
+  --argjson security "$(jq '.security_and_analysis' <<<"$repo_json")" \
+  --argjson actions_permissions "$(gh api "repos/$REPO/actions/permissions" \
+      | jq '{enabled, allowed_actions, sha_pinning_required}')" \
+  --argjson selected_actions "$(gh api "repos/$REPO/actions/permissions/selected-actions" 2>/dev/null || echo null)" \
+  --argjson workflow_permissions "$(gh api "repos/$REPO/actions/permissions/workflow")" \
+  --argjson ruleset_bypass "$(gh api "repos/$REPO/rulesets" --paginate --jq '.[].id' \
+      | while read -r id; do gh api "repos/$REPO/rulesets/$id" | jq '{name, bypass_actors}'; done \
+      | jq -s 'sort_by(.name)')" \
+  --argjson classic_protection_main "$classic" \
+  --argjson inventory "$(jq -n \
+      --argjson hooks "$(gh api "repos/$REPO/hooks" | jq 'length')" \
+      --argjson deploy_keys "$(gh api "repos/$REPO/keys" | jq 'length')" \
+      --argjson environments "$(gh api "repos/$REPO/environments" --jq '.total_count')" \
+      --argjson actions_secrets "$(gh api "repos/$REPO/actions/secrets" --jq '.total_count')" \
+      --argjson actions_variables "$(gh api "repos/$REPO/actions/variables" --jq '.total_count')" \
+      --argjson dependabot_secrets "$(gh api "repos/$REPO/dependabot/secrets" --jq '.total_count')" \
+      '{hooks: $hooks, deploy_keys: $deploy_keys, environments: $environments,
+        actions_secrets: $actions_secrets, actions_variables: $actions_variables,
+        dependabot_secrets: $dependabot_secrets}')" \
+  '{merge: $merge, security_and_analysis: $security,
+    actions_permissions: $actions_permissions,
+    selected_actions: $selected_actions,
+    workflow_permissions: $workflow_permissions,
+    ruleset_bypass: $ruleset_bypass,
+    classic_protection_main: $classic_protection_main,
+    inventory: $inventory}' \
+  | jq -S . > "$OUT/repo-admin-snapshot.json"
+echo "wrote $OUT/repo-admin-snapshot.json"

--- a/scripts/normalize-repo-public.jq
+++ b/scripts/normalize-repo-public.jq
@@ -1,0 +1,24 @@
+# Project GET /repos/{owner}/{repo} down to the settings-like fields that are
+# visible WITHOUT authentication on a public repo (verified 2026-07-13:
+# identical output from an admin-token and an anonymous response). Volatile
+# fields (counts, timestamps, description, topics) are deliberately excluded.
+# Admin-gated fields (merge methods, security_and_analysis) live in
+# repo-admin-snapshot.json.
+{
+  default_branch,
+  visibility,
+  archived,
+  disabled,
+  is_template,
+  fork,
+  allow_forking,
+  web_commit_signoff_required,
+  pull_request_creation_policy,
+  has_issues,
+  has_projects,
+  has_wiki,
+  has_discussions,
+  has_pages,
+  has_downloads,
+  license: (.license.spdx_id // null)
+}

--- a/scripts/normalize-ruleset.jq
+++ b/scripts/normalize-ruleset.jq
@@ -1,0 +1,26 @@
+# Normalize a GitHub ruleset export to a stable, viewer-independent form.
+# Keeps only declarative fields readable by ANY token (including the Actions
+# GITHUB_TOKEN and anonymous callers); strips ids, timestamps, links, and
+# viewer-dependent fields: bypass_actors is only returned to callers with
+# write access to the ruleset, and current_user_can_bypass varies by caller.
+# bypass_actors is recorded in repo-admin-snapshot.json instead.
+# Arrays with set semantics are sorted so exports are diff-stable.
+{
+  name: .name,
+  target: .target,
+  enforcement: .enforcement,
+  conditions: (.conditions // {}
+    | with_entries(.value |= (
+        if type == "object"
+        then with_entries(.value |= (if type == "array" then sort else . end))
+        else . end))),
+  rules: (
+    .rules
+    | map(if .type == "required_status_checks"
+          then .parameters.required_status_checks |= sort_by(.context)
+          elif .type == "pull_request"
+          then .parameters.allowed_merge_methods |= sort
+          else . end)
+    | sort_by(.type)
+  )
+}


### PR DESCRIPTION
## SDLC remediation — WP3

Closes CO-9.1/CO-9.3/CO-6.3 gaps per `docs/compliance/remediation-2026-07-workpapers/specs/wp3-settings-as-code.md` (with the audit's amendments: spec Step 0 superseded by WP1's required-checks batch, Step 8 superseded by WP1's actions policy).

### What this adds
- **`.github/settings/`** — the declared control-plane state: normalized per-ruleset baselines, anonymous-visible repo settings, and an admin-only snapshot (incl. the selected-actions allowlist, a spec addition since WP1 introduced it; classic protection recorded as `null` post-retirement; zero-count credential inventory)
- **`scripts/export-settings.sh` + shared jq normalizers** — admin-run re-export; the drift workflow uses the *same* normalizers so the two sides cannot disagree
- **`settings-drift.yml`** — weekly (Tue 04:37 UTC) + on-baseline-push + dispatch: re-exports what the unprivileged `GITHUB_TOKEN` can read (all rulesets + public settings), diffs byte-for-byte, files/updates one deduped `settings-drift` issue and fails the run on divergence, auto-closes on recovery. **No standing PAT** — admin-only fields are deliberately snapshot-only (documented blind spot in the README, consistent with the #171 zero-standing-secrets decision).

### Validation performed
- Normalizer viewer-independence: admin-token vs anonymous responses normalize byte-identically (both rulesets + repo projection)
- Export idempotency: second run leaves the tree clean
- Local drift simulation against the committed baselines: CLEAN
- shellcheck / actionlint / zizmor / check-json / check-yaml: all pass (the new shell is linted by the WP2 gates)

### Process change (the point of the PR)
From this merge onward, **settings changes are PR-first** (README in `.github/settings/`): PR the intended state → merge → apply → clean re-export. Break-glass allowed with reconciliation before the next weekly run. Today's WP1 hardening batch is the recorded bootstrap exception — the last sanctioned click-ops.

### Post-merge validation plan
The push trigger fires on merge (paths match) → expect green, no issue. Then the negative test per the spec: scratch branch with one flipped baseline value, `workflow_dispatch` on it → expect red + issue with exact diff → restore → green + auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsw8k4NU2AqSkrWZStXnj4