### PR TITLE
docs: add project roadmap and except-tuple formatting note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ scripts/
 SECURITY.md              # disclosure path + threat-model summary
 CONTRIBUTING.md          # dev loop + commit conventions + PR checklist
 CODE_OF_CONDUCT.md       # Contributor Covenant 2.1
+ROADMAP.md               # ~12-month direction + explicit non-goals (single-retailer AGL, read-only, no telemetry)
 ```
 
 ---
@@ -642,6 +643,15 @@ The HA Energy dashboard requires:
   `_safe_float` helpers in `agl/parser.py` / `coordinator.py` so `inf`/`nan`/
   negative values can't reach `async_add_external_statistics` and corrupt the
   cumulative-sum series.
+- **Don't "fix" a bare multi-type `except A, B:` by adding parentheses.** The
+  unparenthesised form is intentional: it is `ruff format`'s canonical output
+  for this repo's Python 3.14 target (PEP 758, where `except A, B:` means
+  exactly `except (A, B):` and catches every listed type). Adding parentheses
+  is not idempotent — `ruff format` strips them straight back out and the
+  `ruff format --check` CI gate then fails. It is valid, correct 3.14 syntax,
+  and HA 2026.7 requires Python 3.14.2 so it always runs. (An audit once
+  compiled it under an older Python, saw a `SyntaxError`, and flagged it as a
+  repo-breaking bug — it is not one; do not act on that.)
 - **Don't forward raw AGL response dicts** via `dict(rate)` or similar
   open-schema passthrough. Allowlist exactly the fields the coordinator
   consumes, so a MITM-crafted response can't smuggle keys into runtime state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Project roadmap** (`ROADMAP.md`): the direction for roughly the next
+  twelve months plus explicit non-goals — single-retailer (AGL Australia)
+  only, electricity and its solar feed-in only, read-only Energy-dashboard
+  import, and no telemetry, device control, or portal scraping.
 - **Agent-side release/merge gates** (`.claude/`): the `/pr` command now
   refuses to merge with unchecked checklist boxes (the human-review
   disclosure box in particular); `/release` pre-conditions enforce the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,67 @@
+# Roadmap
+
+This roadmap states what `haggle` intends to do — and deliberately will not do —
+over roughly the next twelve months. It is a direction of travel, not a
+contract: `haggle` is a single-maintainer, best-effort open-source project, and
+priorities shift as AGL changes its API and as users report issues. Tracked work
+lives in [GitHub issues](https://github.com/NaanyaBiz/haggle/issues); the
+priority labels (`P1`/`P2`/`P3`) there are the live source of truth.
+
+_Last reviewed: 2026-07. Reviewed at least annually and at each minor release._
+
+## Direction (next ~12 months)
+
+**Ship v0.4.0 stable — solar generation GA.** Complete the beta soak, verify
+diagnostics end-to-end on a live install ([#159](https://github.com/NaanyaBiz/haggle/issues/159)),
+and promote solar feed-in generation/credit statistics from beta to stable.
+
+**Make Time-of-Use accurate and self-owned.**
+- Derive tariff bands locally from user-configured ToU windows instead of
+  trusting AGL's per-interval `consumption.type`
+  ([#141](https://github.com/NaanyaBiz/haggle/issues/141)).
+- Validate the plan-text ToU rate-mapping heuristic against a real ToU plan
+  capture and correct it if AGL labels bands differently
+  ([#90](https://github.com/NaanyaBiz/haggle/issues/90)).
+- Fix per-band rate-sensor registration and bill projection on ToU contracts
+  ([#126](https://github.com/NaanyaBiz/haggle/issues/126)).
+
+**Improve the Energy-dashboard experience.** Resolve the cumulative-sensor
+"decoy" in HA's source picker so users add the right statistics the first time
+([#147](https://github.com/NaanyaBiz/haggle/issues/147)).
+
+**Keep the engineering baseline healthy.** Decompose the one remaining
+over-complexity function
+([#187](https://github.com/NaanyaBiz/haggle/issues/187)), keep the OpenSSF
+Scorecard posture verified ([#179](https://github.com/NaanyaBiz/haggle/issues/179)),
+and maintain the secure-SDLC conformance record as control surfaces change.
+
+**Reach more users.** Once v0.4.0 has soaked, evaluate submitting `haggle` to
+the HACS default store so it is installable without adding a custom repository.
+
+## Non-goals (what `haggle` will *not* do)
+
+These are deliberate scope boundaries, not backlog items:
+
+- **One retailer only.** `haggle` targets AGL Australia's customer API. It will
+  not grow into a multi-retailer abstraction.
+- **Electricity (and its solar feed-in) only.** No gas, water, or other
+  utilities.
+- **Read-only.** `haggle` imports historical usage/cost/solar statistics into
+  the HA Energy dashboard. It will not control devices, change tariffs, or take
+  any write action on the AGL account.
+- **No telemetry.** No phone-home, analytics, or external telemetry vendors —
+  in the integration or in CI.
+- **No portal scraping or OTP flows.** Authentication is Auth0 PKCE through the
+  user's real browser; `haggle` will not automate the AGL web portal or handle
+  credentials directly.
+- **No destructive uninstall.** Removing the integration will not delete the
+  user's accumulated `haggle:*` energy history
+  ([#91](https://github.com/NaanyaBiz/haggle/issues/91), decided
+  won't-implement).
+
+## How priorities are set
+
+Priority reflects consequence to users, not effort. Correctness of the
+energy/cost data written to the recorder outranks new features; a defect that
+writes wrong statistics or takes the integration down is always addressed before
+enhancement work.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,9 +35,6 @@ over-complexity function
 Scorecard posture verified ([#179](https://github.com/NaanyaBiz/haggle/issues/179)),
 and maintain the secure-SDLC conformance record as control surfaces change.
 
-**Reach more users.** Once v0.4.0 has soaked, evaluate submitting `haggle` to
-the HACS default store so it is installable without adding a custom repository.
-
 ## Non-goals (what `haggle` will *not* do)
 
 These are deliberate scope boundaries, not backlog items:


### PR DESCRIPTION
## Summary

Docs-only. Two things, both surfaced by the OpenSSF Silver self-assessment pass:

- **`ROADMAP.md`** — the project's intended direction for roughly the next twelve months and, just as importantly, its **explicit non-goals** (single-retailer AGL Australia only; electricity + solar feed-in only; read-only Energy-dashboard import; no telemetry, no device control, no portal scraping; no destructive uninstall). Near-term items are grounded in the live P1/P2 issues (#159, #141, #90, #126, #147, #187, #179) rather than invented, and it states the standing priority rule (correctness of recorded energy/cost data outranks features). Closes the OpenSSF `documentation_roadmap` MUST.
- **`AGENTS.md` "What NOT to Do" guard** — records that the bare multi-type `except A, B:` clauses in `parser.py`/`coordinator.py`/`config_flow.py` are **intentional**: they are `ruff format`'s canonical output for this repo's Python 3.14 target (PEP 758, `except A, B:` ≡ `except (A, B):`). Adding parentheses is non-idempotent — `ruff format` strips them and the `ruff format --check` CI gate fails — so a future reader must not "fix" them. Context: a Silver-audit agent compiled the file under an older Python, hit a `SyntaxError`, and flagged it as a repo-breaking bug. It is not one — HA 2026.7 requires Python 3.14.2 (`REQUIRED_PYTHON_VER`), where the syntax is valid and catches every listed type. This note prevents that false alarm (and the CI-breaking "fix") from recurring.

Repo Map + CHANGELOG updated for the new `ROADMAP.md`.

**Scope note (per the Codex review protocol):**
- *In scope:* factual accuracy of the roadmap against the current open issues and the documented non-goals; correctness of the PEP-758 / `ruff format` claim in the guard note.
- *Out of scope:* any code change (this PR ships none); the `access_continuity` Silver blocker (a real-world continuity arrangement the maintainer has chosen to defer — the project stays at OpenSSF **Passing**, not Silver).

## Test plan

- [x] Docs only — no code, workflow, or ruleset behaviour changed; CI (ruff/mypy/pytest/hassfest/HACS) will confirm no regression.
- [x] Pre-commit clean (Conventional Commit, Co-Authored-By trailer, secret scan).
- [x] Roadmap issue references verified against `gh issue list` (all open at time of writing).
- Manual test on a real HA instance: N/A — docs only.

## AI generation disclosure

- [x] This PR was generated or co-authored by Claude (Anthropic). All commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`.
- [x] The human maintainer has reviewed and understands every change.
