### PR TITLE
chore: agent-side gates for checklist discipline + release acceptance

### DIFF
--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -44,6 +44,26 @@ If any check fails, report the failure and stop. Do not create a release from a 
 1. `custom_components/haggle/manifest.json` → `"version": "X.Y.Z"`
 2. (hacs.json does NOT contain a version field — skip)
 3. `CHANGELOG.md` → move `## [Unreleased]` items to `## [X.Y.Z] - YYYY-MM-DD`
+4. `CHANGELOG.md` → add the escaped-defect count line directly under the
+   new `## [X.Y.Z] — YYYY-MM-DD` heading (before the first `###`
+   subsection). Count `escaped`-labelled issues closed since the previous
+   release was published:
+
+   ```bash
+   PREV_DATE=$(gh release list --limit 1 --json publishedAt --jq '.[0].publishedAt')
+   gh issue list --state closed --label escaped --limit 200 \
+     --json number,closedAt,labels \
+     --jq "[.[] | select(.closedAt > \"$PREV_DATE\") | {n: .number, high: ([.labels[].name] | index(\"sev:high\") != null)}]"
+   ```
+
+   Write the line even when the count is zero (the zero is the evidence):
+
+   `**Escaped defects closed this release:** 2 (1 sev:high) — #126, #147.`
+   `**Escaped defects closed this release:** 0.`
+
+   release.yml copies the whole section into the GitHub Release notes, so
+   this line ships in the release notes automatically — do not edit
+   release.yml.
 
 ## Bump via PR (the ruleset blocks direct commits to main)
 
@@ -63,6 +83,27 @@ gh pr create --title "chore(release): v$VERSION" --body "Version bump for v$VERS
 gh pr checks --watch   # wait for green
 gh pr merge --squash   # halts on the interactive permission prompt — the human approval IS the release gate
 ```
+
+For **stable** releases the PR body MUST carry the acceptance record
+(values supplied by the /release command; never invented — prereleases
+keep the plain one-line body above):
+
+    gh pr create --title "chore(release): v$VERSION" --body "$(cat <<'EOF'
+    Version bump for v$VERSION.
+
+    ## Acceptance evidence
+    - Beta soak: v$VERSION-beta.N published <date> → <N> days on the
+      maintainer's live HA, zero regressions
+      (or: HOTFIX — validation: <evidence supplied by Dave>)
+    - App reconciliation: <date> — dashboard <X.XX> kWh vs app <X.XX> kWh
+    - Beta blockers: 0 open (`beta-blocker` label)
+    - Downgrade test: v$VERSION → v<prev stable> redownload — entry loads,
+      no double-count, re-upgrade clean
+    EOF
+    )"
+
+Also copy the soak/hotfix line into the CHANGELOG `## [X.Y.Z]` promote
+entry.
 
 ## Tag the squash-merge commit (signed)
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -102,6 +102,12 @@ gh pr create \
   --body "<body>"
 ```
 
+> **Before merging (required)**: re-read the PR body on GitHub. Every
+> checklist box must be ticked or deleted-with-reason (`gh pr view
+> <number> --json body`). If the "human maintainer has reviewed and
+> understands every change" box is unchecked, STOP — ask Dave to review
+> and tick it; do not merge.
+
 > **Note — merging from a worktree**: `gh pr merge` will fail because
 > `main` is checked out in the primary worktree. Use the GitHub API
 > instead:

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -18,6 +18,22 @@ Example:
 1. Working tree is clean (`git status --porcelain` returns empty).
 2. On `main` branch.
 3. Latest CI run on `main` is green (`gh run list --branch main --limit 1`).
+4. **Stable versions only** (no `-` in the version): the acceptance gate
+   of `docs/releasing.md` passes —
+   a. Beta soak ≥ 7 days since the newest `v<version>-beta.*` release
+      (compute below), OR Dave supplies an explicit hotfix-validation
+      statement to embed in the release PR;
+   b. `gh issue list --label beta-blocker --state open` is empty;
+   c. Dave confirms the app-reconciliation result and downgrade-test
+      result to record (ask; do not invent numbers).
+
+   ```bash
+   LAST_BETA_DATE=$(gh release list --limit 40 --json tagName,publishedAt \
+     --jq "[.[] | select(.tagName | startswith(\"v$VERSION-\"))] | first | .publishedAt // empty")
+   if [ -n "$LAST_BETA_DATE" ]; then
+     python3 -c "from datetime import datetime,timezone;d=datetime.fromisoformat('$LAST_BETA_DATE'.replace('Z','+00:00'));print('soak days:',(datetime.now(timezone.utc)-d).days)"
+   fi
+   ```
 
 If any pre-condition fails, report the failure and stop.
 
@@ -26,10 +42,14 @@ If any pre-condition fails, report the failure and stop.
 The `release-manager` subagent, providing it:
 - The target version string
 - The current CHANGELOG.md `## [Unreleased]` section as context
