### PR TITLE
docs: rollback / downgrade guide (WP8 PR-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Rollback / downgrade guide** (README, CO-15.6): any prior release can
+  be reinstalled via HACS Redownload — config entries are downgrade-safe
+  (newer versions only add keys; schema version has never changed),
+  statistics survive (idempotent imports; a wipe is only ever needed when
+  leaving a version whose release notes say it corrupted sums), and
+  downgrading below v0.4.0 merely freezes the solar series until
+  re-upgrade. Cross-linked from the Energy-dashboard troubleshooting doc.
+
 ## [0.4.0-beta.6] — 2026-07-14
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ security settings. Your imported `haggle:*` statistics are deliberately kept (th
 your own meter history); prune them via Developer Tools → Statistics if you want them
 gone.
 
+## Rollback / downgrade
+
+Any prior release (except yanked ones) can be reinstalled:
+**HACS → Haggle → ⋮ → Redownload → pick the version → restart HA.**
+
+- **Config entries are downgrade-safe.** Newer versions only *add* keys
+  to the stored entry (e.g. the solar-heal record, TLS-pin hashes);
+  older versions ignore keys they don't know, and the entry schema
+  version has never changed. No re-setup needed in either direction.
+- **Statistics survive.** Downgrading never requires touching the
+  recorder: imports are idempotent, so the older version simply
+  overwrites the trailing rewindow with its own (identical) sums. A
+  statistics wipe is only needed when the release notes for the version
+  you are *leaving* say it wrote corrupted sums — the procedure (delete
+  the `haggle:*` rows from `statistics` / `statistics_short_term`, let
+  the 30-day backfill rebuild) is in the CHANGELOG entries that need it.
+- **Solar caveat**: downgrading below v0.4.0 freezes the
+  `haggle:generation_*` series (history stays, no new rows). On
+  re-upgrade the gap backfills automatically.
+- **Outage tolerance**: AGL data lags 24–48 h anyway and every poll
+  re-fetches the trailing 7 days on top of a 30-day backfill floor —
+  an outage or rollback window of hours-to-days loses no data.
+
+Each stable release records a manual downgrade test to the previous
+stable in its release PR (see `docs/releasing.md`).
+
 ## Energy dashboard
 
 **Add the `haggle:…` statistics as your dashboard sources — never the

--- a/docs/energy-dashboard.md
+++ b/docs/energy-dashboard.md
@@ -56,6 +56,10 @@ not for the Energy dashboard:
 
 ## Troubleshooting
 
+Suspect a recently-updated Haggle version rather than your dashboard
+config? Any prior release can be reinstalled safely — see
+[Rollback / downgrade](../README.md#rollback--downgrade) in the README.
+
 **A whole day shows as one big bar, on the wrong day.**
 The dashboard is charting a `sensor.…` entity instead of the `haggle:…`
 statistic. Remove the sensor from the dashboard's sources and add the


### PR DESCRIPTION
## Summary

- **README "Rollback / downgrade" section** (CO-15.6): users can reinstall any prior release via HACS Redownload. The downgrade-tolerance claims were verified against source, not assumed (work paper): v0.3.1's `__init__.py` reads only `CONF_REFRESH_TOKEN` via `[]` and everything else via `.get()`, never schema-validates `entry.data`, so 0.4.x-only keys (solar-heal record, TLS pins) are ignored and survive the downgrade round-trip; `config_flow.VERSION = 1` on both sides — no migration gate.
- Statistics guidance: downgrade never requires a recorder wipe (idempotent on `(statistic_id, start)`); a wipe is only needed when *leaving* a version whose release notes say it wrote corrupted sums. Solar caveat: below v0.4.0 the `haggle:generation_*` series freezes (history intact), self-fills on re-upgrade.
- Cross-link from `docs/energy-dashboard.md` § Troubleshooting.
- The per-release manual downgrade *test* is operational, defined in `docs/releasing.md` (PR #204) — first execution at the v0.4.0 stable promote. Automating it in CI was recommended against (full HA+HACS container rig for a 10-minute, ~4×/year manual check).

Merge note: references `docs/releasing.md`, so merge after (or alongside) #204.

## Test plan

- [x] Docs only — markdown renders; anchor `#rollback--downgrade` matches the heading
- [x] No code touched — CI will confirm required checks
- Manual test on a real HA instance: N/A — docs only (the documented downgrade procedure itself gets its first recorded execution at the v0.4.0 stable promotion)

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [x] The human maintainer has reviewed and understands every change.
