### PR TITLE
fix: suppress bill-period solar totals on every frozen-writes cycle

### DIFF
--- a/custom_components/haggle/coordinator.py
+++ b/custom_components/haggle/coordinator.py
@@ -337,13 +337,15 @@ class HaggleCoordinator(DataUpdateCoordinator[HaggleData]):
         # on a cycle that planned no sweep (e.g. solar writes frozen via
         # options, CO-10.3) — publishing totals from it would be a standing
         # undercount. A wrong number is worse than a blank one.
-        heal_pending = (self.config_entry.data.get(CONF_SOLAR_HEAL) or {}).get(
-            "state"
-        ) == SOLAR_HEAL_PENDING
-        publish_period = (heal_ctx is None and not heal_pending) or (
-            # the drain-and-publish shortcut (#152) applies only when a heal
-            # sweep actually ran this cycle — a frozen cycle's successful
-            # consumption fetch must not satisfy it
+        # Frozen solar writes (options, CO-10.3) suppress the period totals
+        # outright: with planning skipped, the heal DETECTOR never runs, so an
+        # unhealed leading hole may exist with no pending record to prove it —
+        # publishing would be a standing undercount. A wrong number is worse
+        # than a blank one. (This also covers the persisted-PENDING case.)
+        # When enabled, the gate is unchanged: no sweep in flight, or a
+        # completed-and-drained sweep (#152) — the shortcut stays scoped to
+        # cycles where a sweep actually ran.
+        publish_period = (heal_ctx is None and self._solar_writes_enabled()) or (
             heal_ctx is not None and fetch_complete and await self._recorder_drained()
         )
         if self._has_solar and publish_period:

--- a/custom_components/haggle/strings.json
+++ b/custom_components/haggle/strings.json
@@ -93,7 +93,7 @@
           "solar_statistics_enabled": "Write solar statistics (backfill and self-heal)"
         },
         "data_description": {
-          "solar_statistics_enabled": "Turn off to freeze all solar statistics writes (backfill, self-heal, give-up markers) without uninstalling or downgrading. Existing statistics are untouched; solar sensors stop updating and eventually show 'unknown'. Takes effect from the next poll. Consumption statistics are unaffected."
+          "solar_statistics_enabled": "Turn off to freeze all solar statistics writes (backfill, self-heal, give-up markers) without uninstalling or downgrading. Existing statistics are untouched; the bill-period solar sensors read 'unknown' while disabled and the cumulative sensors keep their last stored values. Takes effect from the next poll. Consumption statistics are unaffected."
         }
       }
     }

--- a/custom_components/haggle/translations/en.json
+++ b/custom_components/haggle/translations/en.json
@@ -93,7 +93,7 @@
           "solar_statistics_enabled": "Write solar statistics (backfill and self-heal)"
         },
         "data_description": {
-          "solar_statistics_enabled": "Turn off to freeze all solar statistics writes (backfill, self-heal, give-up markers) without uninstalling or downgrading. Existing statistics are untouched; solar sensors stop updating and eventually show 'unknown'. Takes effect from the next poll. Consumption statistics are unaffected."
+          "solar_statistics_enabled": "Turn off to freeze all solar statistics writes (backfill, self-heal, give-up markers) without uninstalling or downgrading. Existing statistics are untouched; the bill-period solar sensors read 'unknown' while disabled and the cumulative sensors keep their last stored values. Takes effect from the next poll. Consumption statistics are unaffected."
         }
       }
     }

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -2742,6 +2742,50 @@ class TestGenerationHealState:
         # the pending record must be untouched — no phantom attempt burned
         assert coord.config_entry.data[CONF_SOLAR_HEAL]["attempts"] == 1
 
+    async def test_frozen_writes_suppress_totals_without_pending_record(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Freezing BEFORE a heal was ever armed leaves no pending record —
+        the heal detector never ran, so an unhealed leading hole may exist
+        undetected. Period totals stay suppressed on every frozen cycle."""
+        coord = _make_coordinator(
+            hass,
+            client=self._solar_client(),
+            options={OPT_SOLAR_STATISTICS_ENABLED: False},
+        )
+        today = datetime.now(UTC).date()
+        yesterday = today - timedelta(days=1)
+        stat_id_cons = f"{DOMAIN}:{STAT_CONSUMPTION}_{_CONTRACT}"
+
+        async def _last_stat(stat_id: str) -> tuple[float | None, date | None]:
+            if stat_id == stat_id_cons:
+                return (500.0, yesterday)
+            return (12.3, yesterday)
+
+        with (
+            patch.object(coord, "_get_last_stat", side_effect=_last_stat),
+            patch.object(
+                coord, "_fetch_range", new_callable=AsyncMock, return_value=True
+            ),
+            patch.object(
+                coord,
+                "_get_generation_period_totals",
+                new_callable=AsyncMock,
+                return_value=(4.0, 1.0),
+            ) as mock_totals,
+            patch.object(coord, "_import_intervals", new_callable=AsyncMock),
+            patch.object(
+                coord,
+                "_get_stored_tou_bands",
+                new_callable=AsyncMock,
+                return_value=set(),
+            ),
+        ):
+            data = await coord._fetch_and_import()
+        mock_totals.assert_not_awaited()
+        assert data.generation_period_kwh is None
+        assert CONF_SOLAR_HEAL not in coord.config_entry.data
+
     async def test_option_default_keeps_solar_writes(self, hass: HomeAssistant) -> None:
         """Options absent -> solar planning runs (pins the default)."""
         coord = _make_coordinator(hass, client=self._solar_client())


### PR DESCRIPTION
Fix-forward for Codex's valid post-merge finding on #195: freezing solar writes before a heal was ever armed skips planning, so the heal detector never runs — an unhealed leading hole can exist with **no pending record to prove it**, and the `heal_pending` guard saw nothing. Totals are now suppressed outright on frozen cycles (wrong-number-worse-than-blank doctrine); when enabled, the gate is unchanged. Red-then-green regression test; options wording updated to the immediate-unknown behaviour. 253 tests, 90.27% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsw8k4NU2AqSkrWZStXnj4