### PR TITLE
feat: raise HA Repairs for solar give-up states + surface stall holes in diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ custom_components/haggle/
 ├── manifest.json        # HACS/HA metadata; hassfest validates this
 ├── const.py             # all constants — DOMAIN, API hosts, config-entry keys, data keys
 ├── config_flow.py       # PKCE authorize URL → user pastes callback → exchange → select_contract
-├── diagnostics.py       # anonymized config-entry diagnostics (schema v1) — public-safe; parsed by the triage routine (docs/diagnostics.md)
+├── diagnostics.py       # anonymized config-entry diagnostics (schema v2) — public-safe; parsed by the triage routine (docs/diagnostics.md)
 ├── coordinator.py       # HaggleCoordinator: 30-day backfill (throttled, 429-aware, per-series ranges) + incremental statistics import (aggregate + per-tariff ToU series + solar generation/credit on hasSolar contracts) + bill-period solar totals
 ├── sensor.py            # 14 SensorEntityDescription entries (3 conditional ToU rate sensors, 5 conditional solar sensors); HaggleEnergySensor
 ├── agl/
@@ -420,7 +420,13 @@ and each item carries **both** a `consumption` block and a shape-identical
   `SOLAR_STALL_GIVE_UP_CYCLES` consecutive zero-progress cycles on the SAME
   chunk, zero-delta markers advance the resume past the span (WARNING logged).
   In-memory counter — restart resets it (conservative). Rate-limited sweeps