-- Instructions to update `manifest.json` + `CHANGELOG.md`, route the bump
+- Instructions to update `manifest.json` + `CHANGELOG.md` (including the
+  escaped-defect count line — release-manager "Files to update" step 4),
+  route the bump
   through a short-lived PR (the `protect-main` ruleset blocks direct
   commits to main), then create a **signed tag on the squash-merge commit**
   and push it
+- For stable releases, the acceptance evidence gathered above, to be
+  embedded verbatim in the release PR body
 
 ## After completion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent-side release/merge gates** (`.claude/`): the `/pr` command now
+  refuses to merge with unchecked checklist boxes (the human-review
+  disclosure box in particular); `/release` pre-conditions enforce the
+  `docs/releasing.md` acceptance gate for stables (soak computation,
+  beta-blocker check, evidence collection); the release-manager agent
+  records the acceptance evidence in the release PR body and the
+  escaped-defect count line in the CHANGELOG section.
+
+### Added
+
 - **Recorder-backed sum-chain regression tests**
   (`tests/test_recorder_statistics.py`, CO-15.6): the three defect classes
   that previously escaped through the mocked recorder seam — the v0.3.0


### PR DESCRIPTION
## Summary

The agent-side enforcement of the three policies merged today — these four edits were spec'd in WP8 PR-4/PR-5 and WP9-B but held back pending explicit maintainer approval of self-modifying `.claude/**` changes (approved in session):

- **`.claude/commands/pr.md`**: pre-merge gate — every checklist box ticked or deleted-with-reason; if the "human maintainer has reviewed" box is unchecked, STOP and ask (enforces #202's policy).
- **`.claude/commands/release.md`**: stable-only pre-condition 4 — the `docs/releasing.md` acceptance gate (≥7-day soak computation, hotfix-evidence alternative, `beta-blocker` emptiness, evidence values confirmed by the maintainer, never invented); "Delegates to" now passes the evidence and points at the escaped-count step (enforces #204's policy).
- **`.claude/agents/release-manager.md`**: "Files to update" step 4 — the escaped-defect count line (written even at zero) via the validated `gh issue list` query (#206's policy); stable release PRs must carry the acceptance-evidence body verbatim, prereleases keep the one-line body.

Per AGENTS.md's grant-union rule: no tool grants are widened here — these edits only add *refusals and required evidence* to existing flows, so no SECURITY.md / threat-model re-assessment is triggered.

First real exercise: the v0.4.0 stable promotion (~2026-07-21).

## Test plan

- [x] Docs/agent-instruction files only — no code, no workflow changes; CI will confirm required checks
- [x] Soak-computation bash block dry-run against live releases earlier today (beta.6 → soak days computed correctly)
- [x] Escaped-count `gh` query shape validated live in the WP9 work papers
- Manual test on a real HA instance: N/A — agent instruction files only

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic).
      All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [x] The human maintainer has reviewed and understands every change.
