### PR TITLE
ci: weekly compat run vs latest phcc/HA (WP8 PR-3)

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,85 @@
+name: Compat
+
+# Early-warning canary: run the full suite against the LATEST
+# pytest-homeassistant-custom-component and homeassistant (including
+# betas — phcc releases near-daily tracking HA dev). Deliberately
+# non-blocking: schedule + manual dispatch only, never a PR check.
+# A failure here means the NEXT HA release will likely break us,
+# not that main is broken. Failures open/refresh one ha-compat issue.
+
+on:
+  schedule:
+    # Weekly Tuesday 05:17 UTC — offset from CodeQL (Mon 03:17),
+    # Scorecard (Mon 04:22), Fuzz (Mon 05:42) and settings-drift
+    # (Tue 04:37) crons.
+    - cron: "17 5 * * 2"
+  workflow_dispatch:
+
+# Zero default perms; each job states exactly what it needs
+# (zizmor excessive-permissions gate rejects blanket read-all).
+permissions: {}
+
+jobs:
+  compat:
+    name: Suite vs latest phcc/HA
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --extra dev
+
+      - name: Upgrade to latest harness + HA (incl. beta)
+        run: |
+          uv pip install --upgrade --prerelease=allow \
+            pytest-homeassistant-custom-component homeassistant
+          echo "Versions under test:"
+          uv pip list | grep -E '^(homeassistant|pytest-homeassistant)'
+
+      # --no-sync: uv run would otherwise re-sync the venv back to
+      # uv.lock and silently undo the upgrade above.
+      - name: Pytest vs latest
+        run: uv run --no-sync pytest --no-cov
+
+  report:
+    name: Open/refresh ha-compat issue
+    # gh CLI only — no actions at all in the one job holding a write scope
+    # (repo rule: third-party actions never share a job with write perms).
+    needs: compat
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: File or update tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          open_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label ha-compat --state open --json number --jq '.[0].number // empty')
+          if [ -n "$open_issue" ]; then
+            gh issue comment "$open_issue" --repo "$GITHUB_REPOSITORY" \
+              --body "Weekly compat run failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Weekly compat run vs latest phcc/HA failed" \
+              --label ha-compat \
+              --body "The suite fails against the latest pytest-homeassistant-custom-component / homeassistant (incl. beta). Upstream HA change likely to break the next release window. Run: $RUN_URL — versions under test are printed in the 'Upgrade to latest harness' step."
+          fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -15,6 +15,14 @@ on:
     - cron: "17 5 * * 2"
   workflow_dispatch:
 
+# Serialize runs: a manual dispatch overlapping the scheduled run could
+# otherwise race the report job's list-then-create and file duplicate
+# ha-compat issues (Codex, #203). Queued, never cancelled — every run
+# still executes.
+concurrency:
+  group: compat
+  cancel-in-progress: false
+
 # Zero default perms; each job states exactly what it needs
 # (zizmor excessive-permissions gate rejects blanket read-all).
 permissions: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ scripts/
 │   ├── hassfest.yml     # Home Assistant integration manifest validation
 │   ├── release.yml      # tag-triggered Release (first-party gh CLI): tag-on-main + tag-signature gates, HACS-installed attested zip (zip_release), SBOM attestations, check-run snapshot
 │   ├── codeql.yml       # weekly + per-PR CodeQL Python scan
+│   ├── compat.yml       # weekly non-blocking suite vs latest phcc/HA (incl. beta) — early upstream-breakage warning
 │   ├── scorecard.yml    # weekly + on-push OpenSSF Scorecard self-assessment (feeds README badge)
 │   ├── fuzz.yml         # weekly deep run + unconditional 120s PR smoke; corpus cached across runs; crash artifacts uploaded
 │   └── settings-drift.yml # weekly: re-export rulesets + public repo settings, diff vs .github/settings/, issue on drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Weekly compat canary** (`.github/workflows/compat.yml`, CO-15.6): runs
+  the full suite against the latest `pytest-homeassistant-custom-component`
+  and `homeassistant` (including betas) every Tuesday — days-early warning
+  of upstream HA breakage. Non-blocking by construction (never a PR check);
+  failures open or refresh a single `ha-compat` issue.
+
 ## [0.4.0-beta.6] — 2026-07-14
 
 ### Security


### PR DESCRIPTION
## Summary

- **New `.github/workflows/compat.yml`** (CO-15.6): weekly (Tue 05:17 UTC, offset from the four existing crons) + manual-dispatch run of the full suite against the **latest** `pytest-homeassistant-custom-component` and `homeassistant` including betas — phcc releases near-daily tracking HA's tip, so this gives days-early warning of upstream breakage before it can reach a Dependabot dev-deps PR.
- Deliberately **non-blocking**: never a PR check (ruleset's required checks untouched); a failure means "the next HA release will likely break us", not "main is broken". Failures open or refresh a single `ha-compat`-labelled issue.
- House rules held: first-party + already-allowlisted actions only, same Dependabot-maintained SHAs as `ci.yml`; `permissions: {}` top-level with explicit job grants (zizmor gate clean); the only job holding a write scope (`issues: write`) runs **zero actions** — `gh` CLI only; `persist-credentials: false` on checkout.
- Two verified execution gotchas encoded as comments: `uv run --no-sync` (plain `uv run` re-syncs the venv back to `uv.lock`, silently undoing the upgrade) and `--prerelease=allow` on the upgrade.
- `ha-compat` label created (one-shot `gh` mutation — labels are not settings-as-code, same precedent as the WP9-A taxonomy labels).

Post-merge validation: I'll dispatch `compat.yml` once and confirm (a) versions-under-test print in the log, (b) green run, (c) it does not appear as a check on any open PR.

## Test plan

- [x] `actionlint` + `zizmor --min-severity medium` clean (pre-commit hooks, exact CI toolchain)
- [x] No code/deps touched — `uv.lock` untouched; suite unaffected
- Manual test on a real HA instance: N/A — CI plumbing only

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [x] The human maintainer has reviewed and understands every change.