-  and heal sweeps are excluded by design.
+  and heal sweeps are excluded by design. Each give-up persists a span record
+  to `entry.data[CONF_SOLAR_STALL_SPANS]` (bounded list, surfaced in
+  diagnostics as `stall_give_up_spans`) and raises a persistent HA Repairs
+  issue — the marker rows make coverage stats look healthy over the hole, so
+  the span record is the only durable evidence (CO-16.4). Heal/repair
+  give-ups likewise raise Repairs issues and mark the done record with
+  `gave_up`/`attempts` so diagnostics can tell give-up from clean completion.
 - The beta.1 "numbers don't match" report (#128) was a **window artifact** —
   a cumulative-since-backfill sensor compared against the app's
   billing-period tile — not a field bug. When validating against the app,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Solar give-up states now raise actionable HA Repairs issues** instead of
+  only logging (SDLC remediation WP7, CO-16.4): heal/repair exhaustion and
+  stall give-up each create a persistent Repairs issue in Settings, the heal
+  record distinguishes give-up from clean completion (`gave_up`/`attempts`),
+  and stall give-up spans are persisted and surfaced in diagnostics
+  (schema v2) — previously the zero-delta marker rows made these permanent
+  holes invisible behind healthy-looking coverage stats.
+
 ### CI
 
 - **Settings-as-code + weekly drift detection** (SDLC remediation WP3,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -155,6 +155,11 @@ both the browser and the HA host simultaneously.
   use, so a stolen copy is invalidated at the integration's next exchange;
   the fallback `unique_id` is a one-way hash, never token material. If the
   token file worries you, enable full-disk encryption on the HA host.
+- Besides the refresh token, the config-entry data carries only
+  operational state: TLS pins (hashes), the solar heal record, and the
+  bounded `solar_stall_spans` give-up list — dates and counts only.
+  HA Repairs issues raised for give-up states key on the config entry's
+  random id, never on an account or contract identifier.
 - The short-lived access token (15-minute expiry) is **never** persisted.
 - The fallback `unique_id` (when contracts cannot be discovered at
   install time) is `sha256(refresh_token)[:16]`, not a token prefix.

--- a/custom_components/haggle/const.py
+++ b/custom_components/haggle/const.py
@@ -153,6 +153,9 @@ CONF_PINNED_SPKI_AUTH: Final = "pinned_spki_auth"  # secure.agl.com.au
 CONF_PINNED_SPKI_BFF: Final = "pinned_spki_bff"  # api.platform.agl.com.au
 # One-time solar generation leading-hole heal (#128). Stored as a record:
 #   {"state": "pending"|"done", "floor": "YYYY-MM-DD", "attempts": int}
+# A "done" record reached by GIVE-UP (rather than clean completion) additionally
+# carries {"gave_up": True, "attempts": int} so diagnostics can tell the two
+# apart — they previously collapsed to an identical {"state": "done"}.
 # Absent = never attempted. "pending" = a full-window re-import is in progress;
 # the `floor` is frozen when the heal starts so a 429-interrupted retry re-fetches
 # the SAME window instead of sliding forward and dropping its oldest day (Codex
@@ -166,6 +169,18 @@ CONF_SOLAR_HEAL: Final = "solar_heal"
 SOLAR_HEAL_PENDING: Final = "pending"
 SOLAR_HEAL_DONE: Final = "done"
 MAX_SOLAR_HEAL_ATTEMPTS: Final = 3
+
+# Permanent-hole records written when the normal-path solar backfill gives up
+# (#154, CO-16.4): the give-up writes healthy-looking zero-delta marker rows,
+# so the coverage stats in diagnostics self-mask the hole — these spans are the
+# only durable evidence. Surfaced as diagnostics `stall_give_up_spans` and as a
+# Repairs issue per span. Bounded list (oldest dropped) so entry.data stays small.
+CONF_SOLAR_STALL_SPANS: Final = "solar_stall_spans"
+MAX_STALL_SPAN_RECORDS: Final = 12
+# Learn-more target for the give-up Repairs issues.
+ISSUE_LEARN_MORE_URL: Final = (
+    "https://github.com/NaanyaBiz/haggle/blob/main/docs/diagnostics.md"
+)
 
 # Coordinator data attribute names — must match HaggleData field names exactly.
 DATA_CONSUMPTION_KWH: Final = "latest_cumulative_kwh"  # TOTAL_INCREASING sensor

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -802,10 +802,15 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         dismissed heal issue cannot swallow a later repair give-up.
         """
         kind = "solar_repair_gave_up" if repairing else "solar_heal_gave_up"
+        # Issue id keys on entry_id (random hex), NOT the contract number —
+        # ids serialize verbatim into HA's issue registry store, and the
+        # Class B discipline keeps identifiers out of composite strings.
+        # The entry placeholder (title = the entry's own display name) tells
+        # multi-entry installs which contract needs attention.
         ir.async_create_issue(
             self.hass,
             DOMAIN,
-            f"{kind}_{self.contract_number}",
+            f"{kind}_{self.config_entry.entry_id}",
             is_fixable=False,
             is_persistent=True,
             severity=ir.IssueSeverity.ERROR if repairing else ir.IssueSeverity.WARNING,
@@ -813,6 +818,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             translation_placeholders={
                 "attempts": str(attempts),
                 "floor": floor.isoformat(),
+                "entry": self.config_entry.title,
             },
             learn_more_url=ISSUE_LEARN_MORE_URL,
         )
@@ -1165,10 +1171,16 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 CONF_SOLAR_STALL_SPANS: spans[-MAX_STALL_SPAN_RECORDS:],
             },
         )
+        # entry_id not contract number (Class B stays out of the registry
+        # store); the give-up DATE in the id means a recurrence of the same
+        # span — possible after the user repairs the marker rows — raises a
+        # fresh issue instead of staying swallowed by an old dismissal.
+        gave_up_date = spans[-1]["gave_up_at"][:10]
         ir.async_create_issue(
             self.hass,
             DOMAIN,
-            f"solar_stall_gave_up_{self.contract_number}_{start.isoformat()}",
+            f"solar_stall_gave_up_{self.config_entry.entry_id}"
+            f"_{start.isoformat()}_{gave_up_date}",
             is_fixable=False,
             is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
@@ -1177,6 +1189,7 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 "start": start.isoformat(),
                 "end": end.isoformat(),
                 "cycles": str(cycles),
+                "entry": self.config_entry.title,
             },
             learn_more_url=ISSUE_LEARN_MORE_URL,
         )

--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -30,6 +30,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -47,8 +48,11 @@ from .const import (
     BACKFILL_DAYS,
     BACKFILL_INTER_REQUEST_DELAY,
     CONF_SOLAR_HEAL,
+    CONF_SOLAR_STALL_SPANS,
     DOMAIN,
+    ISSUE_LEARN_MORE_URL,
     MAX_SOLAR_HEAL_ATTEMPTS,
+    MAX_STALL_SPAN_RECORDS,
     RECORDER_DRAIN_TIMEOUT,
     RETRY_INTERVAL_ON_ERROR,
     REWINDOW_DAYS,
@@ -757,7 +761,14 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                     "solar dates)",
                     attempts + 1,
                 )
-            new = {"state": SOLAR_HEAL_DONE}
+            # Distinguish give-up from clean completion in the persisted record
+            # (diagnostics) — both previously collapsed to {"state": "done"}.
+            new = {
+                "state": SOLAR_HEAL_DONE,
+                "gave_up": True,
+                "attempts": attempts + 1,
+            }
+            self._raise_heal_give_up_issue(floor, attempts + 1, repairing=repairing)
         else:
             new = {
                 "state": SOLAR_HEAL_PENDING,
@@ -776,6 +787,35 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
                 self.config_entry,
                 data={**self.config_entry.data, CONF_SOLAR_HEAL: record},
             )
+
+    def _raise_heal_give_up_issue(
+        self, floor: date, attempts: int, *, repairing: bool
+    ) -> None:
+        """Raise an HA Repairs issue for a heal/repair give-up (CO-16.4).
+
+        The give-up means a permanent hole (or a frozen downward step) in the
+        solar statistics; a log WARNING most users never read is not an alert.
+        Non-fixable (there is no automated remediation), persistent across
+        restarts, one issue id per event class per contract. Never deleted by
+        code — the underlying data condition is permanent; the user dismisses
+        it once read. The heal and repair generations get distinct ids so a
+        dismissed heal issue cannot swallow a later repair give-up.
+        """
+        kind = "solar_repair_gave_up" if repairing else "solar_heal_gave_up"
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"{kind}_{self.contract_number}",
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.ERROR if repairing else ir.IssueSeverity.WARNING,
+            translation_key=kind,
+            translation_placeholders={
+                "attempts": str(attempts),
+                "floor": floor.isoformat(),
+            },
+            learn_more_url=ISSUE_LEARN_MORE_URL,
+        )
 
     async def _generation_needs_heal(
         self, stat_id_gen: str, floor: date, today: date
@@ -1096,7 +1136,50 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
             count,
         )
         await self._import_generation([], fetched_days=span)
+        self._record_stall_give_up(span[0], span[-1], count)
         self._solar_stall = None
+
+    def _record_stall_give_up(self, start: date, end: date, cycles: int) -> None:
+        """Persist a stall give-up span and raise a Repairs issue (CO-16.4).
+
+        The give-up writes zero-delta marker rows over the span, so the
+        per-series coverage stats look healthy over the hole and the in-memory
+        counter leaves no trace — this record is the only durable artifact.
+        entry.data write follows the solar_heal pattern: no reload listener
+        fires. Issue id is per-span so a later, different hole is not masked
+        by a dismissal of an earlier one.
+        """
+        spans = list(self.config_entry.data.get(CONF_SOLAR_STALL_SPANS) or [])
+        spans.append(
+            {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "cycles": cycles,
+                "gave_up_at": dt_util.utcnow().isoformat(timespec="seconds"),
+            }
+        )
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={
+                **self.config_entry.data,
+                CONF_SOLAR_STALL_SPANS: spans[-MAX_STALL_SPAN_RECORDS:],
+            },
+        )
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"solar_stall_gave_up_{self.contract_number}_{start.isoformat()}",
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="solar_stall_gave_up",
+            translation_placeholders={
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "cycles": str(cycles),
+            },
+            learn_more_url=ISSUE_LEARN_MORE_URL,
+        )
 
     async def _fetch_day_consumption(
         self, day: date, previous: bool

--- a/custom_components/haggle/diagnostics.py
+++ b/custom_components/haggle/diagnostics.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_PINNED_SPKI_BFF,
     CONF_REFRESH_TOKEN,
     CONF_SOLAR_HEAL,
+    CONF_SOLAR_STALL_SPANS,
     DOMAIN,
     STAT_CONSUMPTION,
     STAT_COST,
@@ -49,7 +50,7 @@ if TYPE_CHECKING:
 
     from . import HaggleConfigEntry
 
-DIAGNOSTICS_SCHEMA_VERSION = 1
+DIAGNOSTICS_SCHEMA_VERSION = 2
 
 _TO_REDACT = {CONF_REFRESH_TOKEN}
 
@@ -180,6 +181,10 @@ async def async_get_config_entry_diagnostics(
     # field: distinguishes "period sensors deliberately blank while a heal
     # runs" from "gate failed" from "heal gave up" (#128 beta.3 round).
     solar_heal = entry_data.pop(CONF_SOLAR_HEAL, None)
+    # Stall give-up spans — the marker rows written at give-up make the
+    # coverage stats look healthy over the hole, so this is the only place
+    # the hole is visible (CO-16.4). None = never gave up.
+    stall_spans = entry_data.pop(CONF_SOLAR_STALL_SPANS, None)
 
     runtime = getattr(entry, "runtime_data", None)
     coordinator = runtime.coordinator if runtime is not None else None
@@ -243,6 +248,7 @@ async def async_get_config_entry_diagnostics(
             "pin_present_bff": pin_bff,
         },
         "solar_heal": solar_heal,
+        "stall_give_up_spans": stall_spans,
         "coordinator": coordinator_block,
         "statistics": statistics,
     }

--- a/custom_components/haggle/strings.json
+++ b/custom_components/haggle/strings.json
@@ -70,5 +70,19 @@
         "name": "Solar feed-in rate"
       }
     }
+  },
+  "issues": {
+    "solar_heal_gave_up": {
+      "title": "Solar history backfill gave up",
+      "description": "Haggle tried {attempts} times to backfill older solar history (back to {floor}), but AGL kept returning errors for at least one day, and has stopped retrying. The days that could not be fetched are permanently missing from the solar statistics. If those days matter to you, check whether the AGL app shows data for the same dates, then see the diagnostics guide (Learn more) for recovery options."
+    },
+    "solar_repair_gave_up": {
+      "title": "Solar statistics repair gave up",
+      "description": "Haggle detected a downward step in the cumulative solar statistics and tried {attempts} times to rebuild the series (back to {floor}), but could not complete a clean sweep. A downward step may persist in the solar statistics. It can be corrected manually via Developer Tools → Statistics — see the diagnostics guide (Learn more)."
+    },
+    "solar_stall_gave_up": {
+      "title": "Solar backfill skipped {start} to {end}",
+      "description": "AGL returned errors for every day in {start}..{end} for {cycles} consecutive polls, so Haggle marked the span as covered and moved on. These days are recorded as zero export and will not be retried automatically — a permanent gap in the solar statistics. If the AGL app shows data for these dates, see the diagnostics guide (Learn more) for recovery options."
+    }
   }
 }

--- a/custom_components/haggle/strings.json
+++ b/custom_components/haggle/strings.json
@@ -74,15 +74,15 @@
   "issues": {
     "solar_heal_gave_up": {
       "title": "Solar history backfill gave up",
-      "description": "Haggle tried {attempts} times to backfill older solar history (back to {floor}), but AGL kept returning errors for at least one day, and has stopped retrying. The days that could not be fetched are permanently missing from the solar statistics. If those days matter to you, check whether the AGL app shows data for the same dates, then see the diagnostics guide (Learn more) for recovery options."
+      "description": "For entry {entry}: Haggle tried {attempts} times to backfill older solar history (back to {floor}), but AGL kept returning errors for at least one day, and has stopped retrying. The days that could not be fetched are permanently missing from the solar statistics. If those days matter to you, check whether the AGL app shows data for the same dates, then see the diagnostics guide (Learn more) for recovery options."
     },
     "solar_repair_gave_up": {
       "title": "Solar statistics repair gave up",
-      "description": "Haggle detected a downward step in the cumulative solar statistics and tried {attempts} times to rebuild the series (back to {floor}), but could not complete a clean sweep. A downward step may persist in the solar statistics. It can be corrected manually via Developer Tools → Statistics — see the diagnostics guide (Learn more)."
+      "description": "For entry {entry}: Haggle detected a downward step in the cumulative solar statistics and tried {attempts} times to rebuild the series (back to {floor}), but could not complete a clean sweep. A downward step may persist in the solar statistics. It can be corrected manually via Developer Tools → Statistics — see the diagnostics guide (Learn more)."
     },
     "solar_stall_gave_up": {
       "title": "Solar backfill skipped {start} to {end}",
-      "description": "AGL returned errors for every day in {start}..{end} for {cycles} consecutive polls, so Haggle marked the span as covered and moved on. These days are recorded as zero export and will not be retried automatically — a permanent gap in the solar statistics. If the AGL app shows data for these dates, see the diagnostics guide (Learn more) for recovery options."
+      "description": "For entry {entry}: AGL returned errors for every day in {start}..{end} for {cycles} consecutive polls, so Haggle marked the span as covered and moved on. These days are recorded as zero export and will not be retried automatically — a permanent gap in the solar statistics. If the AGL app shows data for these dates, see the diagnostics guide (Learn more) for recovery options."
     }
   }
 }

--- a/custom_components/haggle/translations/en.json
+++ b/custom_components/haggle/translations/en.json
@@ -70,5 +70,19 @@
         "name": "Solar feed-in rate"
       }
     }
+  },
+  "issues": {
+    "solar_heal_gave_up": {
+      "title": "Solar history backfill gave up",
+      "description": "Haggle tried {attempts} times to backfill older solar history (back to {floor}), but AGL kept returning errors for at least one day, and has stopped retrying. The days that could not be fetched are permanently missing from the solar statistics. If those days matter to you, check whether the AGL app shows data for the same dates, then see the diagnostics guide (Learn more) for recovery options."
+    },
+    "solar_repair_gave_up": {
+      "title": "Solar statistics repair gave up",
+      "description": "Haggle detected a downward step in the cumulative solar statistics and tried {attempts} times to rebuild the series (back to {floor}), but could not complete a clean sweep. A downward step may persist in the solar statistics. It can be corrected manually via Developer Tools → Statistics — see the diagnostics guide (Learn more)."
+    },
+    "solar_stall_gave_up": {
+      "title": "Solar backfill skipped {start} to {end}",
+      "description": "AGL returned errors for every day in {start}..{end} for {cycles} consecutive polls, so Haggle marked the span as covered and moved on. These days are recorded as zero export and will not be retried automatically — a permanent gap in the solar statistics. If the AGL app shows data for these dates, see the diagnostics guide (Learn more) for recovery options."
+    }
   }
 }

--- a/custom_components/haggle/translations/en.json
+++ b/custom_components/haggle/translations/en.json
@@ -74,15 +74,15 @@
   "issues": {
     "solar_heal_gave_up": {
       "title": "Solar history backfill gave up",
-      "description": "Haggle tried {attempts} times to backfill older solar history (back to {floor}), but AGL kept returning errors for at least one day, and has stopped retrying. The days that could not be fetched are permanently missing from the solar statistics. If those days matter to you, check whether the AGL app shows data for the same dates, then see the diagnostics guide (Learn more) for recovery options."
+      "description": "For entry {entry}: Haggle tried {attempts} times to backfill older solar history (back to {floor}), but AGL kept returning errors for at least one day, and has stopped retrying. The days that could not be fetched are permanently missing from the solar statistics. If those days matter to you, check whether the AGL app shows data for the same dates, then see the diagnostics guide (Learn more) for recovery options."
     },
     "solar_repair_gave_up": {
       "title": "Solar statistics repair gave up",
-      "description": "Haggle detected a downward step in the cumulative solar statistics and tried {attempts} times to rebuild the series (back to {floor}), but could not complete a clean sweep. A downward step may persist in the solar statistics. It can be corrected manually via Developer Tools → Statistics — see the diagnostics guide (Learn more)."
+      "description": "For entry {entry}: Haggle detected a downward step in the cumulative solar statistics and tried {attempts} times to rebuild the series (back to {floor}), but could not complete a clean sweep. A downward step may persist in the solar statistics. It can be corrected manually via Developer Tools → Statistics — see the diagnostics guide (Learn more)."
     },
     "solar_stall_gave_up": {
       "title": "Solar backfill skipped {start} to {end}",
-      "description": "AGL returned errors for every day in {start}..{end} for {cycles} consecutive polls, so Haggle marked the span as covered and moved on. These days are recorded as zero export and will not be retried automatically — a permanent gap in the solar statistics. If the AGL app shows data for these dates, see the diagnostics guide (Learn more) for recovery options."
+      "description": "For entry {entry}: AGL returned errors for every day in {start}..{end} for {cycles} consecutive polls, so Haggle marked the span as covered and moved on. These days are recorded as zero export and will not be retried automatically — a permanent gap in the solar statistics. If the AGL app shows data for these dates, see the diagnostics guide (Learn more) for recovery options."
     }
   }
 }

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -23,7 +23,12 @@ The file is built to be posted publicly:
 | Usage figures, rates, tariff bands, solar flags, timestamps | Included — they are the diagnostic payload and are not personally identifying. |
 | HA core / Python / OS versions | Added automatically by Home Assistant's diagnostics wrapper (`home_assistant` block). |
 
-## Schema v1 field reference
+Schema v2 adds give-up visibility: `stall_give_up_spans` and the
+`gave_up` marker on `solar_heal` — each such record is mirrored by an HA
+Repairs issue in Settings, so holes announce themselves instead of hiding
+behind healthy-looking coverage stats.
+
+## Schema v2 field reference
 
 For the automated triage routine and maintainers. The integration's payload
 is under the standard HA wrapper's `"data"` key. `schema_version` gates
@@ -32,7 +37,7 @@ fall back to treating the file as opaque JSON.
 
 | Field | Meaning | Diagnostic signal |
 |---|---|---|
-| `schema_version` | Payload shape contract (currently `1`). | Gate parsing on it. |
+| `schema_version` | Payload shape contract (currently `2`). | Gate parsing on it. |
 | `integration.version` | Installed Haggle version. | Satisfies the "Haggle version" triage check. |
 | `contract_ref` / `account_ref` | Stable anonymous install identifiers (HMAC-keyed per install). | Correlate multiple reports from the same install. |
 | `runtime_available` | Whether setup succeeded far enough to have runtime state. | `false` → the setup failure itself is the bug (auth/network); `coordinator` is `null` and `statistics` empty — don't chase data-shape theories. |
@@ -44,7 +49,8 @@ fall back to treating the file as opaque JSON.
 | `coordinator.active_tou_bands` | ToU bands with stored statistics. | Empty on a self-described ToU account → interval tagging or plan problem. |
 | `coordinator.bill_period_start` | Start date of the current AGL bill period (last seen). | Required context for any "period sensor ≠ app tile" report — the period sensors measure from this date, the app tile does too, but cumulative sensors don't. |
 | `coordinator.data.*` | Latest `HaggleData` snapshot (period totals, rates, cumulative sums, solar period values). | `generation_period_kwh: null` with solar → generation backfill not caught up, **or a heal cycle is suppressing it** — check `solar_heal`. |
-| `solar_heal` | One-time generation leading-hole heal record: `{state, floor, attempts}`; `null` if never armed. | `state: "pending"` → period solar sensors are deliberately `unknown` this cycle and a full-window re-import is in progress. `"done"` with a still-short period total → compare `statistics.<generation>.first_date` against `floor`. |
+| `solar_heal` | One-time generation leading-hole heal record: `{state, floor, attempts}`; `null` if never armed. | `state: "pending"` → period solar sensors are deliberately `unknown` this cycle and a full-window re-import is in progress. `"done"` with a still-short period total → compare `statistics.<generation>.first_date` against `floor`. A `done` record with `gave_up: true` (+ final `attempts`) was reached by give-up, not clean completion — some days are permanently missing. |
+| `stall_give_up_spans` | List of `{start, end, cycles, gave_up_at}` spans where the normal-path solar backfill gave up (#154) and wrote zero-delta markers; `null` if never. | The ONLY durable evidence of these holes — the marker rows make `first_date`/`row_count` look healthy over them. Any span here + a "solar missing days" report → this is the cause; the days will not self-heal. |
 | `statistics.<series>.first_date` | **Earliest** day stored per series. | Later than `bill_period_start` (or the 30-day floor) while `last_date` is current → **leading hole** (#128 class): the resume logic will never revisit those days on its own. |
 | `statistics.<series>.last_date` | Most recent day imported per statistics series. | More than ~3 days behind today → fetch stall (rate limit, auth, or zero-day stall classes). A missing series that should exist → that feature never started. |
 | `statistics.<series>.row_count` | Stored hourly rows in the series. | Far fewer rows than the `first_date`→`last_date` span implies → interior gaps (transient per-day fetch errors, #145 class). |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -298,8 +298,14 @@ regression test in `tests/test_coordinator_statistics.py`):
 - **Bounded give-up**: the solar leading-hole heal is capped at
   `MAX_SOLAR_HEAL_ATTEMPTS` (3) sweeps (lifetime hard cap 2×); a
   persistently erroring span is abandoned after
-  `SOLAR_STALL_GIVE_UP_CYCLES` (3) zero-progress cycles. Both produce rare
-  permanent holes rather than wedged integrations — accepted, logged at
+  `SOLAR_STALL_GIVE_UP_CYCLES` (3) zero-progress cycles. Every give-up is
+  user-visible: a persistent HA Repairs issue (ids key on the config
+  entry's random id, never an identifier) plus durable records — the heal
+  record's `gave_up`/`attempts` markers and the bounded
+  `solar_stall_spans` list in the entry data (dates and counts only,
+  Class C) — surfaced in diagnostics as `stall_give_up_spans`. Both
+  produce rare permanent holes rather than wedged integrations —
+  accepted, logged at
   WARNING (surfacing these as HA Repairs is tracked separately).
 - **Restart survival**: multi-cycle repair state is persisted in
   `entry.data` (`{state, floor, attempts}`), and the rotated refresh token

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -2413,7 +2413,9 @@ class TestGenerationHealState:
 
         registry = ir.async_get(hass)
         assert (
-            registry.async_get_issue(DOMAIN, f"solar_heal_gave_up_{_CONTRACT}")
+            registry.async_get_issue(
+                DOMAIN, f"solar_heal_gave_up_{coord.config_entry.entry_id}"
+            )
             is not None
         )
 
@@ -2605,7 +2607,9 @@ class TestGenerationHealState:
 
         registry = ir.async_get(hass)
         assert (
-            registry.async_get_issue(DOMAIN, f"solar_repair_gave_up_{_CONTRACT}")
+            registry.async_get_issue(
+                DOMAIN, f"solar_repair_gave_up_{coord.config_entry.entry_id}"
+            )
             is not None
         )
 
@@ -2726,10 +2730,12 @@ class TestSolarStallGiveUp:
         from homeassistant.helpers import issue_registry as ir
 
         registry = ir.async_get(hass)
+        gave_up_date = spans[0]["gave_up_at"][:10]
         assert (
             registry.async_get_issue(
                 DOMAIN,
-                f"solar_stall_gave_up_{_CONTRACT}_{chunk[0].isoformat()}",
+                f"solar_stall_gave_up_{coord.config_entry.entry_id}"
+                f"_{chunk[0].isoformat()}_{gave_up_date}",
             )
             is not None
         )

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -25,8 +25,10 @@ from custom_components.haggle.const import (
     CONF_CONTRACT_NUMBER,
     CONF_REFRESH_TOKEN,
     CONF_SOLAR_HEAL,
+    CONF_SOLAR_STALL_SPANS,
     DOMAIN,
     MAX_SOLAR_HEAL_ATTEMPTS,
+    MAX_STALL_SPAN_RECORDS,
     REWINDOW_DAYS,
     SOLAR_HEAL_DONE,
     SOLAR_HEAL_PENDING,
@@ -2403,7 +2405,38 @@ class TestGenerationHealState:
             },
             fetch_complete=False,
         )
-        assert self._heal(coord)["state"] == SOLAR_HEAL_DONE
+        heal = self._heal(coord)
+        assert heal["state"] == SOLAR_HEAL_DONE
+        assert heal["gave_up"] is True
+        assert heal["attempts"] == MAX_SOLAR_HEAL_ATTEMPTS
+        from homeassistant.helpers import issue_registry as ir
+
+        registry = ir.async_get(hass)
+        assert (
+            registry.async_get_issue(DOMAIN, f"solar_heal_gave_up_{_CONTRACT}")
+            is not None
+        )
+
+    async def test_clean_completion_records_no_give_up(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A clean sweep records plain done — no give-up marker, no Repairs
+        issue (the two previously collapsed to the same record; CO-16.4)."""
+        today = datetime.now(UTC).date()
+        coord, _, _, _ = await self._run(
+            hass,
+            preset={
+                "state": SOLAR_HEAL_PENDING,
+                "floor": (today - timedelta(days=25)).isoformat(),
+                "attempts": 1,
+            },
+            fetch_complete=True,
+        )
+        assert self._heal(coord) == {"state": SOLAR_HEAL_DONE}
+        from homeassistant.helpers import issue_registry as ir
+
+        registry = ir.async_get(hass)
+        assert not [i for i in registry.issues.values() if i.domain == DOMAIN]
 
     async def test_done_never_rearms(self, hass: HomeAssistant) -> None:
         """Once DONE, a still-present leading gap (needs_heal True) is NOT
@@ -2562,7 +2595,19 @@ class TestGenerationHealState:
             },
             fetch_complete=False,
         )
-        assert self._heal(coord) == {"state": SOLAR_HEAL_DONE, "repair": True}
+        assert self._heal(coord) == {
+            "state": SOLAR_HEAL_DONE,
+            "repair": True,
+            "gave_up": True,
+            "attempts": MAX_SOLAR_HEAL_ATTEMPTS,
+        }
+        from homeassistant.helpers import issue_registry as ir
+
+        registry = ir.async_get(hass)
+        assert (
+            registry.async_get_issue(DOMAIN, f"solar_repair_gave_up_{_CONTRACT}")
+            is not None
+        )
 
     async def test_period_totals_published_after_complete_drained_heal(
         self, hass: HomeAssistant
@@ -2673,6 +2718,46 @@ class TestSolarStallGiveUp:
         assert marked[-1] == chunk[1]
         assert len(marked) == BACKFILL_CHUNK_DAYS
         assert coord._solar_stall is None  # counter reset after give-up
+        spans = coord.config_entry.data[CONF_SOLAR_STALL_SPANS]
+        assert len(spans) == 1
+        assert spans[0]["start"] == chunk[0].isoformat()
+        assert spans[0]["end"] == chunk[1].isoformat()
+        assert spans[0]["cycles"] == SOLAR_STALL_GIVE_UP_CYCLES
+        from homeassistant.helpers import issue_registry as ir
+
+        registry = ir.async_get(hass)
+        assert (
+            registry.async_get_issue(
+                DOMAIN,
+                f"solar_stall_gave_up_{_CONTRACT}_{chunk[0].isoformat()}",
+            )
+            is not None
+        )
+
+    async def test_stall_span_list_is_bounded(self, hass: HomeAssistant) -> None:
+        """The persisted span list drops the oldest beyond
+        MAX_STALL_SPAN_RECORDS so entry.data stays small."""
+        coord = _make_coordinator(hass)
+        dummies = [
+            {
+                "start": f"2026-01-{d:02d}",
+                "end": f"2026-01-{d:02d}",
+                "cycles": 3,
+                "gave_up_at": "2026-01-01T00:00:00+00:00",
+            }
+            for d in range(1, MAX_STALL_SPAN_RECORDS + 1)
+        ]
+        hass.config_entries.async_update_entry(
+            coord.config_entry,
+            data={**coord.config_entry.data, CONF_SOLAR_STALL_SPANS: dummies},
+        )
+        chunk = self._chunk()
+        with patch.object(coord, "_import_generation", new_callable=AsyncMock):
+            for _ in range(SOLAR_STALL_GIVE_UP_CYCLES):
+                await coord._track_solar_stall(chunk, progressed=False, skipped=True)
+        spans = coord.config_entry.data[CONF_SOLAR_STALL_SPANS]
+        assert len(spans) == MAX_STALL_SPAN_RECORDS
+        assert spans[-1]["start"] == chunk[0].isoformat()  # newest last
 
     async def test_progress_resets_counter(self, hass: HomeAssistant) -> None:
         """Any successful day (even alongside skips) resets the count — the

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -313,6 +313,35 @@ class TestSagaFields:
         assert result["solar_heal"] == heal
         assert CONF_SOLAR_HEAL not in result["entry"]["data"]
 
+    async def test_stall_spans_surfaced(self, hass: HomeAssistant) -> None:
+        """Stall give-up spans appear top-level, never under entry.data —
+        they are the only durable evidence of marker-masked holes (CO-16.4)."""
+        from custom_components.haggle.const import CONF_SOLAR_STALL_SPANS
+
+        spans = [
+            {
+                "start": "2026-06-01",
+                "end": "2026-06-07",
+                "cycles": 3,
+                "gave_up_at": "2026-06-10T00:00:00+00:00",
+            }
+        ]
+        entry = await _make_entry(hass, has_solar=True)
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_SOLAR_STALL_SPANS: spans}
+        )
+        with _patched_stats():
+            result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["stall_give_up_spans"] == spans
+        assert CONF_SOLAR_STALL_SPANS not in result["entry"]["data"]
+
+    async def test_stall_spans_none_when_never(self, hass: HomeAssistant) -> None:
+        entry = await _make_entry(hass)
+        with _patched_stats():
+            result = await async_get_config_entry_diagnostics(hass, entry)
+        assert result["stall_give_up_spans"] is None
+
     async def test_solar_heal_none_when_never_armed(self, hass: HomeAssistant) -> None:
         entry = await _make_entry(hass)
         with _patched_stats():


