### PR TITLE
chore: acceptance-criteria field + checklist discipline (WP8 PR-4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -16,6 +16,18 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: >-
+        Testable pass/fail statements for "this feature is done" — e.g.
+        "sum of exported kWh matches the AGL app's Sold-to-Grid tile for
+        the same day". Optional: if left empty on a non-trivial request,
+        the maintainer states them on the issue before implementation.
+    validations:
+      required: false
+
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,10 @@
 - [ ] This PR was generated or co-authored by Claude (Anthropic).
       All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
 - [ ] The human maintainer has reviewed and understands every change.
+
+<!--
+Checklist discipline: before merge, every box above must be either ticked
+or deleted with a one-line reason inline. The "human maintainer has
+reviewed" box is this repo's core provenance claim — a PR must not merge
+with it unchecked.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,11 @@ invisible to anyone who doesn't already know to look.
 GitHub auto-closes on merge. If a PR partially addresses an issue,
 comment on the issue rather than closing it.
 
+Non-trivial feature issues state acceptance criteria up front (the
+feature template has an optional field; if it is left empty the
+maintainer states them on the issue before implementation); the closing
+PR's test plan references them.
+
 When mid-sprint code-review or audit work surfaces a tail of items,
 spawn issues for each one and label-and-prioritise them rather than
 trying to fold everything into the current PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,10 @@ Every PR that touches code (not pure CI/tooling fixes) must update:
   facts changed; "What NOT to Do" if a footgun was discovered.
 - `Closes #N` in the PR body if it resolves an open issue.
 
+Checklist boxes are evidence, not decoration: before merge, every box is
+either ticked or deleted with a one-line reason. The AI-generation /
+human-review disclosure boxes must never merge unchecked.
+
 The `/pr` slash command (Claude Code) walks through this checklist and
 opens the PR with a sensible body.
 


### PR DESCRIPTION
## Summary

- **Feature template** gains an optional "Acceptance criteria" textarea (CO-15.4): testable pass/fail statements; kept optional deliberately — hard-required form fields deter the drive-by beta testers whose reports are the acceptance channel (won't-fix register item). If empty on a non-trivial request, the maintainer states them on the issue before implementation (rule added to AGENTS.md § GitHub Issues Workflow).
- **Checklist discipline** (CO-15.4 exhibit: PR #177 merged with the human-review box unchecked): `.github/pull_request_template.md` and `CONTRIBUTING.md` now state that before merge every checklist box is either ticked or deleted with a one-line reason, and the AI-generation / human-review disclosure boxes never merge unchecked.

**Pending second commit**: the spec'd matching pre-merge gate in `.claude/commands/pr.md` was blocked by the self-modification permission gate — it will be added to this branch once the maintainer approves that edit (flagged in session).

## Test plan

- [x] `feature.yml` is valid YAML (pre-commit check-yaml passed); field renders as optional — verify via the "Feature request" template on GitHub after merge
- [x] No code touched — `pytest`/`ruff`/`mypy` unaffected; CI will confirm
- Manual test on a real HA instance: N/A — templates and docs only

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [x] The human maintainer has reviewed and understands every change.
