### PR TITLE
docs: release acceptance policy + beta-soak rule (WP8 PR-5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ tests/
 
 docs/
 ├── energy-dashboard.md  # user guide — which haggle:* statistics to add per plan type, sensor glossary, troubleshooting (#137 footgun)
+├── releasing.md         # release acceptance policy — beta-soak rule, hotfix evidence rule, downgrade test, acceptance record
 ├── diagnostics.md       # diagnostics schema v1 reference — users + triage routine (bump with DIAGNOSTICS_SCHEMA_VERSION)
 ├── threat-model.md      # living threat model — trust boundaries, STRIDE register + dispositions, AI agents, regulatory scope, resilience targets
 └── agents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release acceptance policy** (`docs/releasing.md`, CO-15.5, CO-10.1):
+  standing beta-soak rule (≥ 7 days on the maintainer's live HA +
+  AGL-app reconciliation + zero open `beta-blocker` issues before any
+  stable), the hotfix-evidence rule for stables that skip the ladder, the
+  once-per-stable manual downgrade test, and the acceptance-evidence
+  record every stable release PR must carry. New `beta-blocker` label
+  gates promotion.
+
 ## [0.4.0-beta.6] — 2026-07-14
 
 ### Security

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,64 @@
+# Release acceptance policy
+
+Channel model: every MINOR ships as `vX.Y.0-beta.N` prereleases on the
+HACS beta channel first, then promotes to stable with zero code diff.
+PATCH releases (hotfixes) may skip the ladder only under the hotfix rule
+below. `release.yml` marks any tag containing `-` as a prerelease.
+
+## Beta-soak rule (standing)
+
+A stable `vX.Y.0` may be tagged only when ALL of:
+
+1. **Soak**: the latest `vX.Y.0-beta.N` has run ≥ 7 days on the
+   maintainer's live HA instance with zero regressions attributable to it.
+2. **Reconciliation**: Energy dashboard daily kWh (and, on solar
+   contracts, sold-to-grid kWh) reconciles with the AGL app for at least
+   one complete recent day (delta ≤ 0.05 kWh — AGL rounds to 2 dp).
+3. **Zero beta blockers**: `gh issue list --label beta-blocker --state
+   open` is empty. Tag beta-user reports that must gate promotion with
+   `beta-blocker` as they arrive.
+
+## Hotfix rule (stables that skip the ladder)
+
+A PATCH stable fixing a severe defect may ship without beta soak ONLY
+with recorded validation evidence in the release PR: what was verified,
+against what ground truth (live recorder inspection, AGL portal CSV,
+app reconciliation), on which HA version. "CI is green" alone is not
+validation evidence for a statistics-path fix.
+
+## Acceptance evidence record
+
+The `chore(release)` PR body for every stable release carries an
+"Acceptance evidence" section (the release-manager agent enforces this):
+soak duration or hotfix evidence, reconciliation result, beta-blocker
+count, and the downgrade-test result (below). The CHANGELOG promote
+entry summarises the same in one line. This PR body is the release's
+acceptance sign-off record.
+
+## Downgrade test (once per stable line)
+
+Before or with each stable `vX.Y.z`, run one manual downgrade test from
+the new version to the previous stable and record the result in the
+release PR + CHANGELOG:
+
+1. On an HA instance running the new version: note the last poll time
+   and current Energy-dashboard daily totals.
+2. HACS → Haggle → ⋮ → Redownload → select the previous stable →
+   restart HA.
+3. Verify: config entry loads (no repair/setup error), a manual poll
+   or the next scheduled poll succeeds, daily kWh totals unchanged
+   (no double-count — imports are idempotent on (statistic_id, start)).
+4. Redownload back to the new version → restart → verify the entry
+   loads and (0.4.x+) any solar heal record resumes without a re-sweep
+   storm (one bounded backfill of the gap is expected and correct).
+
+## Risk acceptances (structural, not fixable by process)
+
+- **No second human acceptor.** Acceptance is the maintainer dogfooding
+  his own production instance plus volunteer beta testers on issues.
+  Accepted; the compensating control is the recorded evidence above.
+- **No automated health-based rollback.** Pull-based, telemetry-free
+  distribution cannot observe installed-base health or push a rollback.
+  Building telemetry to satisfy this clause would be worse than the gap.
+  Remediation on failure = yank the release + fast forward-fix
+  (demonstrated: v0.1.0 yank; v0.2.1-3 within 28 h).


### PR DESCRIPTION
## Summary

- **`docs/releasing.md`** (CO-15.5, CO-10.1): the release acceptance policy as a standing rule instead of tribal knowledge — beta-soak rule (latest `vX.Y.0-beta.N` ≥ **7 days** on the maintainer's live HA + AGL-app reconciliation ≤ 0.05 kWh + zero open `beta-blocker` issues), the hotfix-evidence rule for PATCH stables that skip the ladder ("CI is green" is explicitly not validation evidence for a statistics-path fix), the once-per-stable manual downgrade test procedure, and the acceptance-evidence record every stable release PR body must carry.
- Records the two structural risk acceptances honestly (no second human acceptor; no telemetry-based rollback — yank + fast forward-fix is the demonstrated remediation).
- New `beta-blocker` label created (one-shot `gh` mutation, same precedent as the taxonomy labels).

**Policy note for the maintainer**: the ≥ 7-day soak is a real policy change vs the v0.2.0-era "24 h+ soak" — you flagged approval of this floor as your call in the program's decision list. Merging this PR sets it. With beta.6 published 2026-07-14, earliest compliant v0.4.0 stable ≈ **2026-07-21** (or sooner only via the hotfix-evidence path).

**Pending second commit**: the matching `/release` pre-condition gates (`.claude/commands/release.md`) and the release-manager acceptance-evidence PR-body template (`.claude/agents/release-manager.md`) are blocked by the self-modification permission gate — they'll be added to this branch once approved (flagged in session). The policy doc is authoritative either way.

## Test plan

- [x] Docs + label only — no code, CI will confirm required checks
- [x] Soak computation dry-run against live data: newest `v0.4.0-*` release = beta.6 published 2026-07-14 → soak-days math verified
- [x] `gh issue list --label beta-blocker --state open` runs and returns empty (label exists)
- Manual test on a real HA instance: N/A — docs only

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [x] The human maintainer has reviewed and understands every change.