### PR DESCRIPTION
## SDLC remediation — WP7 PR-1 (CO-16.4)

Closes the 'permanent data loss with no alert' gap the compliance review flagged: both solar give-up classes now announce themselves.

### The problem
- **Heal/repair give-up** logged a WARNING/ERROR and wrote a done record *identical to clean completion* — post-hoc diagnosis was impossible.
- **Stall give-up** (#154) wrote zero-delta marker rows that make `first_date`/`row_count` look healthy over the hole, and its counter was in-memory only — the log line was the sole artifact of permanent data loss.

### The fix
- Persistent, non-fixable **HA Repairs issues** for all three paths (heal WARN / repair ERROR / per-span stall WARN), with learn-more → the diagnostics guide. Distinct issue ids per event class + contract (+ span start for stalls) so a dismissal can't mask a later, different event. No auto-delete: the underlying data condition is permanent by construction (done never re-arms).
- Heal record distinguishes give-up (`gave_up`, `attempts`) from clean completion.
- Stall spans persisted (`solar_stall_spans`, bounded at 12) and surfaced in **diagnostics schema v2** as `stall_give_up_spans` — routed through the standard scrub pass; dates only, nothing identifier-bearing.
- `docs/diagnostics.md` updated to v2 in the same PR (house rule).

### Deviations from the WP7 spec (both improvements)
- `dt_util.utcnow()` instead of `datetime.now(UTC)` (HA-idiomatic, already imported).
- No `translation_placeholders` in issue ids — ids stay stable across HA locale changes.

### Tests
Give-up records + registry issues asserted for all three paths; **clean completion asserted to create no issue** (the previously-indistinguishable case); span-list boundedness; diagnostics surfacing incl. never-under-entry.data. 241 passed, coverage 90.15% (floor 89).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsw8k4NU2AqSkrWZStXnj4