### PR TITLE
chore(release): v0.4.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-beta.6] — 2026-07-14
+
 ### Security
 
 - **HACS now installs the attested release zip itself** (`zip_release` +

--- a/custom_components/haggle/manifest.json
+++ b/custom_components/haggle/manifest.json
@@ -1,16 +1,22 @@
 {
   "domain": "haggle",
   "name": "AGL Haggle",
-  "after_dependencies": ["recorder"],
-  "codeowners": ["@naanyabiz"],
+  "after_dependencies": [
+    "recorder"
+  ],
+  "codeowners": [
+    "@naanyabiz"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/NaanyaBiz/haggle",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/NaanyaBiz/haggle/issues",
-  "loggers": ["custom_components.haggle"],
+  "loggers": [
+    "custom_components.haggle"
+  ],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.4.0-beta.5"
+  "version": "0.4.0-beta.6"
 }


### PR DESCRIPTION
Version bump for the **canary release** validating the WP4 release chain end-to-end. Everything under `[Unreleased]` moves to `[0.4.0-beta.6]`: WP7 runtime batch (Repairs issues, Auth0 revoke, solar-writes toggle, ceiling tests), WP4 release chain (attested-zip HACS path, fail-closed ancestry + tag-signature gates, attested SBOMs), WP5/WP6 security-docs batch.

Post-merge sequence: signed tag `v0.4.0-beta.6` on the squash commit → release.yml runs both gates → 7-asset attested release → verify commands → maintainer's live HACS install + beta.5 downgrade test → soak clock starts.

No Codex review requested — version-bump-only diff (manifest version + changelog sectioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsw8k4NU2AqSkrWZStXnj4